### PR TITLE
feat: add native multi-file picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.15 - 2026-07-29
+
+- Add typed `Files::pickMany()` on Android and iOS with native multi-selection,
+  ordered background imports, bounded batches, unique sandbox paths, and
+  transactional cleanup when an import fails.
+
 ## 0.5.14 - 2026-07-29
 
 - Accept React Native/CSS-compatible `flex-start` and `flex-end` aliases for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.14"
+version = "0.5.15"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.14"
+version = "0.5.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.14"
+version = "0.5.15"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
@@ -13,6 +13,7 @@ import dev.pam.nativeapp.protocol.WireValue
 import java.io.File
 import java.io.FileOutputStream
 import java.util.Base64
+import java.util.UUID
 import java.util.concurrent.Executors
 import org.json.JSONArray
 import org.json.JSONObject
@@ -30,6 +31,7 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
                 "list" -> executor.execute { list(payload, completion) }
                 "delete" -> executor.execute { delete(payload, completion) }
                 "pick" -> pick(payload, completion)
+                "pickMany" -> pickMany(payload, completion)
                 "capture" -> capture(payload, completion)
                 else -> error("Unknown files method $method")
             }
@@ -124,6 +126,52 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
         }
     }
 
+    private fun pickMany(payload: ByteArray, completion: ModuleCompletion) {
+        val values = WireMap.decode(payload)
+        val type = values.integer("type", 4)
+        val limit = values.integer("limit", DEFAULT_PICK_LIMIT.toLong())
+            .coerceIn(1, MAX_PICK_LIMIT.toLong())
+            .toInt()
+        val mime = when (type) {
+            1L -> "image/*"
+            2L -> "video/*"
+            3L -> "audio/*"
+            else -> "*/*"
+        }
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            this.type = mime
+            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+        }
+        activity.launchForResult(intent) { result, data ->
+            if (result != Activity.RESULT_OK || data == null) {
+                completion.complete(
+                    ModuleResultStatus.FAILURE,
+                    "File selection was cancelled".toByteArray(),
+                )
+                return@launchForResult
+            }
+            val uris = buildList {
+                data.clipData?.let { clips ->
+                    repeat(minOf(clips.itemCount, limit)) { index ->
+                        add(clips.getItemAt(index).uri)
+                    }
+                }
+                if (isEmpty()) {
+                    data.data?.let(::add)
+                }
+            }.distinct().take(limit)
+            if (uris.isEmpty()) {
+                completion.complete(
+                    ModuleResultStatus.FAILURE,
+                    "No file was selected".toByteArray(),
+                )
+                return@launchForResult
+            }
+            executor.execute { importUris(uris, completion) }
+        }
+    }
+
     private fun capture(payload: ByteArray, completion: ModuleCompletion) {
         val type = WireMap.decode(payload).integer("type", 1)
         val isVideo = type == 2L
@@ -166,15 +214,52 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
 
     private fun importUri(uri: Uri, completion: ModuleCompletion) {
         runCatching {
-            var name = "document"
-            var mime = activity.contentResolver.getType(uri) ?: "application/octet-stream"
-            activity.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-                if (cursor.moveToFirst()) {
-                    val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                    if (index >= 0) name = cursor.getString(index)
-                }
+            val imported = importUri(uri)
+            completion.success(imported.file, imported.mime)
+        }.onFailure { completion.failure(it) }
+    }
+
+    private fun importUris(uris: List<Uri>, completion: ModuleCompletion) {
+        val imported = mutableListOf<ImportedFile>()
+        runCatching {
+            var total = 0L
+            uris.forEach { uri ->
+                val remaining = MAX_MULTI_IMPORT_BYTES - total
+                require(remaining > 0) { "Selected files exceed 256 MiB" }
+                val item = importUri(uri, minOf(MAX_IMPORT_BYTES, remaining))
+                imported += item
+                total += item.file.length()
             }
-            val file = uniqueImport(name)
+            val items = JSONArray()
+            imported.forEach { item ->
+                items.put(JSONObject().apply {
+                    put("path", item.file.relativeTo(root).path)
+                    put("name", item.file.name)
+                    put("mimeType", item.mime)
+                    put("size", item.file.length())
+                })
+            }
+            completion.complete(
+                ModuleResultStatus.SUCCESS,
+                WireMap.encode(mapOf("items" to WireValue.Text(items.toString()))),
+            )
+        }.onFailure { error ->
+            imported.forEach { it.file.delete() }
+            completion.failure(error)
+        }
+    }
+
+    private fun importUri(uri: Uri, maximumBytes: Long = MAX_IMPORT_BYTES): ImportedFile {
+        var name = "document"
+        val mime = activity.contentResolver.getType(uri) ?: "application/octet-stream"
+        activity.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index >= 0) name = cursor.getString(index)
+            }
+        }
+        val file = uniqueImport(name)
+        return try {
             activity.contentResolver.openInputStream(uri).use { input ->
                 requireNotNull(input) { "Unable to read selected file" }
                 file.outputStream().use { output ->
@@ -184,16 +269,22 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
                         val read = input.read(buffer)
                         if (read < 0) break
                         total += read
-                        require(total <= MAX_IMPORT_BYTES) {
-                            file.delete()
-                            "Selected file exceeds 64 MiB"
+                        require(total <= maximumBytes) {
+                            if (maximumBytes < MAX_IMPORT_BYTES) {
+                                "Selected files exceed 256 MiB"
+                            } else {
+                                "Selected file exceeds 64 MiB"
+                            }
                         }
                         output.write(buffer, 0, read)
                     }
                 }
             }
-            completion.success(file, mime)
-        }.onFailure { completion.failure(it) }
+            ImportedFile(file, mime)
+        } catch (error: Throwable) {
+            file.delete()
+            throw error
+        }
     }
 
     private fun resolve(path: String): File {
@@ -205,7 +296,7 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
 
     private fun uniqueImport(name: String): File {
         val safe = name.replace(Regex("[^A-Za-z0-9_.-]"), "_").take(128).ifEmpty { "file" }
-        return File(root, "imports/${System.currentTimeMillis()}-$safe").apply {
+        return File(root, "imports/${UUID.randomUUID()}-$safe").apply {
             parentFile?.mkdirs()
         }
     }
@@ -242,7 +333,12 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
     }
 
     private companion object {
+        const val DEFAULT_PICK_LIMIT = 10
+        const val MAX_PICK_LIMIT = 50
         const val MAX_READ_BYTES = 1024 * 1024L
         const val MAX_IMPORT_BYTES = 64L * 1024L * 1024L
+        const val MAX_MULTI_IMPORT_BYTES = 256L * 1024L * 1024L
     }
+
+    private data class ImportedFile(val file: File, val mime: String)
 }

