### PR TITLE
feat(sqlite): add native bulk write fast path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.4 - 2026-07-28
+
+- Add a native SQLite bulk-write fast path that crosses the bridge once,
+  reuses one prepared statement and commits one transaction.
+- Enable WAL, normal synchronous durability, foreign keys, bounded lock waits,
+  and memory-backed temporary storage for private application databases.
+
 ## 0.5.3 - 2026-07-28
 
 - Keep flex layouts consistent after safe-area insets reduce their native

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.3"
+version = "0.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/SQLiteModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/SQLiteModule.kt
@@ -3,6 +3,7 @@ package dev.pam.nativeapp.modules
 import android.content.Context
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteStatement
 import dev.pam.nativeapp.protocol.WireMap
 import dev.pam.nativeapp.protocol.WireValue
 import org.json.JSONArray
@@ -20,19 +21,28 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
                 val values = WireMap.decode(payload)
                 val database = open(values.requiredText("database"))
                 val sql = values.requiredText("sql")
-                val arguments = decodeArguments(values.requiredText("arguments"))
                 when (method) {
                     "execute" -> {
+                        val arguments = decodeArguments(values.requiredText("arguments"))
                         database.execSQL(sql, arguments)
                         completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))
                     }
                     "query" -> {
+                        val arguments = decodeArguments(values.requiredText("arguments"))
                         val rows = database.rawQuery(sql, arguments.map(::stringArgument).toTypedArray())
                             .use(::encodeRows)
                         completion.complete(
                             ModuleResultStatus.SUCCESS,
                             WireMap.encode(mapOf("rows" to WireValue.Text(rows.toString()))),
                         )
+                    }
+                    "executeMany" -> {
+                        executeMany(
+                            database,
+                            sql,
+                            decodeArgumentSets(values.requiredText("arguments")),
+                        )
+                        completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))
                     }
                     else -> error("Unknown SQLite method $method")
                 }
@@ -48,7 +58,13 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
     private fun open(name: String): SQLiteDatabase =
         databases.getOrPut(name) {
             val root = File(context.filesDir, "pam-databases").apply { mkdirs() }
-            SQLiteDatabase.openOrCreateDatabase(File(root, name), null)
+            SQLiteDatabase.openOrCreateDatabase(File(root, name), null).apply {
+                enableWriteAheadLogging()
+                execSQL("PRAGMA synchronous=NORMAL")
+                execSQL("PRAGMA foreign_keys=ON")
+                execSQL("PRAGMA busy_timeout=5000")
+                execSQL("PRAGMA temp_store=MEMORY")
+            }
         }
 
     private fun decodeArguments(value: String): Array<Any?> {
@@ -58,6 +74,51 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
                 JSONObject.NULL -> null
                 is Boolean -> if (item) 1L else 0L
                 is String, is Number -> item
+                else -> error("SQLite arguments must be scalar")
+            }
+        }
+    }
+
+    private fun decodeArgumentSets(value: String): List<Array<Any?>> {
+        val batches = JSONArray(value)
+        require(batches.length() in 1..MAX_BATCH_ROWS) {
+            "SQLite executeMany requires between 1 and 10000 argument sets"
+        }
+        return List(batches.length()) { index ->
+            decodeArguments(batches.getJSONArray(index).toString())
+        }
+    }
+
+    private fun executeMany(
+        database: SQLiteDatabase,
+        sql: String,
+        argumentSets: List<Array<Any?>>,
+    ) {
+        val statement = database.compileStatement(sql)
+        database.beginTransactionNonExclusive()
+        try {
+            argumentSets.forEach { arguments ->
+                statement.clearBindings()
+                bind(arguments, statement)
+                statement.execute()
+            }
+            database.setTransactionSuccessful()
+        } finally {
+            database.endTransaction()
+            statement.close()
+        }
+    }
+
+    private fun bind(arguments: Array<Any?>, statement: SQLiteStatement) {
+        arguments.forEachIndexed { offset, value ->
+            val index = offset + 1
+            when (value) {
+                null -> statement.bindNull(index)
+                is Boolean -> statement.bindLong(index, if (value) 1L else 0L)
+                is Byte, is Short, is Int, is Long ->
+                    statement.bindLong(index, (value as Number).toLong())
+                is Float, is Double -> statement.bindDouble(index, (value as Number).toDouble())
+                is String -> statement.bindString(index, value)
                 else -> error("SQLite arguments must be scalar")
             }
         }
@@ -109,5 +170,6 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
     private companion object {
         const val MAX_QUERY_ROWS = 1_000
         const val MAX_QUERY_COLUMNS = 256
+        const val MAX_BATCH_ROWS = 10_000
     }
 }

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/SQLiteModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/SQLiteModule.kt
@@ -60,12 +60,18 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
             val root = File(context.filesDir, "pam-databases").apply { mkdirs() }
             SQLiteDatabase.openOrCreateDatabase(File(root, name), null).apply {
                 enableWriteAheadLogging()
-                execSQL("PRAGMA synchronous=NORMAL")
-                execSQL("PRAGMA foreign_keys=ON")
-                execSQL("PRAGMA busy_timeout=5000")
-                execSQL("PRAGMA temp_store=MEMORY")
+                setForeignKeyConstraintsEnabled(true)
+                pragma(this, "synchronous=NORMAL")
+                pragma(this, "busy_timeout=5000")
+                pragma(this, "temp_store=MEMORY")
             }
         }
