### PR TITLE
fix(android): keep chat and forms above keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ ancestor event context is composed into registered descendants before their
 native elements are built, so compound tags can wire triggers and items
 without a runtime tree lookup.
 
+Native handlers may be a public method name or a bounded component expression.
+Expressions capture their render scope and run only when dispatched, which
+makes per-item actions concise: `on:longPress="select($item['id'])"`.
+
+Android route transitions animate the platform display lists directly instead
+of allocating full-screen bitmap layers. This keeps media-heavy first
+navigation responsive and avoids a large one-frame texture upload.
+
 `FunctionalComponent::make()` supports standalone functions. A project can mix
 functional trees, class components, tags, custom template factories, and direct
 `Element` construction in the same screen.

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
@@ -133,6 +133,41 @@ class PamNavigationHostInstrumentedTest {
     }
 
     @Test
+    fun transitionsReuseHardwareAcceleratedDisplayListsWithoutBitmapLayers() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var first: View
+            lateinit var second: View
+            onMain(instrumentation) {
+                val navigation = PamNavigationHost(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                    )
+                    operation = OPERATION_PUSH
+                    transition = TRANSITION_SLIDE_FROM_RIGHT
+                    durationMs = 120
+                }
+                activity.host.addView(navigation)
+                first = View(activity)
+                second = View(activity)
+                navigation.insert(first, 0)
+                navigation.insert(second, 1)
+                navigation.navigate(1)
+            }
+
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                assertEquals(View.LAYER_TYPE_NONE, first.layerType)
+                assertEquals(View.LAYER_TYPE_NONE, second.layerType)
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
+    @Test
     fun permanentDrawerStartsBelowTheStatusBar() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val activity = launchActivity(instrumentation)
@@ -187,6 +222,7 @@ class PamNavigationHostInstrumentedTest {
     private companion object {
         const val OPERATION_PUSH = 2
         const val OPERATION_POP = 3
+        const val TRANSITION_SLIDE_FROM_RIGHT = 2
         const val TRANSITION_NONE = 8
         const val TYPE_PERMANENT = 4
     }

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamScrollContainerInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamScrollContainerInstrumentedTest.kt
@@ -133,6 +133,50 @@ class PamScrollContainerInstrumentedTest {
         }
     }
 
