### PR TITLE
chore(release): PAM Native 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.3.0"
+version = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.3.0';
+    public const string SDK_VERSION = '0.4.0';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2271,8 +2271,8 @@ $assert(
     'Selecting a tab must lazily mount only the next destination.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.3.0',
-    'The runtime SDK contract must match the 0.3 package release line.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.4.0',
+    'The runtime SDK contract must match the 0.4 package release line.',
 );
 
 echo "Pam Native PHP SDK tests passed.\n";

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1817,7 +1817,7 @@ file_put_contents(
     "protocol": 1,
     "pamNative": {
         "minimum": "0.3.0",
-        "maximumExclusive": "0.4.0"
+        "maximumExclusive": "0.5.0"
     },
     "php": {
         "provider": "Pam\\Native\\Tests\\Fixtures\\ExamplePluginProvider"


### PR DESCRIPTION
## Release

- eleva workspace Rust e SDK PHP para 0.4.0
- preserva a matriz de compatibilidade de plugins da linha anterior
- publicação condicionada aos gates Rust, Android API 26/36 e UIKit