--- a/android/pam-native.properties
+++ b/android/pam-native.properties
@@ -4,5 +4,5 @@ applicationName=Pam Native
 minSdk=26
 targetSdk=36
 versionCode=11
-versionName=0.5.14
+versionName=0.5.15
 abis=arm64-v8a,x86_64

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -47,6 +47,16 @@ Files::pick(MediaPickerType::Image, function ($file): void {
     $this->selectedPath = $file->path;
 });
 
+Files::pickMany(
+    MediaPickerType::Image,
+    function (array $files): void {
+        foreach ($files as $file) {
+            // Upload $file->path without moving bytes through PHP.
+        }
+    },
+    limit: 10,
+);
+
 MediaCapture::capture(CaptureType::Photo, function ($photo): void {
     $this->photoPath = $photo->path;
 });

--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -10,7 +10,7 @@ table, see the [capability cookbook](examples.md).
 | --- | --- |
 | Gestures | `UI\GestureDetector` |
 | Video and audio | `UI\MediaPlayer` |
-| Camera and gallery | `System\MediaCapture`, `System\Files::pick()` |
+| Camera and gallery | `System\MediaCapture`, `System\Files::pick()`, `System\Files::pickMany()` |
 | Gesture navigation | `Navigation\Navigator`, `NavigationHost` |
 | Bottom Sheet | `UI\BottomSheet` |
 | Declarative animations | `UI\Animated` |
@@ -33,7 +33,12 @@ with controls, autoplay, looping, mute, volume, seek, rate and progress events.
 ## Files, camera and gallery
 
 `Files::pick()` imports an image, video, audio file or document into the
