### PR TITLE
fix(android): adapt drawer system bar icons

### DIFF
--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
@@ -3,6 +3,7 @@ package dev.pam.nativeapp.render
 import android.app.Instrumentation
 import android.content.Intent
 import android.graphics.Color
+import android.os.Build
 import android.view.View
 import android.view.WindowInsetsController
 import android.widget.FrameLayout
@@ -23,10 +24,17 @@ class PamNavigationHostInstrumentedTest {
         try {
             onMain(instrumentation) {
                 val lightStatusBar = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
-                activity.window.insetsController?.setSystemBarsAppearance(
-                    lightStatusBar,
-                    lightStatusBar,
-                )
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    activity.window.insetsController?.setSystemBarsAppearance(
+                        lightStatusBar,
+                        lightStatusBar,
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    activity.window.decorView.systemUiVisibility =
+                        activity.window.decorView.systemUiVisibility or
+                        View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                }
                 val drawer = PamDrawerLayout(activity).apply {
                     addView(View(activity))
                     addView(View(activity).apply { setBackgroundColor(Color.rgb(8, 24, 43)) })
@@ -34,16 +42,34 @@ class PamNavigationHostInstrumentedTest {
                 activity.host.addView(drawer)
 
                 drawer.setOpen(true, animated = false)
-                assertEquals(
-                    0,
-                    activity.window.insetsController?.systemBarsAppearance?.and(lightStatusBar),
-                )
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    assertEquals(
+                        0,
+                        activity.window.insetsController?.systemBarsAppearance?.and(lightStatusBar),
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    assertEquals(
+                        0,
+                        activity.window.decorView.systemUiVisibility and
+                            View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR,
+                    )
+                }
 
                 drawer.setOpen(false, animated = false)
-                assertEquals(
-                    lightStatusBar,
-                    activity.window.insetsController?.systemBarsAppearance?.and(lightStatusBar),
-                )
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    assertEquals(
+                        lightStatusBar,
+                        activity.window.insetsController?.systemBarsAppearance?.and(lightStatusBar),
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    assertEquals(
+                        View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR,
+                        activity.window.decorView.systemUiVisibility and
+                            View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR,
+                    )
+                }
             }
         } finally {
             activity.finish()

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
@@ -2,7 +2,9 @@ package dev.pam.nativeapp.render
 
 import android.app.Instrumentation
 import android.content.Intent
+import android.graphics.Color
 import android.view.View
+import android.view.WindowInsetsController
 import android.widget.FrameLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -14,6 +16,40 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class PamNavigationHostInstrumentedTest {
+    @Test
+    fun drawerAdaptsStatusBarIconsAndRestoresThemWhenClosed() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            onMain(instrumentation) {
+                val lightStatusBar = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+                activity.window.insetsController?.setSystemBarsAppearance(
+                    lightStatusBar,
+                    lightStatusBar,
+                )
+                val drawer = PamDrawerLayout(activity).apply {
+                    addView(View(activity))
+                    addView(View(activity).apply { setBackgroundColor(Color.rgb(8, 24, 43)) })
+                }
+                activity.host.addView(drawer)
+
+                drawer.setOpen(true, animated = false)
+                assertEquals(
+                    0,
+                    activity.window.insetsController?.systemBarsAppearance?.and(lightStatusBar),
+                )
+
+                drawer.setOpen(false, animated = false)
+                assertEquals(
+                    lightStatusBar,
+                    activity.window.insetsController?.systemBarsAppearance?.and(lightStatusBar),
+                )
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
     @Test
     fun pushAndPopExposeOnlyTheDestinationAfterTheStagedFrame() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
@@ -4,11 +4,14 @@ import android.animation.ValueAnimator
 import android.app.Activity
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.drawable.ColorDrawable
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
+import android.view.WindowInsetsController
 import android.view.inputmethod.InputMethodManager
 import android.widget.FrameLayout
 import kotlin.math.abs
@@ -38,6 +41,7 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     private var drawerBaseBottomPadding = 0
     private var insetViewport: View? = null
     private var viewportBaseBottomPadding = 0
+    private var statusBarAppearanceBeforeOpen: Int? = null
 
     init {
         clipChildren = false
@@ -370,11 +374,47 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
             } else {
                 window.insetsController?.show(WindowInsets.Type.statusBars())
             }
+            val controller = window.insetsController ?: return
+            if (open) {
+                if (statusBarAppearanceBeforeOpen == null) {
+                    statusBarAppearanceBeforeOpen = controller.systemBarsAppearance
+                }
+                val lightStatusBar = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+                controller.setSystemBarsAppearance(
+                    if (drawerBackgroundIsLight()) lightStatusBar else 0,
+                    lightStatusBar,
+                )
+            } else {
+                statusBarAppearanceBeforeOpen?.let { appearance ->
+                    val lightStatusBar = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+                    controller.setSystemBarsAppearance(appearance, lightStatusBar)
+                }
+                statusBarAppearanceBeforeOpen = null
+            }
         } else {
             @Suppress("DEPRECATION")
-            window.decorView.systemUiVisibility =
-                if (hideStatusBarOnOpen && open) View.SYSTEM_UI_FLAG_FULLSCREEN else 0
+            window.decorView.systemUiVisibility = when {
+                hideStatusBarOnOpen && open -> View.SYSTEM_UI_FLAG_FULLSCREEN
+                open && drawerBackgroundIsLight() ->
+                    window.decorView.systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                open ->
+                    window.decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
+                else -> window.decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_FULLSCREEN.inv()
+            }
         }
+    }
+
+    private fun drawerBackgroundIsLight(): Boolean {
+        val drawer = getChildAt(1) ?: return false
+        val color = (drawer.background as? ColorDrawable)?.color
+            ?: drawer.backgroundTintList?.defaultColor
+            ?: return false
+        val luminance = (
+            0.2126 * Color.red(color) +
+                0.7152 * Color.green(color) +
+                0.0722 * Color.blue(color)
+            ) / 255.0
+        return luminance > 0.5
     }
 
     private companion object {

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
@@ -42,6 +42,7 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     private var insetViewport: View? = null
     private var viewportBaseBottomPadding = 0
     private var statusBarAppearanceBeforeOpen: Int? = null
+    private var systemUiVisibilityBeforeOpen: Int? = null
 
     init {
         clipChildren = false
@@ -393,13 +394,22 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
             }
         } else {
             @Suppress("DEPRECATION")
-            window.decorView.systemUiVisibility = when {
-                hideStatusBarOnOpen && open -> View.SYSTEM_UI_FLAG_FULLSCREEN
-                open && drawerBackgroundIsLight() ->
-                    window.decorView.systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                open ->
-                    window.decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
-                else -> window.decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_FULLSCREEN.inv()
+            if (open) {
+                if (systemUiVisibilityBeforeOpen == null) {
+                    systemUiVisibilityBeforeOpen = window.decorView.systemUiVisibility
+                }
+                window.decorView.systemUiVisibility = when {
+                    hideStatusBarOnOpen -> View.SYSTEM_UI_FLAG_FULLSCREEN
+                    drawerBackgroundIsLight() ->
+                        window.decorView.systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                    else ->
+                        window.decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
+                }
+            } else {
+                systemUiVisibilityBeforeOpen?.let { appearance ->
+                    window.decorView.systemUiVisibility = appearance
+                }
+                systemUiVisibilityBeforeOpen = null
             }
         }
     }


### PR DESCRIPTION
## Summary\n- adapt status bar icon appearance to drawer surface luminance\n- restore the previous system bar appearance when the drawer closes\n- cover open/close behavior with an Android instrumentation test\n\n## Validation\n- connectedDebugAndroidTest on API 36: 2/2 passed