### PR TITLE
fix(template): consume logical right operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.12 - 2026-07-29
+
+### Fixed
+
+- Template `&&` and `||` expressions now always consume their right operand,
+  preventing valid compound conditions from failing with an unexpected-token
+  error when PHP short-circuits the evaluated boolean value.
+
 ## 0.5.11 - 2026-07-29
 
 - Add a typed, asynchronous audio recorder for Android and iOS with AAC/M4A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Template `&&` and `||` expressions now always consume their right operand,
   preventing valid compound conditions from failing with an unexpected-token
   error when PHP short-circuits the evaluated boolean value.
+- Empty successful storage reads are treated as cache misses instead of invalid
+  wire maps, and iOS now returns the same encoded empty-map contract as Android.
 
 ## 0.5.11 - 2026-07-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.11"
+version = "0.5.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.11"
+version = "0.5.12"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/pam-native.properties
+++ b/android/pam-native.properties
@@ -4,5 +4,5 @@ applicationName=Pam Native
 minSdk=26
 targetSdk=36
 versionCode=11
-versionName=0.5.11
+versionName=0.5.12
 abis=arm64-v8a,x86_64

--- a/ios/Sources/PamNative/Modules/StorageModule.swift
+++ b/ios/Sources/PamNative/Modules/StorageModule.swift
@@ -26,7 +26,7 @@ public final class StorageModule: NativeModule, ClosableNativeModule, @unchecked
                     if let value = self.defaults.string(forKey: key) {
                         completion(.success, try WireMap.encode(["value": .text(value)]))
                     } else {
-                        completion(.success, Data())
+                        completion(.success, try WireMap.encode([:]))
                     }
                 case "set":
                     guard case let .text(value)? = values["value"] else {

--- a/packages/native/src/Internal/TemplateExpression.php
+++ b/packages/native/src/Internal/TemplateExpression.php
@@ -96,7 +96,8 @@ final class TemplateExpression
         $value = $this->logicalAnd();
 
         while ($this->take(T_BOOLEAN_OR) || $this->take('||')) {
-            $value = (bool) $value || (bool) $this->logicalAnd();
+            $right = $this->logicalAnd();
+            $value = (bool) $value || (bool) $right;
         }
 
         return $value;
@@ -107,7 +108,8 @@ final class TemplateExpression
         $value = $this->equality();
 
         while ($this->take(T_BOOLEAN_AND) || $this->take('&&')) {
-            $value = (bool) $value && (bool) $this->equality();
+            $right = $this->equality();
+            $value = (bool) $value && (bool) $right;
         }
 
         return $value;

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.5.11';
+    public const string SDK_VERSION = '0.5.12';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/Storage/Storage.php
+++ b/packages/native/src/Storage/Storage.php
@@ -28,6 +28,11 @@ final class Storage
                     throw new RuntimeException($payload);
                 }
 
+                if ($payload === '') {
+                    $callback(null);
+
+                    return;
+                }
                 $values = Wire::decodeMap($payload);
                 $callback(isset($values['value']) ? (string) $values['value'] : null);
             },

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2412,6 +2412,23 @@ final class Dashboard extends Component
 PAM,
 );
 
+$assert(
+    \Pam\Native\Internal\TemplateExpression::evaluate(
+        '$left && $right',
+        null,
+        ['left' => false, 'right' => true],
+    ) === false,
+    'Template logical AND must consume its right operand when the left operand is false.',
+);
+$assert(
+    \Pam\Native\Internal\TemplateExpression::evaluate(
+        '$left || $right',
+        null,
+        ['left' => true, 'right' => false],
+    ) === true,
+    'Template logical OR must consume its right operand when the left operand is true.',
+);
+
 TemplateRegistry::reset();
 App::components($pamPhpDirectory, $pamPhpCache);
 $dashboardClass = 'Pam\\Native\\Tests\\Sfc\\Dashboard';
@@ -2743,8 +2760,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.5.11',
-    'The runtime SDK contract must match the 0.5.11 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.5.12',
+    'The runtime SDK contract must match the 0.5.12 package release.',
 );
 
 $bottomSheet = BottomSheet::make(

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -108,6 +108,7 @@ use Pam\Native\System\Sensors;
 use Pam\Native\System\Location;
 use Pam\Native\LocationPosition;
 use Pam\Native\System\AudioRecorder;
+use Pam\Native\Storage\Storage;
 use Pam\Native\AudioRecording;
 use Pam\Native\SensorType;
 use Pam\Native\Style;
@@ -1754,6 +1755,23 @@ $assert(
         && $recording->size === 19_200
         && $recording->mimeType === 'audio/mp4',
     'Audio recorder facade did not decode the native recording.',
+);
+
+$missingStoredValue = 'not-dispatched';
+$storageRequest = Storage::get(
+    'chat.draft.missing',
+    static function (?string $value) use (&$missingStoredValue): void {
+        $missingStoredValue = $value;
+    },
+);
+Runtime::dispatchModuleResult(
+    $storageRequest,
+    ModuleResultStatus::Success->value,
+    '',
+);
+$assert(
+    $missingStoredValue === null,
+    'Storage get must treat an empty successful payload as a cache miss.',
 );
 
 $batchRequestId = SQLite::executeMany(


### PR DESCRIPTION
## Summary
- fix compound template conditions when PHP would short-circuit the evaluated value
- always parse and consume the right operand for logical AND and logical OR
- add regression coverage for both failure directions
- prepare v0.5.12

## Validation
- php packages/native/tests/run.php
- cargo check --workspace
- git diff --check