-application sandbox and returns a `FileReference`. `MediaCapture::capture()`
+application sandbox and returns a `FileReference`. `Files::pickMany()` uses the
+native multi-selection picker, preserves selection order, imports off the UI
+thread, and returns up to 50 typed `FileReference` values in one bridge result.
+If any import fails, files already copied by that selection are removed.
+Each file is bounded to 64 MiB and a multi-selection is bounded to 256 MiB.
+`MediaCapture::capture()`
 captures a full-resolution photo or video. `Files::read()` and `Files::write()`
 only accept sandbox-relative paths and bridge at most one MiB per call; imports
 are bounded to 64 MiB. `Files::stat()` returns typed metadata,

--- a/ios/Sources/PamNative/Modules/FilesModule.swift
+++ b/ios/Sources/PamNative/Modules/FilesModule.swift
@@ -7,6 +7,8 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
     private let queue = DispatchQueue(label: "dev.pam.native.files")
     private let root: URL
     private var pending: ModuleCompletion?
+    private var pendingMultiple = false
+    private var pendingLimit = 10
     private var captureType = 1
 
     override init() {
@@ -32,7 +34,12 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
             case "pick":
                 let values = try WireMap.decode(payload)
                 let type = values["type"]?.integerValue ?? 4
-                presentPicker(type: Int(type), completion: completion)
+                presentPicker(type: Int(type), multiple: false, limit: 1, completion: completion)
+            case "pickMany":
+                let values = try WireMap.decode(payload)
+                let type = values["type"]?.integerValue ?? 4
+                let limit = min(50, max(1, Int(values["limit"]?.integerValue ?? 10)))
+                presentPicker(type: Int(type), multiple: true, limit: limit, completion: completion)
             case "capture":
                 let values = try WireMap.decode(payload)
                 presentCapture(type: Int(values["type"]?.integerValue ?? 1), completion: completion)
@@ -126,7 +133,12 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
         } catch { completion(.failure, Data(error.localizedDescription.utf8)) }
     }
 
-    private func presentPicker(type: Int, completion: @escaping ModuleCompletion) {
+    private func presentPicker(
+        type: Int,
+        multiple: Bool,
+        limit: Int,
+        completion: @escaping ModuleCompletion
+    ) {
         DispatchQueue.main.async {
             guard self.pending == nil, let presenter = Self.presenter() else {
                 completion(.failure, Data("Another picker is active".utf8))
@@ -139,9 +151,11 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
             default: [.item]
             }
             self.pending = completion
+            self.pendingMultiple = multiple
+            self.pendingLimit = limit
             let picker = UIDocumentPickerViewController(forOpeningContentTypes: types)
             picker.delegate = self
-            picker.allowsMultipleSelection = false
+            picker.allowsMultipleSelection = multiple
             presenter.present(picker, animated: true)
         }
     }
@@ -168,8 +182,16 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
         _ controller: UIDocumentPickerViewController,
         didPickDocumentsAt urls: [URL]
     ) {
-        guard let source = urls.first else { return finishFailure("No document was selected") }
-        queue.async { self.importFile(source, completion: self.takePending()) }
+        guard !urls.isEmpty else { return finishFailure("No document was selected") }
+        let multiple = pendingMultiple
+        let selected = Array(urls.prefix(pendingLimit))
+        queue.async {
+            if multiple {
+                self.importFiles(selected, completion: self.takePending())
+            } else if let source = selected.first {
+                self.importFile(source, completion: self.takePending())
+            }
+        }
     }
 
     func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
@@ -222,6 +244,90 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
         } catch { completion(.failure, Data(error.localizedDescription.utf8)) }
     }
 
