### PR TITLE
feat: align native material fields and grouped drawers

### DIFF
--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
@@ -389,7 +389,8 @@ class PamRenderer(
             NodeKind.INPUT -> PamEditText(context).apply {
                 isSingleLine = true
                 minHeight = 0
-                setPadding(dp(12f), 0, dp(12f), 0)
+                background = null
+                setPadding(0, 0, 0, 0)
             }
             NodeKind.IMAGE -> PamImageView(context)
             NodeKind.IMAGE_BACKGROUND -> PamImageBackground(context)
@@ -2522,13 +2523,29 @@ class PamRenderer(
         val bottomLeft = dp(
             state.number(PropKey.BORDER_BOTTOM_LEFT_RADIUS, logicalRadius).toFloat(),
         ).toFloat()
-        val borderWidth = listOf(
-            PropKey.BORDER_WIDTH,
-            PropKey.BORDER_LEFT_WIDTH,
-            PropKey.BORDER_TOP_WIDTH,
-            PropKey.BORDER_RIGHT_WIDTH,
-            PropKey.BORDER_BOTTOM_WIDTH,
-        ).maxOf { key -> dp(state.number(key, 0.0).toFloat()) }
+        val uniformBorderWidth = dp(state.number(PropKey.BORDER_WIDTH, 0.0).toFloat())
+        fun directionalBorderWidth(key: PropKey): Int {
+            return if (state.properties.containsKey(key)) {
+                dp(state.number(key, 0.0).toFloat())
+            } else {
+                uniformBorderWidth
+            }
+        }
+        val leftBorderWidth = directionalBorderWidth(PropKey.BORDER_LEFT_WIDTH)
+        val topBorderWidth = directionalBorderWidth(PropKey.BORDER_TOP_WIDTH)
+        val rightBorderWidth = directionalBorderWidth(PropKey.BORDER_RIGHT_WIDTH)
+        val bottomBorderWidth = directionalBorderWidth(PropKey.BORDER_BOTTOM_WIDTH)
+        val borderWidth = maxOf(
+            leftBorderWidth,
+            topBorderWidth,
+            rightBorderWidth,
+            bottomBorderWidth,
+        )
+        val hasDirectionalBorder = borderWidth > 0 && (
+            leftBorderWidth != rightBorderWidth ||
+                leftBorderWidth != topBorderWidth ||
+                leftBorderWidth != bottomBorderWidth
+            )
         val borderColor = state.integer(PropKey.BORDER_COLOR, Color.TRANSPARENT.toLong()).toInt()
         val imageHost = state.kind == NodeKind.IMAGE ||
             state.kind == NodeKind.IMAGE_BACKGROUND
@@ -2545,9 +2562,73 @@ class PamRenderer(
         val shape = GradientDrawable().apply {
             setColor(color)
             cornerRadii = radii
-            if (!imageHost && borderWidth > 0) {
+            if (!imageHost && borderWidth > 0 && !hasDirectionalBorder) {
                 setStroke(borderWidth, borderColor)
             }
+        }
+        val background = if (!imageHost && hasDirectionalBorder) {
+            val borders = object : android.graphics.drawable.Drawable() {
+                private val paint = android.graphics.Paint(
+                    android.graphics.Paint.ANTI_ALIAS_FLAG,
+                ).apply {
+                    this.color = borderColor
+                    style = android.graphics.Paint.Style.FILL
+                }
+
+                override fun draw(canvas: android.graphics.Canvas) {
+                    val area = bounds
+                    if (leftBorderWidth > 0) {
+                        canvas.drawRect(
+                            area.left.toFloat(),
+                            area.top.toFloat(),
+                            (area.left + leftBorderWidth).toFloat(),
+                            area.bottom.toFloat(),
+                            paint,
+                        )
+                    }
+                    if (topBorderWidth > 0) {
+                        canvas.drawRect(
+                            area.left.toFloat(),
+                            area.top.toFloat(),
+                            area.right.toFloat(),
+                            (area.top + topBorderWidth).toFloat(),
+                            paint,
+                        )
+                    }
+                    if (rightBorderWidth > 0) {
+                        canvas.drawRect(
+                            (area.right - rightBorderWidth).toFloat(),
+                            area.top.toFloat(),
+                            area.right.toFloat(),
+                            area.bottom.toFloat(),
+                            paint,
+                        )
+                    }
+                    if (bottomBorderWidth > 0) {
+                        canvas.drawRect(
+                            area.left.toFloat(),
+                            (area.bottom - bottomBorderWidth).toFloat(),
+                            area.right.toFloat(),
+                            area.bottom.toFloat(),
+                            paint,
+                        )
+                    }
+                }
+
+                override fun setAlpha(alpha: Int) {
+                    paint.alpha = alpha
+                }
+
+                override fun setColorFilter(colorFilter: android.graphics.ColorFilter?) {
+                    paint.colorFilter = colorFilter
+                }
+
+                @Suppress("DEPRECATION")
+                override fun getOpacity(): Int = android.graphics.PixelFormat.TRANSLUCENT
+            }
+            android.graphics.drawable.LayerDrawable(arrayOf(shape, borders))
+        } else {
+            shape
         }
         pamImageView(view)?.setCornerRadii(radii)
         if (imageHost) {
@@ -2579,7 +2660,7 @@ class PamRenderer(
             }
         }
         if (ripple == null || imageHost) {
-            view.background = shape
+            view.background = background
             if (!imageHost) {
                 view.foreground = null
             }

--- a/ios/Sources/PamNative/Protocol/PamProtocol.swift
+++ b/ios/Sources/PamNative/Protocol/PamProtocol.swift
@@ -328,6 +328,10 @@ public enum PamConstants {
     public static let rippleAlpha = 248
     public static let borderWidth = 36
     public static let borderColor = 37
+    public static let borderLeftWidth = 122
+    public static let borderTopWidth = 123
+    public static let borderRightWidth = 124
+    public static let borderBottomWidth = 125
     public static let margin = 26
     public static let testId = 18
     public static let padding = 8

--- a/ios/Sources/PamNative/Render/PamRenderComponents.swift
+++ b/ios/Sources/PamNative/Render/PamRenderComponents.swift
@@ -317,7 +317,7 @@ final class PamInputField: UITextField, UITextFieldDelegate {
     override init(frame: CGRect) {
         super.init(frame: frame)
         delegate = self
-        borderStyle = .roundedRect
+        borderStyle = .none
         autocorrectionType = .default
         translatesAutoresizingMaskIntoConstraints = true
         syncFontCache()
@@ -326,7 +326,7 @@ final class PamInputField: UITextField, UITextFieldDelegate {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         delegate = self
-        borderStyle = .roundedRect
+        borderStyle = .none
         syncFontCache()
     }
 

--- a/ios/Sources/PamNative/Render/PamRenderer.swift
+++ b/ios/Sources/PamNative/Render/PamRenderer.swift
@@ -15,6 +15,7 @@ public final class PamRenderer {
     private var children: [Int64: [Int64]] = [:]
     private var eventBridges: [Int64: [Int: EventBridge]] = [:]
     private var localModalActions: [Int64: UIAction.Identifier] = [:]
+    private var borderLayers: [Int64: PamBorderLayers] = [:]
     private var rootId: Int64 = 0
     private var nextMountOrder: Int64 = 1
     private let maxEventBytes = 1024 * 1024
@@ -100,6 +101,7 @@ public final class PamRenderer {
         }
         eventBridges.removeAll()
         localModalActions.removeAll()
+        borderLayers.removeAll()
 
         for node in nodes.values {
             cancelImageLoad(for: node)
@@ -216,6 +218,8 @@ public final class PamRenderer {
         }
         eventBridges[id] = nil
         localModalActions[id] = nil
+        borderLayers[id]?.remove()
+        borderLayers[id] = nil
 
         cancelImageLoad(for: state)
 
@@ -355,6 +359,7 @@ public final class PamRenderer {
             width: max(0, width),
             height: max(0, height),
         )
+        applyBorder(view: view, nodeId: id)
     }
 
     private func addChild(to parent: Int64, child: Int64) {
@@ -931,10 +936,19 @@ public final class PamRenderer {
                 state: nodes[nodeId],
                 kind: Int(value.integerOrNil() ?? 1)
             )
-        case PamConstants.backgroundColor, PamConstants.borderColor:
+        case PamConstants.backgroundColor:
             if let color = value.integerOrNil() {
                 view.backgroundColor = UIColor(argb: color)
             }
+        case PamConstants.borderColor,
+             PamConstants.borderWidth,
+             PamConstants.borderLeftWidth,
+             PamConstants.borderTopWidth,
+             PamConstants.borderRightWidth,
+             PamConstants.borderBottomWidth:
+            applyBorder(view: view, nodeId: nodeId)
+        case PamConstants.borderRadius:
+            view.layer.cornerRadius = CGFloat(value.decimalOrZero())
         case PamConstants.enabled:
             if let enabled = value.boolOrNil() {
                 view.isUserInteractionEnabled = enabled
@@ -1058,8 +1072,19 @@ public final class PamRenderer {
         }
     }
 
-    private func resetProperty(view: UIView, nodeId _: Int64, key: Int, state: NodeState) {
+    private func resetProperty(view: UIView, nodeId: Int64, key: Int, state: NodeState) {
         switch key {
+        case PamConstants.backgroundColor:
+            view.backgroundColor = .clear
+        case PamConstants.borderColor,
+             PamConstants.borderWidth,
+             PamConstants.borderLeftWidth,
+             PamConstants.borderTopWidth,
+             PamConstants.borderRightWidth,
+             PamConstants.borderBottomWidth:
+            applyBorder(view: view, nodeId: nodeId)
+        case PamConstants.borderRadius:
+            view.layer.cornerRadius = 0
         case PamConstants.fontSize,
              PamConstants.fontWeight,
              PamConstants.fontStyle,
@@ -1120,6 +1145,46 @@ public final class PamRenderer {
         default:
             break
         }
+    }
+
+    private func applyBorder(view: UIView, nodeId: Int64) {
+        guard let state = nodes[nodeId] else { return }
+        let uniform = CGFloat(
+            state.properties[PamConstants.borderWidth]?.decimalOrNil() ?? 0
+        )
+        func width(_ key: Int) -> CGFloat {
+            CGFloat(state.properties[key]?.decimalOrNil() ?? Double(uniform))
+        }
+
+        let left = max(0, width(PamConstants.borderLeftWidth))
+        let top = max(0, width(PamConstants.borderTopWidth))
+        let right = max(0, width(PamConstants.borderRightWidth))
+        let bottom = max(0, width(PamConstants.borderBottomWidth))
+        let color = UIColor(
+            argb: state.properties[PamConstants.borderColor]?.integerOrNil() ?? 0
+        ).cgColor
+        let directional = left != top || left != right || left != bottom
+
+        if !directional {
+            borderLayers[nodeId]?.remove()
+            borderLayers[nodeId] = nil
+            view.layer.borderWidth = left
+            view.layer.borderColor = color
+            return
+        }
+
+        view.layer.borderWidth = 0
+        view.layer.borderColor = nil
+        let layers = borderLayers[nodeId] ?? PamBorderLayers(host: view.layer)
+        borderLayers[nodeId] = layers
+        layers.update(
+            bounds: view.bounds,
+            left: left,
+            top: top,
+            right: right,
+            bottom: bottom,
+            color: color,
+        )
     }
 
     private func applyTextSizing(view: UIView, state: NodeState?) {
@@ -2373,6 +2438,66 @@ private extension PropValue {
         default:
             nil
         }
+    }
+}
+
+private final class PamBorderLayers {
+    private let left = CALayer()
+    private let top = CALayer()
+    private let right = CALayer()
+    private let bottom = CALayer()
+
+    init(host: CALayer) {
+        for layer in [left, top, right, bottom] {
+            layer.zPosition = 10_000
+            host.addSublayer(layer)
+        }
+    }
+
+    func update(
+        bounds: CGRect,
+        left leftWidth: CGFloat,
+        top topWidth: CGFloat,
+        right rightWidth: CGFloat,
+        bottom bottomWidth: CGFloat,
+        color: CGColor
+    ) {
+        left.backgroundColor = color
+        top.backgroundColor = color
+        right.backgroundColor = color
+        bottom.backgroundColor = color
+
+        left.frame = CGRect(
+            x: bounds.minX,
+            y: bounds.minY,
+            width: leftWidth,
+            height: bounds.height,
+        )
+        top.frame = CGRect(
+            x: bounds.minX,
+            y: bounds.minY,
+            width: bounds.width,
+            height: topWidth,
+        )
+        right.frame = CGRect(
+            x: bounds.maxX - rightWidth,
+            y: bounds.minY,
+            width: rightWidth,
+            height: bounds.height,
+        )
+        bottom.frame = CGRect(
+            x: bounds.minX,
+            y: bounds.maxY - bottomWidth,
+            width: bounds.width,
+            height: bottomWidth,
+        )
+    }
+
+    func remove() {
+        left.removeFromSuperlayer()
+        top.removeFromSuperlayer()
+        right.removeFromSuperlayer()
+        bottom.removeFromSuperlayer()
     }
 }
 

--- a/ios/Sources/PamNative/Render/PamRenderer.swift
+++ b/ios/Sources/PamNative/Render/PamRenderer.swift
@@ -452,7 +452,7 @@ public final class PamRenderer {
             return UILabel()
         case .input:
             let field = PamInputField()
-            field.borderStyle = .roundedRect
+            field.borderStyle = .none
             return field
         case .image, .imageBackground:
             return UIImageView()

--- a/packages/native/src/Navigation/DrawerNavigator.php
+++ b/packages/native/src/Navigation/DrawerNavigator.php
@@ -30,6 +30,8 @@ final class DrawerNavigator implements Renderable, Restorable
     private int $selected;
     private bool $open;
     private float $windowWidth = 0.0;
+    /** @var array<string, bool> */
+    private array $expandedGroups = [];
 
     /**
      * @param list<NavigationDrawerItem> $routes
@@ -115,6 +117,34 @@ final class DrawerNavigator implements Renderable, Restorable
         return false;
     }
 
+    public function toggleGroup(string $group): bool
+    {
+        $exists = false;
+        foreach ($this->routes as $route) {
+            if ($route->group === $group) {
+                $exists = true;
+                break;
+            }
+        }
+        if (!$exists) {
+            return false;
+        }
+
+        $this->expandedGroups[$group] = !$this->isGroupExpanded($group);
+        State::set($this->stateKey(), $this->saveState());
+
+        return true;
+    }
+
+    public function isGroupExpanded(string $group): bool
+    {
+        if (($this->expandedGroups[$group] ?? false) === true) {
+            return true;
+        }
+
+        return $this->routes[$this->selected - 1]->group === $group;
+    }
+
     public function openDrawer(): void
     {
         $this->open = true;
@@ -160,39 +190,98 @@ final class DrawerNavigator implements Renderable, Restorable
             heightPercent: 100.0,
             flexGrow: 1.0,
         ));
-        $items = [];
-        foreach ($this->routes as $index => $route) {
+        $routeItem = function (
+            NavigationDrawerItem $route,
+            int $index,
+        ): Pressable {
             $selected = $index + 1 === $this->selected;
             $label = Text::make($route->label)->style(new Style(
                 textColor: $selected
                     ? $this->activeColor
                     : $this->inactiveColor,
-                fontSize: 15.0,
-                fontWeight: $selected ? 700 : 500,
+                fontSize: 14.0,
+                lineHeight: 20.0,
+                fontWeight: $selected ? 600 : 400,
             ));
             $row = $route->icon === null
                 ? Row::make($label)
                 : Row::make($route->icon, $label);
-            $items[] = Pressable::make($row->style(new Style(
+
+            return Pressable::make($row->style(new Style(
                 gap: 16.0,
                 alignItems: \Pam\Native\Align::Center,
             )))
                 ->onPress(fn (): bool => $this->navigate($route->name))
                 ->style(new Style(
-                    minHeight: 52.0,
+                    minHeight: 48.0,
                     paddingHorizontal: 16.0,
-                    borderRadius: 14.0,
+                    borderRadius: 4.0,
                     backgroundColor: $selected
                         ? $this->activeBackgroundColor
                         : null,
+                    justifyContent: \Pam\Native\Justify::Center,
+                    animationDurationMs: 200,
+                    animateChanges: true,
                 ))
                 ->accessibilityRole(AccessibilityRole::Button)
                 ->accessibilityLabel($route->label);
+        };
+        $items = [];
+        /** @var array<string, list<array{0: NavigationDrawerItem, 1: int}>> $groups */
+        $groups = [];
+        foreach ($this->routes as $index => $route) {
+            if ($route->group === null) {
+                $items[] = $routeItem($route, $index);
+                continue;
+            }
+            $groups[$route->group][] = [$route, $index];
+        }
+        foreach ($groups as $group => $groupRoutes) {
+            $expanded = $this->isGroupExpanded($group);
+            $items[] = Pressable::make(
+                Row::make(
+                    Text::make($group)->style(new Style(
+                        textColor: $this->inactiveColor,
+                        fontSize: 12.0,
+                        lineHeight: 16.0,
+                        fontWeight: 700,
+                        letterSpacing: 0.08,
+                        flexGrow: 1.0,
+                    )),
+                    Text::make($expanded ? '-' : '+')->style(new Style(
+                        textColor: $this->inactiveColor,
+                        fontSize: 18.0,
+                        lineHeight: 20.0,
+                    )),
+                )->style(new Style(
+                    widthPercent: 100.0,
+                    alignItems: \Pam\Native\Align::Center,
+                )),
+            )
+                ->onPress(fn (): bool => $this->toggleGroup($group))
+                ->style(new Style(
+                    minHeight: 44.0,
+                    paddingHorizontal: 16.0,
+                    marginTop: 4.0,
+                    borderRadius: 4.0,
+                    justifyContent: \Pam\Native\Justify::Center,
+                ))
+                ->accessibilityRole(AccessibilityRole::Button)
+                ->accessibilityLabel($group);
+            if (!$expanded) {
+                continue;
+            }
+            foreach ($groupRoutes as [$route, $index]) {
+                $items[] = $routeItem($route, $index)->style(new Style(
+                    marginLeft: 8.0,
+                    paddingLeft: 12.0,
+                ));
+            }
         }
         $defaultDrawer = SafeAreaView::make(
             ScrollView::make(
                 Column::make(...$items)->style(new Style(
-                    padding: 12.0,
+                    padding: 8.0,
                     gap: 4.0,
                     widthPercent: 100.0,
                 )),
@@ -265,6 +354,20 @@ final class DrawerNavigator implements Renderable, Restorable
                     is_string($entry) && in_array($entry, $valid, true),
             ));
         }
+        if (is_array($state['expandedGroups'] ?? null)) {
+            $validGroups = [];
+            foreach ($this->routes as $item) {
+                if ($item->group !== null) {
+                    $validGroups[$item->group] = true;
+                }
+            }
+            $this->expandedGroups = [];
+            foreach ($state['expandedGroups'] as $group) {
+                if (is_string($group) && isset($validGroups[$group])) {
+                    $this->expandedGroups[$group] = true;
+                }
+            }
+        }
     }
 
     public function saveState(): array
@@ -274,6 +377,7 @@ final class DrawerNavigator implements Renderable, Restorable
             'selected' => $this->selectedRoute(),
             'open' => $this->open,
             'history' => $this->history,
+            'expandedGroups' => array_keys(array_filter($this->expandedGroups)),
         ];
     }
 }

--- a/packages/native/src/Navigation/DrawerRouter.php
+++ b/packages/native/src/Navigation/DrawerRouter.php
@@ -50,6 +50,7 @@ final class DrawerRouter
         Renderable|Closure $content,
         ?Renderable $icon = null,
         ?string $badge = null,
+        ?string $group = null,
     ): self {
         $copy = clone $this;
         $copy->routes[] = new NavigationDrawerItem(
@@ -58,6 +59,7 @@ final class DrawerRouter
             $content,
             $icon,
             $badge,
+            $group,
         );
 
         return $copy;

--- a/packages/native/src/Navigation/NavigationDrawerItem.php
+++ b/packages/native/src/Navigation/NavigationDrawerItem.php
@@ -16,12 +16,14 @@ final readonly class NavigationDrawerItem
         public Renderable|Closure $content,
         public ?Renderable $icon = null,
         public ?string $badge = null,
+        public ?string $group = null,
     ) {
         if (
             preg_match('/^[A-Za-z][A-Za-z0-9_.-]{0,63}$/D', $name) !== 1
             || trim($label) === ''
             || strlen($label) > 64
             || $badge !== null && strlen($badge) > 12
+            || $group !== null && (trim($group) === '' || strlen($group) > 48)
         ) {
             throw new InvalidArgumentException(
                 'Drawer routes require safe names and bounded labels.',

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2270,6 +2270,52 @@ $assert(
     $homeTabRenders === 1 && $ordersTabRenders === 1,
     'Selecting a tab must lazily mount only the next destination.',
 );
+$groupedDrawer = Router::drawer('overview')
+    ->route('overview', 'Overview', Screen::make(Text::make('Overview')))
+    ->route(
+        'button',
+        'Button',
+        Screen::make(Text::make('Button')),
+        group: 'Actions',
+    )
+    ->route(
+        'field',
+        'Text field',
+        Screen::make(Text::make('Text field')),
+        group: 'Forms',
+    )
+    ->persistence('test-grouped-drawer')
+    ->build();
+$assert(
+    !$groupedDrawer->isGroupExpanded('Actions')
+        && $groupedDrawer->toggleGroup('Actions')
+        && $groupedDrawer->isGroupExpanded('Actions')
+        && $groupedDrawer->navigate('field')
+        && $groupedDrawer->isGroupExpanded('Forms'),
+    'Grouped drawer routes must collapse cleanly and keep every destination navigable.',
+);
+$restoredGroupedDrawer = Router::drawer('overview')
+    ->route('overview', 'Overview', Screen::make(Text::make('Overview')))
+    ->route(
+        'button',
+        'Button',
+        Screen::make(Text::make('Button')),
+        group: 'Actions',
+    )
+    ->route(
+        'field',
+        'Text field',
+        Screen::make(Text::make('Text field')),
+        group: 'Forms',
+    )
+    ->persistence('test-grouped-drawer')
+    ->build();
+$assert(
+    $restoredGroupedDrawer->selectedRoute() === 'field'
+        && $restoredGroupedDrawer->isGroupExpanded('Actions')
+        && $restoredGroupedDrawer->isGroupExpanded('Forms'),
+    'Grouped drawer state must restore selection and expanded sections.',
+);
 $assert(
     \Pam\Native\Protocol::SDK_VERSION === '0.4.3',
     'The runtime SDK contract must match the 0.4 package release line.',


### PR DESCRIPTION
## Summary
- render directional native borders for filled and underlined fields
- remove platform input chrome so PAM UI owns exact field geometry
- add grouped, persistent, vertically aligned drawer navigation
- cover grouped navigation behavior in PHP contracts

## Validation
- PHP SDK contracts
- Android unit tests and debug build
- physical Galaxy S10 navigation and visual checks
- CI will run UIKit and simulator contracts