### PR TITLE
chore: prepare PAM Native 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.4.1"
+version = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.4.1';
+    public const string SDK_VERSION = '0.4.2';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2271,7 +2271,7 @@ $assert(
     'Selecting a tab must lazily mount only the next destination.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.4.1',
+    \Pam\Native\Protocol::SDK_VERSION === '0.4.2',
     'The runtime SDK contract must match the 0.4 package release line.',
 );
 


### PR DESCRIPTION
## Summary\n- publish the Android drawer system-bar adaptation\n- restore legacy Android status-bar appearance on close\n- keep Rust and PHP protocol package versions aligned at 0.4.2\n\n## Validation\n- full PR matrix passed on the implementation commit\n- Android API 26 and API 36 instrumentation passed