### PR TITLE
Fix permanent drawer status bar insets

### DIFF
--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
@@ -12,6 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import dev.pam.nativeapp.PamTestActivity
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -131,6 +132,47 @@ class PamNavigationHostInstrumentedTest {
         }
     }
 
+    @Test
+    fun permanentDrawerStartsBelowTheStatusBar() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var drawer: View
+            onMain(instrumentation) {
+                val layout = PamDrawerLayout(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                    )
+                    addView(View(activity))
+                    drawer = View(activity)
+                    addView(drawer)
+                    setDrawerType(TYPE_PERMANENT)
+                }
+                activity.host.addView(layout)
+            }
+
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                val expectedTop = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    drawer.rootWindowInsets
+                        ?.getInsets(android.view.WindowInsets.Type.statusBars())
+                        ?.top ?: 0
+                } else {
+                    @Suppress("DEPRECATION")
+                    drawer.rootWindowInsets?.systemWindowInsetTop ?: 0
+                }
+                assertTrue(expectedTop > 0)
+                assertEquals(
+                    expectedTop,
+                    (drawer.layoutParams as FrameLayout.LayoutParams).topMargin,
+                )
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
     private fun launchActivity(instrumentation: Instrumentation): PamTestActivity =
         instrumentation.startActivitySync(
             Intent(instrumentation.targetContext, PamTestActivity::class.java).apply {
@@ -146,5 +188,6 @@ class PamNavigationHostInstrumentedTest {
         const val OPERATION_PUSH = 2
         const val OPERATION_POP = 3
         const val TRANSITION_NONE = 8
+        const val TYPE_PERMANENT = 4
     }
 }

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
@@ -75,6 +75,28 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         requestApplyInsets()
+        post {
+            val insets = rootWindowInsets ?: return@post
+            val nextTop = if (android.os.Build.VERSION.SDK_INT >= 30) {
+                insets.getInsets(WindowInsets.Type.statusBars()).top
+            } else {
+                @Suppress("DEPRECATION")
+                insets.systemWindowInsetTop
+            }
+            val nextBottom = if (android.os.Build.VERSION.SDK_INT >= 30) {
+                insets.getInsets(WindowInsets.Type.navigationBars()).bottom
+            } else {
+                @Suppress("DEPRECATION")
+                insets.systemWindowInsetBottom
+            }
+            if (statusInsetTop != nextTop || navigationInsetBottom != nextBottom) {
+                statusInsetTop = nextTop
+                navigationInsetBottom = nextBottom
+                if (childCount > 1) {
+                    enforceDrawerViewport(getChildAt(1))
+                }
+            }
+        }
     }
 
     fun insert(view: View, index: Int) {

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
@@ -37,6 +37,7 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     private var onClose: (() -> Unit)? = null
     private val overlayPaint = Paint(Paint.ANTI_ALIAS_FLAG)
     private var navigationInsetBottom = 0
+    private var statusInsetTop = 0
     private var insetDrawer: View? = null
     private var drawerBaseBottomPadding = 0
     private var insetViewport: View? = null
@@ -48,13 +49,20 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
         clipChildren = false
         setWillNotDraw(false)
         setOnApplyWindowInsetsListener { _, insets ->
+            val nextTop = if (android.os.Build.VERSION.SDK_INT >= 30) {
+                insets.getInsets(WindowInsets.Type.statusBars()).top
+            } else {
+                @Suppress("DEPRECATION")
+                insets.systemWindowInsetTop
+            }
             val nextBottom = if (android.os.Build.VERSION.SDK_INT >= 30) {
                 insets.getInsets(WindowInsets.Type.navigationBars()).bottom
             } else {
                 @Suppress("DEPRECATION")
                 insets.systemWindowInsetBottom
             }
-            if (navigationInsetBottom != nextBottom) {
+            if (statusInsetTop != nextTop || navigationInsetBottom != nextBottom) {
+                statusInsetTop = nextTop
                 navigationInsetBottom = nextBottom
                 if (childCount > 1) {
                     enforceDrawerViewport(getChildAt(1))
@@ -62,6 +70,11 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
             }
             insets
         }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        requestApplyInsets()
     }
 
     fun insert(view: View, index: Int) {
@@ -91,6 +104,9 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     fun setDrawerType(value: Int) {
         drawerType = value.coerceIn(TYPE_FRONT, TYPE_PERMANENT)
         updateDrawer(false)
+        if (childCount > 1) {
+            enforceDrawerViewport(getChildAt(1))
+        }
     }
 
     fun setDrawerPosition(value: Int) {
@@ -339,13 +355,12 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
             drawer.paddingRight,
             maxOf(drawerBaseBottomPadding, navigationInsetBottom),
         )
-        drawer.layoutParams = (drawer.layoutParams ?: LayoutParams(
-            drawerWidthPx().toInt(),
-            ViewGroup.LayoutParams.MATCH_PARENT,
-        )).apply {
-            width = drawerWidthPx().toInt()
-            height = ViewGroup.LayoutParams.MATCH_PARENT
-        }
+        val drawerParams = (drawer.layoutParams as? LayoutParams)
+            ?: LayoutParams(drawerWidthPx().toInt(), ViewGroup.LayoutParams.MATCH_PARENT)
+        drawerParams.width = drawerWidthPx().toInt()
+        drawerParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+        drawerParams.topMargin = if (resolvedType() == TYPE_PERMANENT) statusInsetTop else 0
+        drawer.layoutParams = drawerParams
         val viewport = (drawer as? ViewGroup)?.getChildAt(0) ?: return
         if (insetViewport !== viewport) {
             insetViewport = viewport


### PR DESCRIPTION
## Summary
- apply the status-bar top inset only to permanent drawers
- request window insets when the native drawer is attached
- preserve modal drawer edge-to-edge behavior and status-icon adaptation
- cover late attachment and permanent layout with an instrumented test

## Validation
- ./gradlew connectedDebugAndroidTest (6 tests, Android API 36)