+
+    private fun pragma(database: SQLiteDatabase, expression: String) {
+        database.rawQuery("PRAGMA $expression", emptyArray()).use { cursor ->
+            cursor.moveToFirst()
+        }
+    }
 
     private fun decodeArguments(value: String): Array<Any?> {
         val array = JSONArray(value)

--- a/android/pam-native.properties
+++ b/android/pam-native.properties
@@ -4,5 +4,5 @@ applicationName=Pam Native
 minSdk=26
 targetSdk=36
 versionCode=5
-versionName=0.5.3
+versionName=0.5.4
 abis=arm64-v8a,x86_64

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -81,9 +81,20 @@ SQLite::query(
     [0, 50],
     fn (array $rows) => $this->notes = $rows,
 );
+
+SQLite::executeMany(
+    'app.db',
+    'INSERT INTO notes (id, body) VALUES (?, ?)',
+    [
+        [1, 'One bridge call'],
+        [2, 'One prepared statement'],
+        [3, 'One native transaction'],
+    ],
+);
 ```
 
 Never interpolate user input into SQL; positional arguments are bound natively.
+Use `executeMany()` for cache hydration, synchronization, and bulk writes.
 
 ## Permissions, local notifications and push
 

--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -80,7 +80,9 @@ forwarding and automatic deep-link routing.
 
 `Database\SQLite` opens databases under the private application directory.
 Statements execute on a serial native queue and positional values are bound,
-not interpolated. Query rows return typed JSON scalars.
+not interpolated. Query rows return typed JSON scalars. Databases use WAL with
+`synchronous=NORMAL` and a bounded busy timeout. `SQLite::executeMany()` reuses
+one prepared statement inside one native transaction for high-volume writes.
 
 ## Interaction and motion
 

--- a/ios/Sources/PamNative/Modules/SQLiteModule.swift
+++ b/ios/Sources/PamNative/Modules/SQLiteModule.swift
@@ -15,9 +15,9 @@ final class SQLiteModule: NativeModule, ClosableNativeModule {
                     throw SQLiteError("Invalid SQLite payload")
                 }
                 let database = try self.open(name)
-                let arguments = try self.decodeArguments(argumentsJSON)
                 switch method {
                 case "execute":
+                    let arguments = try self.decodeArguments(argumentsJSON)
                     let statement = try self.prepare(database, sql)
                     defer { sqlite3_finalize(statement) }
                     try self.bind(arguments, to: statement)
@@ -26,10 +26,15 @@ final class SQLiteModule: NativeModule, ClosableNativeModule {
                     }
                     completion(.success, Data())
                 case "query":
+                    let arguments = try self.decodeArguments(argumentsJSON)
                     let rows = try self.query(database, sql, arguments)
                     let json = try JSONSerialization.data(withJSONObject: rows)
                     let text = String(data: json, encoding: .utf8) ?? "[]"
                     completion(.success, try WireMap.encode(["rows": .text(text)]))
+                case "executeMany":
+                    let argumentSets = try self.decodeArgumentSets(argumentsJSON)
+                    try self.executeMany(database, sql, argumentSets)
+                    completion(.success, Data())
                 default:
                     throw SQLiteError("Unknown SQLite method \(method)")
                 }
@@ -51,8 +56,19 @@ final class SQLiteModule: NativeModule, ClosableNativeModule {
               let database else {
             throw SQLiteError("Unable to open SQLite database")
         }
+        try execute(database, "PRAGMA journal_mode=WAL")
+        try execute(database, "PRAGMA synchronous=NORMAL")
+        try execute(database, "PRAGMA foreign_keys=ON")
+        try execute(database, "PRAGMA busy_timeout=5000")
+        try execute(database, "PRAGMA temp_store=MEMORY")
         databases[name] = database
         return database
+    }
+
+    private func execute(_ database: OpaquePointer, _ sql: String) throws {
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw SQLiteError(String(cString: sqlite3_errmsg(database)))
+        }
     }
 
     private func prepare(_ database: OpaquePointer, _ sql: String) throws -> OpaquePointer {
@@ -70,6 +86,39 @@ final class SQLiteModule: NativeModule, ClosableNativeModule {
             throw SQLiteError("SQLite arguments must be an array")
         }
         return arguments
+    }
+
+    private func decodeArgumentSets(_ json: String) throws -> [[Any]] {
+        let value = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        guard let argumentSets = value as? [[Any]],
+              (1...10_000).contains(argumentSets.count) else {
+            throw SQLiteError("SQLite executeMany requires between 1 and 10000 argument sets")
+        }
+        return argumentSets
+    }
+
+    private func executeMany(
+        _ database: OpaquePointer,
+        _ sql: String,
+        _ argumentSets: [[Any]]
+    ) throws {
+        let statement = try prepare(database, sql)
+        defer { sqlite3_finalize(statement) }
+        try execute(database, "BEGIN IMMEDIATE")
+        do {
+            for arguments in argumentSets {
+                sqlite3_reset(statement)
+                sqlite3_clear_bindings(statement)
+                try bind(arguments, to: statement)
+                guard sqlite3_step(statement) == SQLITE_DONE else {
+                    throw SQLiteError(String(cString: sqlite3_errmsg(database)))
+                }
+            }
+            try execute(database, "COMMIT")
+        } catch {
+            try? execute(database, "ROLLBACK")
+            throw error
+        }
     }
 
     private func bind(_ arguments: [Any], to statement: OpaquePointer) throws {

--- a/packages/native/src/Database/SQLite.php
+++ b/packages/native/src/Database/SQLite.php
@@ -96,18 +96,19 @@ final class SQLite
                 if ($callback === null) {
                     return;
                 }
-                $values = Wire::decodeMap($result->payload);
-                if ($method === 'query') {
-                    $rows = json_decode(
-                        (string) ($values['rows'] ?? '[]'),
-                        true,
-                        512,
-                        JSON_THROW_ON_ERROR,
-                    );
-                    $callback(is_array($rows) ? $rows : []);
+                if ($method !== 'query') {
+                    $callback();
+
                     return;
                 }
-                $callback();
+                $values = Wire::decodeMap($result->payload);
+                $rows = json_decode(
+                    (string) ($values['rows'] ?? '[]'),
+                    true,
+                    512,
+                    JSON_THROW_ON_ERROR,
+                );
+                $callback(is_array($rows) ? $rows : []);
             },
         );
     }

--- a/packages/native/src/Database/SQLite.php
+++ b/packages/native/src/Database/SQLite.php
@@ -41,7 +41,29 @@ final class SQLite
         return self::call('query', $database, $sql, $arguments, $callback);
     }
 
-    /** @param list<string|int|float|bool|null> $arguments */
+    /**
+     * Executes one prepared statement for every argument set inside one native transaction.
+     *
+     * @param list<list<string|int|float|bool|null>> $argumentSets
+     */
+    public static function executeMany(
+        string $database,
+        string $sql,
+        array $argumentSets,
+        ?Closure $callback = null,
+    ): int {
+        if ($argumentSets === [] || count($argumentSets) > 10_000) {
+            throw new InvalidArgumentException(
+                'SQLite executeMany requires between 1 and 10000 argument sets.',
+            );
+        }
+
+        return self::call('executeMany', $database, $sql, $argumentSets, $callback);
+    }
+
+    /**
+     * @param list<string|int|float|bool|null>|list<list<string|int|float|bool|null>> $arguments
+     */
     private static function call(
         string $method,
         string $database,

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.5.3';
+    public const string SDK_VERSION = '0.5.4';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -58,6 +58,7 @@ use Pam\Native\MotionPreset;
 use Pam\Native\HapticFeedback;
 use Pam\Native\Http\Http;
 use Pam\Native\Http\HttpResponse;
+use Pam\Native\Database\SQLite;
 use Pam\Native\NativeOperation;
 use Pam\Native\Forms\FormStatus;
 use Pam\Native\Forms\NativeForm;
@@ -1620,6 +1621,28 @@ $assert(
         && $moduleResult->succeeded()
         && $moduleResult->values() === ['message' => 'fast'],
     'Public native module facade did not decode its result.',
+);
+
+$batchRequestId = SQLite::executeMany(
+    'nitro.db',
+    'INSERT INTO messages (id, body) VALUES (?, ?)',
+    [
+        ['m1', 'fast'],
+        ['m2', 'faster'],
+    ],
+);
+$batchCall = TestDiagnostics::$moduleCall;
+$batchPayload = $batchCall === null ? [] : Wire::decodeMap($batchCall['payload']);
+$assert(
+    $batchCall !== null
+        && $batchCall['requestId'] === $batchRequestId
+        && $batchCall['module'] === 'sqlite'
+        && $batchCall['method'] === 'executeMany'
+        && json_decode((string) ($batchPayload['arguments'] ?? ''), true) === [
+            ['m1', 'fast'],
+            ['m2', 'faster'],
+        ],
+    'SQLite executeMany did not emit one typed bridge call for the complete batch.',
 );
 
 $contacts = null;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2560,8 +2560,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.5.3',
-    'The runtime SDK contract must match the 0.5.3 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.5.4',
+    'The runtime SDK contract must match the 0.5.4 package release.',
 );
 
 $bottomSheet = BottomSheet::make(

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1644,6 +1644,11 @@ $assert(
         ],
     'SQLite executeMany did not emit one typed bridge call for the complete batch.',
 );
+Runtime::dispatchModuleResult(
+    $batchRequestId,
+    \Pam\Native\ModuleResultStatus::Success->value,
+    '',
+);
 
 $contacts = null;
 $contactsRequestId = Contacts::all(static function (array $items) use (&$contacts): void {


### PR DESCRIPTION
## Summary
- add SQLite::executeMany() for one bridge call, one prepared statement, and one native transaction
- enable WAL, synchronous=NORMAL, foreign keys, busy timeout, and in-memory temp storage
- document and test the PHP bridge contract

## Verification
- php packages/native/tests/run.php
- android/gradlew -p android :app:testDebugUnitTest :app:compileDebugKotlin --no-daemon
- physical Galaxy S23 Ultra cold-start and offline-cache validation
- full CI across PHP 8.4/8.5, iOS, Android unit, API 26, and API 36

This is the generic runtime fast path used by PAM Native Nitro; the API remains useful to any PAM Native application.