+    private func importFiles(_ sources: [URL], completion: ModuleCompletion?) {
+        guard let completion else { return }
+        var imported: [URL] = []
+        var totalBytes = 0
+        do {
+            let items = try sources.map { source -> [String: Any] in
+                let remaining = 256 * 1_024 * 1_024 - totalBytes
+                guard remaining > 0 else {
+                    throw FileModuleError("Selected files exceed 256 MiB")
+                }
+                let item = try importFileReference(
+                    source,
+                    maximumBytes: min(64 * 1_024 * 1_024, remaining)
+                )
+                imported.append(item.url)
+                totalBytes += item.size
+                return item.reference
+            }
+            let data = try JSONSerialization.data(withJSONObject: items)
+            completion(.success, try WireMap.encode([
+                "items": .text(String(decoding: data, as: UTF8.self)),
+            ]))
+        } catch {
+            imported.forEach { try? FileManager.default.removeItem(at: $0) }
+            completion(.failure, Data(error.localizedDescription.utf8))
+        }
+    }
+
+    private func importFileReference(
+        _ source: URL,
+        maximumBytes: Int
+    ) throws -> (url: URL, reference: [String: Any], size: Int) {
+        let accessing = source.startAccessingSecurityScopedResource()
+        defer { if accessing { source.stopAccessingSecurityScopedResource() } }
+        let values = try source.resourceValues(forKeys: [.fileSizeKey])
+        if let size = values.fileSize, size > maximumBytes {
+            throw FileModuleError(
+                maximumBytes < 64 * 1_024 * 1_024
+                    ? "Selected files exceed 256 MiB"
+                    : "Selected file exceeds 64 MiB"
+            )
+        }
+        let safe = source.lastPathComponent.replacingOccurrences(
+            of: "[^A-Za-z0-9_.-]",
+            with: "_",
+            options: .regularExpression
+        )
+        let relative = "imports/\(UUID().uuidString)-\(safe)"
+        let destination = try resolve(relative)
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        do {
+            try FileManager.default.copyItem(at: source, to: destination)
+        } catch {
+            try? FileManager.default.removeItem(at: destination)
+            throw error
+        }
+        let importedValues = try destination.resourceValues(forKeys: [.fileSizeKey])
+        let importedSize = importedValues.fileSize ?? 0
+        guard importedSize <= maximumBytes else {
+            try? FileManager.default.removeItem(at: destination)
+            throw FileModuleError(
+                maximumBytes < 64 * 1_024 * 1_024
+                    ? "Selected files exceed 256 MiB"
+                    : "Selected file exceeds 64 MiB"
+            )
+        }
+        let mime = UTType(filenameExtension: source.pathExtension)?.preferredMIMEType
+            ?? "application/octet-stream"
+
+        return (
+            destination,
+            [
+                "path": relative,
+                "name": destination.lastPathComponent,
+                "mimeType": mime,
+                "size": importedSize,
+            ],
+            importedSize
+        )
+    }
+
     private func store(
         _ data: Data,
         name: String,
@@ -238,7 +344,7 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
                 with: "_",
                 options: .regularExpression
             )
-            let relative = "imports/\(Int(Date().timeIntervalSince1970 * 1000))-\(safe)"
+            let relative = "imports/\(UUID().uuidString)-\(safe)"
             let destination = try resolve(relative)
             try FileManager.default.createDirectory(
                 at: destination.deletingLastPathComponent(),
@@ -290,7 +396,11 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
     }
 
     private func takePending() -> ModuleCompletion? {
-        defer { pending = nil }
+        defer {
+            pending = nil
+            pendingMultiple = false
+            pendingLimit = 10
+        }
         return pending
     }
 

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.5.14';
+    public const string SDK_VERSION = '0.5.15';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/System/Files.php
+++ b/packages/native/src/System/Files.php
@@ -10,6 +10,7 @@ use Pam\Native\Internal\Wire;
 use Pam\Native\MediaPickerType;
 use Pam\Native\ModuleResultStatus;
 use Pam\Native\Modules\NativeModules;
+use JsonException;
 use RuntimeException;
 
 final class Files
@@ -82,6 +83,49 @@ final class Files
             'pick',
             ['type' => $type->value],
             static fn (array $values): mixed => $callback(self::reference($values)),
+        );
+    }
+
+    /**
+     * @param Closure(list<FileReference>): void $callback
+     */
+    public static function pickMany(
+        MediaPickerType $type,
+        Closure $callback,
+        int $limit = 10,
+    ): int {
+        return self::invoke(
+            'pickMany',
+            [
+                'limit' => max(1, min(50, $limit)),
+                'type' => $type->value,
+            ],
+            static function (array $values) use ($callback): mixed {
+                try {
+                    $items = json_decode(
+                        (string) ($values['items'] ?? '[]'),
+                        true,
+                        flags: JSON_THROW_ON_ERROR,
+                    );
+                } catch (JsonException $error) {
+                    throw new RuntimeException(
+                        'Native multi-file payload is invalid.',
+                        previous: $error,
+                    );
+                }
+                if (!is_array($items)) {
+                    throw new RuntimeException('Native multi-file payload is invalid.');
+                }
+                $references = [];
+                foreach ($items as $item) {
+                    if (is_array($item)) {
+                        $references[] = self::reference($item);
+                    }
+                }
+                $callback($references);
+
+                return null;
+            },
         );
     }
 

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -17,6 +17,7 @@ use Pam\Native\AsyncValue;
 use Pam\Native\Component;
 use Pam\Native\Contact;
 use Pam\Native\EventKind;
