### PR TITLE
Align package versions for v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.4.2"
+version = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.4.2';
+    public const string SDK_VERSION = '0.4.3';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2271,7 +2271,7 @@ $assert(
     'Selecting a tab must lazily mount only the next destination.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.4.2',
+    \Pam\Native\Protocol::SDK_VERSION === '0.4.3',
     'The runtime SDK contract must match the 0.4 package release line.',
 );
 


### PR DESCRIPTION
## Summary
- bump Rust workspace and crates to 0.4.3
- bump the PHP SDK protocol version to 0.4.3
- align the release contract with the intended tag

## Validation
- cargo test --workspace (34 passed)
- php packages/native/tests/run.php
- scripts/composer-package.sh validate-tag v0.4.3