### PR TITLE
feat(sqlite): add atomic heterogeneous transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.13 - 2026-07-29
+
+### Added
+
+- Add `SQLite::transaction()` for up to 10,000 heterogeneous prepared
+  statements in one bridge call and one native Android/iOS transaction.
+- Roll back the complete statement batch on the first preparation, binding, or
+  execution failure, enabling atomic offline-first snapshot replacement.
+
 ## 0.5.12 - 2026-07-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.12"
+version = "0.5.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.12"
+version = "0.5.13"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/SQLiteModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/SQLiteModule.kt
@@ -44,6 +44,13 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
                         )
                         completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))
                     }
+                    "transaction" -> {
+                        executeTransaction(
+                            database,
+                            decodeStatements(values.requiredText("arguments")),
+                        )
+                        completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))
+                    }
                     else -> error("Unknown SQLite method $method")
                 }
             }.onFailure { error ->
@@ -115,6 +122,39 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
         }
     }
 
+    private fun decodeStatements(value: String): List<Pair<String, Array<Any?>>> {
+        val statements = JSONArray(value)
+        require(statements.length() in 1..MAX_BATCH_ROWS) {
+            "SQLite transaction requires between 1 and 10000 statements"
+        }
+        return List(statements.length()) { index ->
+            val statement = statements.getJSONObject(index)
+            val sql = statement.getString("sql")
+            require(sql.isNotEmpty() && sql.toByteArray().size <= MAX_SQL_BYTES) {
+                "Invalid SQLite transaction SQL statement"
+            }
+            sql to decodeArguments(statement.getJSONArray("arguments").toString())
+        }
+    }
+
+    private fun executeTransaction(
+        database: SQLiteDatabase,
+        statements: List<Pair<String, Array<Any?>>>,
+    ) {
+        database.beginTransactionNonExclusive()
+        try {
+            statements.forEach { (sql, arguments) ->
+                database.compileStatement(sql).use { statement ->
+                    bind(arguments, statement)
+                    statement.execute()
+                }
+            }
+            database.setTransactionSuccessful()
+        } finally {
+            database.endTransaction()
+        }
+    }
+
     private fun bind(arguments: Array<Any?>, statement: SQLiteStatement) {
         arguments.forEachIndexed { offset, value ->
             val index = offset + 1
@@ -177,5 +217,6 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
         const val MAX_QUERY_ROWS = 1_000
         const val MAX_QUERY_COLUMNS = 256
         const val MAX_BATCH_ROWS = 10_000
+        const val MAX_SQL_BYTES = 1_048_576
     }
 }

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/SQLiteModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/SQLiteModule.kt
@@ -12,6 +12,11 @@ import java.io.File
 import java.util.concurrent.Executors
 
 internal class SQLiteModule(private val context: Context) : NativeModule, AutoCloseable {
+    private data class TransactionStatement(
+        val sql: String,
+        val argumentSets: List<Array<Any?>>,
+    )
+
     private val executor = Executors.newSingleThreadExecutor()
     private val databases = mutableMapOf<String, SQLiteDatabase>()
 
@@ -122,7 +127,7 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
         }
     }
 
