### PR TITLE
fix: accept flex layout aliases in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.14 - 2026-07-29
+
+- Accept React Native/CSS-compatible `flex-start` and `flex-end` aliases for
+  template `alignItems`, `alignSelf`, and `justifyContent` properties.
+
 ## 0.5.13 - 2026-07-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.13"
+version = "0.5.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.13"
+version = "0.5.14"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/pam-native.properties
+++ b/android/pam-native.properties
@@ -4,5 +4,5 @@ applicationName=Pam Native
 minSdk=26
 targetSdk=36
 versionCode=11
-versionName=0.5.13
+versionName=0.5.14
 abis=arm64-v8a,x86_64

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -1604,10 +1604,12 @@ final class TemplateRenderer
             PropKey::DrawerOverlayColor,
             => self::colorValue($value, "Template {$key->name}"),
             PropKey::AlignItems, PropKey::AlignSelf => self::named($value, [
-                'start' => 1, 'center' => 2, 'end' => 3, 'stretch' => 4,
+                'start' => 1, 'flex-start' => 1, 'center' => 2,
+                'end' => 3, 'flex-end' => 3, 'stretch' => 4,
             ]),
             PropKey::JustifyContent => self::named($value, [
-                'start' => 1, 'center' => 2, 'end' => 3, 'space-between' => 4,
+                'start' => 1, 'flex-start' => 1, 'center' => 2,
+                'end' => 3, 'flex-end' => 3, 'space-between' => 4,
                 'space-around' => 5, 'space-evenly' => 6,
             ]),
             PropKey::TextAlign => self::named($value, ['start' => 1, 'center' => 2, 'end' => 3]),

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.5.13';
+    public const string SDK_VERSION = '0.5.14';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1277,6 +1277,19 @@ $coreRoleElement = TemplateRenderer::render(
     null,
     [],
 );
+$flexAliasElement = TemplateRenderer::render(
+    TemplateCompiler::compile(
+        '<Row alignItems="flex-start" alignSelf="flex-end" justifyContent="flex-end" />',
+    ),
+    null,
+    [],
+);
+$assert(
+    $flexAliasElement->properties()[PropKey::AlignItems->value] === 1
+        && $flexAliasElement->properties()[PropKey::AlignSelf->value] === 3
+        && $flexAliasElement->properties()[PropKey::JustifyContent->value] === 3,
+    'Template flex-start and flex-end aliases must match native start and end layout values.',
+);
 $gridElement = TemplateRenderer::render(
     TemplateCompiler::compile(
         '<Grid gutterX="16" gutterY="8"><Column span="12" spanSm="6" spanMd="4"><Image source="cover.webp" aspectRatio="1" /><Pressable><Text>Open</Text></Pressable></Column><Column class="col-6 col-lg-3 offset-lg-1 order-md-2" /></Grid>',
@@ -2825,8 +2838,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.5.13',
-    'The runtime SDK contract must match the 0.5.13 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.5.14',
+    'The runtime SDK contract must match the 0.5.14 package release.',
 );
 
 $bottomSheet = BottomSheet::make(


### PR DESCRIPTION
## Summary
- accept `flex-start`/`flex-end` for template alignment props
- preserve existing native integer values
- bump SDK release metadata to 0.5.14

## Validation
- `php packages/native/tests/run.php`
- `cargo test --workspace`
- Android local assemble reached native engine preparation; x86_64 engine artifact is intentionally generated in CI