### PR TITLE
fix: surface errors before runtime boot

### DIFF
--- a/packages/native/src/App.php
+++ b/packages/native/src/App.php
@@ -9,6 +9,7 @@ use Pam\Native\Internal\PamPhpRegistry;
 use Pam\Native\Internal\Runtime;
 use Pam\Native\Plugin\PluginManager;
 use Pam\Native\Navigation\TabNavigator;
+use Throwable;
 
 final class App
 {
@@ -18,11 +19,17 @@ final class App
 
     public static function run(Renderable|Closure $root): void
     {
-        PluginManager::boot();
-        if ($root instanceof TabNavigator) {
-            Runtime::onDimensions($root->dimensions(...));
+        try {
+            PluginManager::boot();
+            if ($root instanceof TabNavigator) {
+                Runtime::onDimensions($root->dimensions(...));
+            }
+            Runtime::boot($root);
+        } catch (Throwable $error) {
+            Runtime::reportError($error);
+
+            throw $error;
         }
-        Runtime::boot($root);
     }
 
     public static function views(string $path, ?string $cachePath = null): void
@@ -34,10 +41,16 @@ final class App
         string $path,
         ?string $cachePath = null,
     ): void {
-        PamPhpRegistry::discover(
-            $path,
-            $cachePath ?? getcwd().'/.pam/components',
-        );
+        try {
+            PamPhpRegistry::discover(
+                $path,
+                $cachePath ?? getcwd().'/.pam/components',
+            );
+        } catch (Throwable $error) {
+            Runtime::reportError($error);
+
+            throw $error;
+        }
     }
 
     /** @param array<string, mixed> $props */

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2542,6 +2542,54 @@ final class Dashboard extends Component
 PAM,
 );
 
+$invalidPamPhpDirectory = $pamPhpDirectory.'-invalid';
+if (
+    !is_dir($invalidPamPhpDirectory)
+    && !mkdir($invalidPamPhpDirectory, 0o755, true)
+    && !is_dir($invalidPamPhpDirectory)
+) {
+    throw new RuntimeException('Cannot create the invalid component fixture directory.');
+}
+file_put_contents(
+    $invalidPamPhpDirectory.'/Invalid.pam.php',
+    <<<'PAM'
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Tests\Sfc;
+
+use Pam\Native\Component;
+
+final class Invalid extends Component
+{
+}
+?>
+
+<template>
+    <Text invalid="unterminated></Text>
+</template>
+PAM,
+);
+TestDiagnostics::$messages = [];
+$prebootError = null;
+try {
+    App::components($invalidPamPhpDirectory, $invalidPamPhpDirectory.'/.cache');
+} catch (RuntimeException $error) {
+    $prebootError = $error;
+}
+$assert(
+    $prebootError instanceof RuntimeException
+        && isset(TestDiagnostics::$messages[0])
+        && str_starts_with(TestDiagnostics::$messages[0], "PAMERR1\n")
+        && str_contains(TestDiagnostics::$messages[0], 'Invalid attributes'),
+    'Component compilation errors before runtime boot must emit structured diagnostics.',
+);
+unlink($invalidPamPhpDirectory.'/Invalid.pam.php');
+rmdir($invalidPamPhpDirectory.'/.cache');
+rmdir($invalidPamPhpDirectory);
+TestDiagnostics::$messages = [];
+
 $assert(
     \Pam\Native\Internal\TemplateExpression::evaluate(
         '$left && $right',


### PR DESCRIPTION
## Summary
- report plugin boot and component discovery failures through the structured PAM error channel
- preserve exception propagation after the Android/iOS overlay receives diagnostics
- cover invalid `.pam.php` compilation before `Runtime::boot()`

## Validation
- `php packages/native/tests/run.php`
- `php packages/native/tests/performance.php`
- `php packages/native/tests/fuzz.php`
- `composer validate --strict --no-check-lock packages/native/composer.json`
- `git diff --check`