-    private fun decodeStatements(value: String): List<Pair<String, Array<Any?>>> {
+    private fun decodeStatements(value: String): List<TransactionStatement> {
         val statements = JSONArray(value)
         require(statements.length() in 1..MAX_BATCH_ROWS) {
             "SQLite transaction requires between 1 and 10000 statements"
@@ -133,20 +138,28 @@ internal class SQLiteModule(private val context: Context) : NativeModule, AutoCl
             require(sql.isNotEmpty() && sql.toByteArray().size <= MAX_SQL_BYTES) {
                 "Invalid SQLite transaction SQL statement"
             }
-            sql to decodeArguments(statement.getJSONArray("arguments").toString())
+            val argumentSets = if (statement.has("argumentSets")) {
+                decodeArgumentSets(statement.getJSONArray("argumentSets").toString())
+            } else {
+                listOf(decodeArguments(statement.getJSONArray("arguments").toString()))
+            }
+            TransactionStatement(sql, argumentSets)
         }
     }
 
     private fun executeTransaction(
         database: SQLiteDatabase,
-        statements: List<Pair<String, Array<Any?>>>,
+        statements: List<TransactionStatement>,
     ) {
         database.beginTransactionNonExclusive()
         try {
-            statements.forEach { (sql, arguments) ->
-                database.compileStatement(sql).use { statement ->
-                    bind(arguments, statement)
-                    statement.execute()
+            statements.forEach { transactionStatement ->
+                database.compileStatement(transactionStatement.sql).use { statement ->
+                    transactionStatement.argumentSets.forEach { arguments ->
+                        statement.clearBindings()
+                        bind(arguments, statement)
+                        statement.execute()
+                    }
                 }
             }
             database.setTransactionSuccessful()

--- a/android/pam-native.properties
+++ b/android/pam-native.properties
@@ -4,5 +4,5 @@ applicationName=Pam Native
 minSdk=26
 targetSdk=36
 versionCode=11
-versionName=0.5.12
+versionName=0.5.13
 abis=arm64-v8a,x86_64

--- a/ios/Sources/PamNative/Modules/SQLiteModule.swift
+++ b/ios/Sources/PamNative/Modules/SQLiteModule.swift
@@ -35,6 +35,10 @@ final class SQLiteModule: NativeModule, ClosableNativeModule {
                     let argumentSets = try self.decodeArgumentSets(argumentsJSON)
                     try self.executeMany(database, sql, argumentSets)
                     completion(.success, Data())
+                case "transaction":
+                    let statements = try self.decodeStatements(argumentsJSON)
+                    try self.executeTransaction(database, statements)
+                    completion(.success, Data())
                 default:
                     throw SQLiteError("Unknown SQLite method \(method)")
                 }
@@ -109,6 +113,44 @@ final class SQLiteModule: NativeModule, ClosableNativeModule {
             for arguments in argumentSets {
                 sqlite3_reset(statement)
                 sqlite3_clear_bindings(statement)
+                try bind(arguments, to: statement)
+                guard sqlite3_step(statement) == SQLITE_DONE else {
+                    throw SQLiteError(String(cString: sqlite3_errmsg(database)))
+                }
+            }
+            try execute(database, "COMMIT")
+        } catch {
+            try? execute(database, "ROLLBACK")
+            throw error
+        }
+    }
+
+    private func decodeStatements(_ json: String) throws -> [(String, [Any])] {
+        let value = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        guard let rawStatements = value as? [[String: Any]],
+              (1...10_000).contains(rawStatements.count) else {
+            throw SQLiteError("SQLite transaction requires between 1 and 10000 statements")
+        }
+        return try rawStatements.map { raw in
+            guard let sql = raw["sql"] as? String,
+                  !sql.isEmpty,
+                  sql.utf8.count <= 1_048_576,
+                  let arguments = raw["arguments"] as? [Any] else {
+                throw SQLiteError("Invalid SQLite transaction statement")
+            }
+            return (sql, arguments)
+        }
+    }
+
+    private func executeTransaction(
+        _ database: OpaquePointer,
+        _ statements: [(String, [Any])]
+    ) throws {
+        try execute(database, "BEGIN IMMEDIATE")
+        do {
+            for (sql, arguments) in statements {
+                let statement = try prepare(database, sql)
+                defer { sqlite3_finalize(statement) }
                 try bind(arguments, to: statement)
                 guard sqlite3_step(statement) == SQLITE_DONE else {
                     throw SQLiteError(String(cString: sqlite3_errmsg(database)))

--- a/ios/Sources/PamNative/Modules/SQLiteModule.swift
+++ b/ios/Sources/PamNative/Modules/SQLiteModule.swift
@@ -125,7 +125,7 @@ final class SQLiteModule: NativeModule, ClosableNativeModule {
         }
     }
 
-    private func decodeStatements(_ json: String) throws -> [(String, [Any])] {
+    private func decodeStatements(_ json: String) throws -> [(String, [[Any]])] {
         let value = try JSONSerialization.jsonObject(with: Data(json.utf8))
         guard let rawStatements = value as? [[String: Any]],
               (1...10_000).contains(rawStatements.count) else {
@@ -134,26 +134,36 @@ final class SQLiteModule: NativeModule, ClosableNativeModule {
         return try rawStatements.map { raw in
             guard let sql = raw["sql"] as? String,
                   !sql.isEmpty,
-                  sql.utf8.count <= 1_048_576,
-                  let arguments = raw["arguments"] as? [Any] else {
+                  sql.utf8.count <= 1_048_576 else {
                 throw SQLiteError("Invalid SQLite transaction statement")
             }
-            return (sql, arguments)
+            if let argumentSets = raw["argumentSets"] as? [[Any]],
+               (1...10_000).contains(argumentSets.count) {
+                return (sql, argumentSets)
+            }
+            guard let arguments = raw["arguments"] as? [Any] else {
+                throw SQLiteError("Invalid SQLite transaction arguments")
+            }
+            return (sql, [arguments])
         }
     }
 
     private func executeTransaction(
         _ database: OpaquePointer,
-        _ statements: [(String, [Any])]
+        _ statements: [(String, [[Any]])]
     ) throws {
         try execute(database, "BEGIN IMMEDIATE")
         do {
-            for (sql, arguments) in statements {
+            for (sql, argumentSets) in statements {
                 let statement = try prepare(database, sql)
                 defer { sqlite3_finalize(statement) }
-                try bind(arguments, to: statement)
-                guard sqlite3_step(statement) == SQLITE_DONE else {
-                    throw SQLiteError(String(cString: sqlite3_errmsg(database)))
+                for arguments in argumentSets {
+                    sqlite3_reset(statement)
+                    sqlite3_clear_bindings(statement)
+                    try bind(arguments, to: statement)
+                    guard sqlite3_step(statement) == SQLITE_DONE else {
+                        throw SQLiteError(String(cString: sqlite3_errmsg(database)))
+                    }
                 }
             }
             try execute(database, "COMMIT")

--- a/packages/native/src/Database/SQLite.php
+++ b/packages/native/src/Database/SQLite.php
@@ -62,6 +62,71 @@ final class SQLite
     }
 
     /**
+     * Executes heterogeneous prepared statements atomically in one native transaction.
+     *
+     * @param list<array{sql: string, arguments?: list<string|int|float|bool|null>}> $statements
+     */
+    public static function transaction(
+        string $database,
+        array $statements,
+        ?Closure $callback = null,
+    ): int {
+        self::validateName($database);
+        if ($statements === [] || count($statements) > 10_000) {
+            throw new InvalidArgumentException(
+                'SQLite transaction requires between 1 and 10000 statements.',
+            );
+        }
+        $normalized = [];
+        foreach ($statements as $statement) {
+            $sql = $statement['sql'] ?? '';
+            $arguments = $statement['arguments'] ?? [];
+            if (!is_string($sql) || $sql === '' || strlen($sql) > 1_048_576) {
+                throw new InvalidArgumentException(
+                    'Every SQLite transaction SQL statement must contain between 1 and 1048576 bytes.',
+                );
+            }
+            if (!is_array($arguments)) {
+                throw new InvalidArgumentException(
+                    'SQLite transaction arguments must be arrays.',
+                );
+            }
+            $normalized[] = [
+                'sql' => $sql,
+                'arguments' => array_values($arguments),
+            ];
+        }
+        try {
+            $encoded = json_encode(
+                $normalized,
+                JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE,
+            );
+        } catch (JsonException $error) {
+            throw new InvalidArgumentException(
+                'SQLite transaction arguments must be JSON scalars.',
+                0,
+                $error,
+            );
+        }
+
+        return NativeModules::call(
+            'sqlite',
+            'transaction',
+            [
+                'database' => $database,
+                'sql' => '',
+                'arguments' => $encoded,
+            ],
+            static function ($result) use ($callback): void {
+                if ($result->status === ModuleResultStatus::Failure) {
+                    throw new RuntimeException($result->payload);
+                }
+                $callback?->__invoke();
+            },
+        );
+    }
+
+    /**
      * @param list<string|int|float|bool|null>|list<list<string|int|float|bool|null>> $arguments
      */
     private static function call(

--- a/packages/native/src/Database/SQLite.php
+++ b/packages/native/src/Database/SQLite.php
@@ -64,7 +64,11 @@ final class SQLite
     /**
      * Executes heterogeneous prepared statements atomically in one native transaction.
      *
-     * @param list<array{sql: string, arguments?: list<string|int|float|bool|null>}> $statements
+     * @param list<array{
+     *   sql: string,
+     *   arguments?: list<string|int|float|bool|null>,
+     *   argumentSets?: list<list<string|int|float|bool|null>>
+     * }> $statements
      */
     public static function transaction(
         string $database,
@@ -81,6 +85,7 @@ final class SQLite
         foreach ($statements as $statement) {
             $sql = $statement['sql'] ?? '';
             $arguments = $statement['arguments'] ?? [];
+            $argumentSets = $statement['argumentSets'] ?? null;
             if (!is_string($sql) || $sql === '' || strlen($sql) > 1_048_576) {
                 throw new InvalidArgumentException(
                     'Every SQLite transaction SQL statement must contain between 1 and 1048576 bytes.',
@@ -91,9 +96,20 @@ final class SQLite
                     'SQLite transaction arguments must be arrays.',
                 );
             }
+            if ($argumentSets !== null
+                && (!is_array($argumentSets)
+                    || $argumentSets === []
+                    || count($argumentSets) > 10_000)) {
+                throw new InvalidArgumentException(
+                    'SQLite transaction argumentSets must contain between 1 and 10000 rows.',
+                );
+            }
             $normalized[] = [
                 'sql' => $sql,
                 'arguments' => array_values($arguments),
+                ...($argumentSets === null
+                    ? []
+                    : ['argumentSets' => array_values($argumentSets)]),
             ];
         }
         try {

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.5.12';
+    public const string SDK_VERSION = '0.5.13';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1810,7 +1810,10 @@ $transactionRequestId = SQLite::transaction(
         ],
         [
             'sql' => 'INSERT INTO messages (id, chat_id, body) VALUES (?, ?, ?)',
-            'arguments' => ['m3', 'chat-1', 'atomic'],
+            'argumentSets' => [
+                ['m3', 'chat-1', 'atomic'],
+                ['m4', 'chat-1', 'batched'],
+            ],
         ],
     ],
 );
@@ -1830,7 +1833,11 @@ $assert(
             ],
             [
                 'sql' => 'INSERT INTO messages (id, chat_id, body) VALUES (?, ?, ?)',
-                'arguments' => ['m3', 'chat-1', 'atomic'],
+                'arguments' => [],
+                'argumentSets' => [
+                    ['m3', 'chat-1', 'atomic'],
+                    ['m4', 'chat-1', 'batched'],
+                ],
             ],
         ],
     'SQLite transaction did not emit one typed bridge call for heterogeneous statements.',

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1801,6 +1801,46 @@ Runtime::dispatchModuleResult(
     '',
 );
 
+$transactionRequestId = SQLite::transaction(
+    'nitro.db',
+    [
+        [
+            'sql' => 'DELETE FROM messages WHERE chat_id = ?',
+            'arguments' => ['chat-1'],
+        ],
+        [
+            'sql' => 'INSERT INTO messages (id, chat_id, body) VALUES (?, ?, ?)',
+            'arguments' => ['m3', 'chat-1', 'atomic'],
+        ],
+    ],
+);
+$transactionCall = TestDiagnostics::$moduleCall;
+$transactionPayload = $transactionCall === null
+    ? []
+    : Wire::decodeMap($transactionCall['payload']);
+$assert(
+    $transactionCall !== null
+        && $transactionCall['requestId'] === $transactionRequestId
+        && $transactionCall['module'] === 'sqlite'
+        && $transactionCall['method'] === 'transaction'
+        && json_decode((string) ($transactionPayload['arguments'] ?? ''), true) === [
+            [
+                'sql' => 'DELETE FROM messages WHERE chat_id = ?',
+                'arguments' => ['chat-1'],
+            ],
+            [
+                'sql' => 'INSERT INTO messages (id, chat_id, body) VALUES (?, ?, ?)',
+                'arguments' => ['m3', 'chat-1', 'atomic'],
+            ],
+        ],
+    'SQLite transaction did not emit one typed bridge call for heterogeneous statements.',
+);
+Runtime::dispatchModuleResult(
+    $transactionRequestId,
+    \Pam\Native\ModuleResultStatus::Success->value,
+    '',
+);
+
 $contacts = null;
 $contactsRequestId = Contacts::all(static function (array $items) use (&$contacts): void {
     $contacts = $items;
@@ -2778,8 +2818,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.5.12',
-    'The runtime SDK contract must match the 0.5.12 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.5.13',
+    'The runtime SDK contract must match the 0.5.13 package release.',
 );
 
 $bottomSheet = BottomSheet::make(


### PR DESCRIPTION
Adds SQLite::transaction() for heterogeneous prepared statements in a single bridge call and native Android/iOS transaction. This enables PAM Nitro to atomically replace offline-first collection snapshots without stale rows or an empty-cache window. Includes PHP bridge contracts and bumps the release to 0.5.13.