+use Pam\Native\FileReference;
 use Pam\Native\FontStyle;
 use Pam\Native\GestureComposition;
 use Pam\Native\GestureDirection;
@@ -24,6 +25,7 @@ use Pam\Native\GestureEvent;
 use Pam\Native\GestureState;
 use Pam\Native\GestureType;
 use Pam\Native\MediaType;
+use Pam\Native\MediaPickerType;
 use Pam\Native\MediaCachePolicy;
 use Pam\Native\MediaPriority;
 use Pam\Native\NativeMenuItem;
@@ -106,6 +108,7 @@ use Pam\Native\System\Clipboard;
 use Pam\Native\System\Contacts;
 use Pam\Native\System\Sensors;
 use Pam\Native\System\Location;
+use Pam\Native\System\Files;
 use Pam\Native\LocationPosition;
 use Pam\Native\System\AudioRecorder;
 use Pam\Native\Storage\Storage;
@@ -1770,6 +1773,55 @@ $assert(
     'Audio recorder facade did not decode the native recording.',
 );
 
+$pickedFiles = [];
+$pickManyRequest = Files::pickMany(
+    MediaPickerType::Image,
+    static function (array $files) use (&$pickedFiles): void {
+        $pickedFiles = $files;
+    },
+    6,
+);
+$pickManyCall = TestDiagnostics::$moduleCall;
+$pickManyPayload = $pickManyCall === null
+    ? []
+    : Wire::decodeMap($pickManyCall['payload']);
+$assert(
+    $pickManyCall !== null
+        && $pickManyCall['requestId'] === $pickManyRequest
+        && $pickManyCall['module'] === 'files'
+        && $pickManyCall['method'] === 'pickMany'
+        && $pickManyPayload === ['limit' => 6, 'type' => MediaPickerType::Image->value],
+    'Files pickMany must emit a bounded typed native module call.',
+);
+Runtime::dispatchModuleResult(
+    $pickManyRequest,
+    ModuleResultStatus::Success->value,
+    Wire::map([
+        'items' => json_encode([
+            [
+                'path' => 'imports/photo-one.jpg',
+                'name' => 'photo-one.jpg',
+                'mimeType' => 'image/jpeg',
+                'size' => 1_024,
+            ],
+            [
+                'path' => 'imports/photo-two.webp',
+                'name' => 'photo-two.webp',
+                'mimeType' => 'image/webp',
+                'size' => 2_048,
+            ],
+        ], JSON_THROW_ON_ERROR),
+    ]),
+);
+$assert(
+    count($pickedFiles) === 2
+        && $pickedFiles[0] instanceof FileReference
+        && $pickedFiles[0]->path === 'imports/photo-one.jpg'
+        && $pickedFiles[1]->mimeType === 'image/webp'
+        && $pickedFiles[1]->size === 2_048,
+    'Files pickMany must decode every native file reference in selection order.',
+);
+
 $missingStoredValue = 'not-dispatched';
 $storageRequest = Storage::get(
     'chat.draft.missing',
@@ -2838,8 +2890,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.5.14',
-    'The runtime SDK contract must match the 0.5.14 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.5.15',
+    'The runtime SDK contract must match the 0.5.15 package release.',
 );
 
 $bottomSheet = BottomSheet::make(


### PR DESCRIPTION
## Summary
- add typed `Files::pickMany()` with a bounded limit
- implement ordered Android/iOS native multi-selection imports off the UI thread
- cap each file at 64 MiB and each selection at 256 MiB
- clean imported files transactionally when any item fails
- use collision-proof sandbox paths and document the API

## Validation
- `php packages/native/tests/run.php`
- `cargo test --workspace`
- `./android/gradlew -p android :app:compileDebugKotlin`