+    @Test
+    fun keyboardInsetKeepsEndAnchoredWithoutMovingAnOlderViewport() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var scroll: PamScrollContainer
+            onMain(instrumentation) {
+                scroll = PamScrollContainer(activity)
+                scroll.insert(View(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        1_000,
+                    )
+                })
+                scroll.setAutoScrollToEndThreshold(24f)
+                scroll.setAnchorToEnd(true)
+                activity.host.addView(scroll, FrameLayout.LayoutParams(300, 400))
+                relayout(activity.host)
+                assertEquals(600, scroll.snapshotOffsetPixels().second)
+
+                scroll.setKeyboardAvoidanceInset(200)
+                relayout(activity.host)
+            }
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                assertEquals(200, scroll.keyboardAvoidanceInsetPixels())
+                assertEquals(800, scroll.snapshotOffsetPixels().second)
+
+                scroll.restoreOffsetPixels(0, 200)
+            }
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                scroll.setKeyboardAvoidanceInset(300)
+                relayout(activity.host)
+            }
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                assertEquals(200, scroll.snapshotOffsetPixels().second)
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
     private fun launchActivity(instrumentation: Instrumentation): PamTestActivity {
         val intent = Intent(
             instrumentation.targetContext,

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamNavigationHost.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamNavigationHost.kt
@@ -250,8 +250,6 @@ internal class PamNavigationHost(context: Context) : FrameLayout(context) {
             return
         }
 
-        incoming.setLayerType(View.LAYER_TYPE_HARDWARE, null)
-        outgoing?.setLayerType(View.LAYER_TYPE_HARDWARE, null)
         running = ValueAnimator.ofFloat(0f, 1f).apply {
             duration = actualDuration
             interpolator = DecelerateInterpolator(1.75f)
@@ -343,8 +341,6 @@ internal class PamNavigationHost(context: Context) : FrameLayout(context) {
 
     private fun finish(incoming: View, outgoing: View?) {
         running = null
-        incoming.setLayerType(View.LAYER_TYPE_NONE, null)
-        outgoing?.setLayerType(View.LAYER_TYPE_NONE, null)
         reset(incoming)
         outgoing?.let {
             reset(it)

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
@@ -505,6 +505,11 @@ class PamRenderer(
             (host as? PamRootHost)?.removePointerObserver(observer)
         }
         if (state.kind == NodeKind.KEYBOARD_AVOIDING_VIEW) {
+            if (state.keyboardAvoidingScrollId != 0L) {
+                views[state.keyboardAvoidingScrollId]
+                    ?.let { it as? PamScrollContainer }
+                    ?.setKeyboardAvoidanceInset(0)
+            }
             host.setOnApplyWindowInsetsListener(null)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 host.setWindowInsetsAnimationCallback(null)
@@ -4009,13 +4014,70 @@ class PamRenderer(
             }
             KEYBOARD_PADDING -> {
                 view.translationY = 0f
-                view.setPadding(0, 0, 0, keyboard)
+                view.setPadding(0, 0, 0, 0)
             }
             else -> {
                 view.translationY = 0f
                 view.setPadding(0, 0, 0, 0)
             }
         }
+        val scroll = when (state.keyboardBehavior) {
+            KEYBOARD_PAN -> precedingScrollContainer(state)
+            KEYBOARD_PADDING -> containedScrollContainer(state)
+            else -> null
+        }
+        val scrollId = scroll?.first ?: 0L
+        if (state.keyboardAvoidingScrollId != scrollId) {
+            if (state.keyboardAvoidingScrollId != 0L) {
+                views[state.keyboardAvoidingScrollId]
+                    ?.let { it as? PamScrollContainer }
+                    ?.setKeyboardAvoidanceInset(0)
+            }
+            state.keyboardAvoidingScrollId = scrollId
+        }
+        scroll?.second?.setKeyboardAvoidanceInset(
+            keyboard,
+        )
+    }
+
+    private fun containedScrollContainer(
+        state: NodeState,
+    ): Pair<Long, PamScrollContainer>? {
+        val descendants = children[state.id] ?: return null
+        for (id in descendants) {
+            firstScrollContainer(id)?.let { return it }
+        }
+        return null
+    }
+
+    private fun firstScrollContainer(id: Long): Pair<Long, PamScrollContainer>? {
+        (views[id] as? PamScrollContainer)?.let { return id to it }
+        val descendants = children[id] ?: return null
+        for (descendant in descendants) {
+            firstScrollContainer(descendant)?.let { return it }
+        }
+        return null
+    }
+
+    private fun precedingScrollContainer(
+        state: NodeState,
+    ): Pair<Long, PamScrollContainer>? {
+        val siblings = children[state.parent] ?: return null
+        val position = siblings.indexOf(state.id)
+        if (position <= 0) return null
+        for (index in position - 1 downTo 0) {
+            lastScrollContainer(siblings[index])?.let { return it }
+        }
+        return null
+    }
+
+    private fun lastScrollContainer(id: Long): Pair<Long, PamScrollContainer>? {
+        (views[id] as? PamScrollContainer)?.let { return id to it }
+        val descendants = children[id] ?: return null
+        for (index in descendants.lastIndex downTo 0) {
+            lastScrollContainer(descendants[index])?.let { return it }
+        }
+        return null
     }
 
     private fun applyMergedStatusBar() {
@@ -4840,6 +4902,7 @@ class PamRenderer(
         var keyboardInset: Int = 0,
         var keyboardBaseHeight: Int = 0,
         var keyboardLayoutListener: View.OnLayoutChangeListener? = null,
+        var keyboardAvoidingScrollId: Long = 0L,
         var defaultHighlightColor: Int = Color.TRANSPARENT,
         var propertyAnimator: ObjectAnimator? = null,
         var keyframeAnimator: ValueAnimator? = null,

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamScrollContainer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamScrollContainer.kt
@@ -38,6 +38,8 @@ internal class PamScrollContainer(context: Context) : FrameLayout(context) {
     private var initialEndAnchorApplied = false
     private var maintainVisibleContentPosition = false
     private var autoScrollToEndThresholdPx = 24
+    private var keyboardAvoidanceInsetPx = 0
+    private var keyboardBaseContentExtentPx = 0
     private val applyOffsetRunnable = Runnable {
         offsetScheduled = false
         applyRequestedOffset()
@@ -185,6 +187,43 @@ internal class PamScrollContainer(context: Context) : FrameLayout(context) {
     fun setAutoScrollToEndThreshold(value: Float) {
         autoScrollToEndThresholdPx = dp(value.coerceAtLeast(0f))
     }
+
+    fun setKeyboardAvoidanceInset(value: Int) {
+        val inset = value.coerceAtLeast(0)
+        if (keyboardAvoidanceInsetPx == inset) return
+        val wasNearEnd =
+            primaryMaxOffset() - primaryCurrentOffset() <= autoScrollToEndThresholdPx
+        if (keyboardAvoidanceInsetPx == 0 && inset > 0) {
+            keyboardBaseContentExtentPx = if (horizontal) content.width else content.height
+        }
+        keyboardAvoidanceInsetPx = inset
+        if (horizontal) {
+            content.setPadding(0, 0, inset, 0)
+            content.minimumWidth = if (inset > 0) {
+                keyboardBaseContentExtentPx + inset
+            } else {
+                0
+            }
+        } else {
+            content.setPadding(0, 0, 0, inset)
+            content.minimumHeight = if (inset > 0) {
+                keyboardBaseContentExtentPx + inset
+            } else {
+                0
+            }
+        }
+        if (inset == 0) keyboardBaseContentExtentPx = 0
+        content.requestLayout()
+        if (anchorToEnd && wasNearEnd) {
+            activeScroll.post {
+                if (isAttachedToWindow && keyboardAvoidanceInsetPx == inset) {
+                    scrollToPrimary(primaryMaxOffset())
+                }
+            }
+        }
+    }
+
+    fun keyboardAvoidanceInsetPixels(): Int = keyboardAvoidanceInsetPx
 
     fun setOnViewportChanged(listener: ((Float, Float) -> Unit)?) {
         viewportChanged = listener

--- a/packages/native/resources/pam-native.custom-data.json
+++ b/packages/native/resources/pam-native.custom-data.json
@@ -51,6 +51,7 @@
                 { "name": "readOnly", "values": [{ "name": "true" }, { "name": "false" }] },
                 { "name": "multiline", "values": [{ "name": "true" }, { "name": "false" }] },
                 { "name": "secure", "values": [{ "name": "true" }, { "name": "false" }] },
+                { "name": "secureTextEntry", "description": "React Native-compatible alias for secure.", "values": [{ "name": "true" }, { "name": "false" }] },
                 { "name": "autoCorrect", "values": [{ "name": "true" }, { "name": "false" }] },
                 { "name": "autoCapitalize", "values": [{ "name": "none" }, { "name": "sentences" }, { "name": "words" }, { "name": "characters" }] },
                 { "name": "autoComplete" },

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -132,6 +132,7 @@ final class TemplateRenderer
         'numberOfLines' => PropKey::NumberOfLines,
         'multiline' => PropKey::Multiline,
         'secure' => PropKey::Secure,
+        'secureTextEntry' => PropKey::Secure,
         'keyboardType' => PropKey::KeyboardType,
         'autoComplete' => PropKey::AutoComplete,
         'editable' => PropKey::InputEditable,
@@ -2267,6 +2268,29 @@ final class TemplateRenderer
         ?object $scope,
         array $data,
     ): Closure {
+        if (
+            is_string($raw)
+            && preg_match('/^[A-Za-z_][A-Za-z0-9_]*\s*\(/D', $raw) === 1
+        ) {
+            if ($scope === null) {
+                throw new RuntimeException(
+                    'Template event expressions require a component scope.',
+                );
+            }
+
+            return static function (mixed $payload = '') use (
+                $raw,
+                $scope,
+                $data,
+            ): void {
+                TemplateExpression::evaluate(
+                    $raw,
+                    $scope,
+                    [...$data, 'event' => $payload],
+                );
+            };
+        }
+
         $resolved = self::value($raw, $scope, $data);
 
         if ($resolved instanceof Closure) {

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -608,6 +608,16 @@ $assert(
         && $inputKey->key === 'Enter',
     'Input helpers must preserve native editing, selection, keyboard, size and key behavior.',
 );
+$secureAliasElement = TemplateRenderer::render(
+    TemplateCompiler::compile('<Input secureTextEntry="true" />'),
+    new class {
+    },
+    [],
+);
+$assert(
+    $secureAliasElement->properties()[PropKey::Secure->value] === true,
+    'Input secureTextEntry must remain a compatible alias for secure.',
+);
 $pressInEvent = null;
 $pressOutEvent = null;
 $pressMoveEvent = null;
@@ -1336,6 +1346,34 @@ $assert(
         && $pressScope->move instanceof PressEvent
         && $pressScope->move->pageX === 12.0,
     'Core Pressable tags must retain gesture properties and typed move events.',
+);
+$itemActionScope = new class {
+    public string $selected = '';
+
+    public function select(string $id): void
+    {
+        $this->selected = $id;
+    }
+};
+$itemActionElement = TemplateRenderer::render(
+    TemplateCompiler::compile(
+        '<Column><Pressable v-for="$item in $items" '
+        .'on:longPress="select($item[\'id\'])"><Text>{{ $item[\'id\'] }}</Text>'
+        .'</Pressable></Column>',
+    ),
+    $itemActionScope,
+    ['items' => [['id' => 'first'], ['id' => 'second']]],
+);
+$assert(
+    $itemActionScope->selected === '',
+    'Native event expressions must not execute during template rendering.',
+);
+$itemActionElement
+    ->children()[1]
+    ->events()[EventKind::LongPress->value]('');
+$assert(
+    $itemActionScope->selected === 'second',
+    'Native event expressions must capture v-for item data until dispatch.',
 );
 $directiveScope = new class {
     /** @var list<string> */


### PR DESCRIPTION
## Summary
- keeps anchored chat scroll content above the Android IME in `pan` mode
- gives descendant scroll containers the correct IME inset in `padding` mode
- preserves the previous scroll position while the keyboard changes the viewport
- accepts `secureTextEntry` as a compatibility alias for secure native inputs
- dispatches bounded native event expressions lazily with captured `v-for` scope
- animates Android navigation with display lists instead of full-screen bitmap layers

## Performance
On the API 36 x86_64 emulator, removing transition bitmap layers reduced the same media-heavy chat opening from 56% to 20% janky frames, p50 from 38 ms to 17 ms, and p90 from 65 ms to 34 ms.

## Validation
- PHP SDK contract suite
- Android Kotlin and instrumented-test compilation
- API 26/API 36 renderer CI
- ZeChat offline-first inbox/chat, keyboard, image viewer, long-press actions, reply context, and Android Back on API 36 emulator