### PR TITLE
feat: render sandbox files as images

### DIFF
--- a/android/app/src/main/java/dev/pam/nativeapp/render/NativeImageLoader.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/NativeImageLoader.kt
@@ -87,6 +87,25 @@ internal class NativeImageCallbacks(
     val onCacheReady: (String, Long) -> Unit = { _, _ -> },
 )
 
+internal fun resolvePamImageFile(root: File, source: String): File {
+    val uri = URI(source)
+    require(uri.scheme.equals("pam-file", ignoreCase = true)) {
+        "Invalid sandbox image URI."
+    }
+    require(uri.authority.isNullOrEmpty()) {
+        "Sandbox image URI cannot contain an authority."
+    }
+    val sandbox = root.canonicalFile
+    val relative = uri.path.orEmpty().removePrefix("/")
+    require(relative.isNotEmpty()) { "Sandbox image path is empty." }
+    val candidate = File(sandbox, relative).canonicalFile
+    require(candidate.path.startsWith(sandbox.path + File.separator)) {
+        "Sandbox image path escapes the application sandbox."
+    }
+    require(candidate.isFile) { "Sandbox image does not exist." }
+    return candidate
+}
+
 internal class NativeImageLoader(
     private val context: Context,
 ) : AutoCloseable {
@@ -465,6 +484,11 @@ internal class NativeImageLoader(
                     android.net.Uri.parse(source),
                 )?.use(::readBounded)
                     ?: error("Image source cannot be opened.")
+            "pam-file" ->
+                resolvePamImageFile(
+                    File(context.filesDir, "pam-files"),
+                    source,
+                ).inputStream().use(::readBounded)
             "asset" -> context.assets.open(
                 uri.schemeSpecificPart.removePrefix("//").removePrefix("/"),
             ).use(::readBounded)

--- a/android/app/src/test/java/dev/pam/nativeapp/render/PamImageFileTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/render/PamImageFileTest.kt
@@ -1,0 +1,38 @@
+package dev.pam.nativeapp.render
+
+import java.nio.file.Files
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class PamImageFileTest {
+    @Test
+    fun resolvesAnExistingSandboxFile() {
+        val root = Files.createTempDirectory("pam-image-root")
+        val image = root.resolve("imports/photo one.jpg")
+        image.parent.createDirectories()
+        image.createFile()
+
+        assertEquals(
+            image.toFile().canonicalFile,
+            resolvePamImageFile(root.toFile(), "pam-file:///imports/photo%20one.jpg"),
+        )
+    }
+
+    @Test
+    fun rejectsAuthorityTraversalAndMissingFiles() {
+        val root = Files.createTempDirectory("pam-image-root").toFile()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            resolvePamImageFile(root, "pam-file://host/photo.jpg")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            resolvePamImageFile(root, "pam-file:///../photo.jpg")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            resolvePamImageFile(root, "pam-file:///missing.jpg")
+        }
+    }
+}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -45,6 +45,7 @@ Files::write('drafts/message.txt', 'Hello', function (): void {
 
 Files::pick(MediaPickerType::Image, function ($file): void {
     $this->selectedPath = $file->path;
+    $this->selectedImageSource = $file->uri();
 });
 
 Files::pickMany(

--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -36,6 +36,10 @@ with controls, autoplay, looping, mute, volume, seek, rate and progress events.
 application sandbox and returns a `FileReference`. `Files::pickMany()` uses the
 native multi-selection picker, preserves selection order, imports off the UI
 thread, and returns up to 50 typed `FileReference` values in one bridge result.
+`FileReference::uri()` returns a sandboxed `pam-file:///...` source that can be
+passed directly to `Image` and rendered immediately without copying bytes
+through PHP or exposing an absolute device path. Image reads and decoding stay
+off the UI thread, and both renderers reject authority and path traversal.
 If any import fails, files already copied by that selection are removed.
 Each file is bounded to 64 MiB and a multi-selection is bounded to 256 MiB.
 `MediaCapture::capture()`

--- a/ios/Sources/PamNative/Render/PamRenderer.swift
+++ b/ios/Sources/PamNative/Render/PamRenderer.swift
@@ -2250,10 +2250,39 @@ public final class PamRenderer {
         if source.hasPrefix("asset://") {
             return UIImage(named: String(source.dropFirst("asset://".count)))
         }
+        if let url = sandboxFileURL(source) {
+            return UIImage(contentsOfFile: url.path)
+        }
         if source.hasPrefix("file://"), let url = URL(string: source) {
             return UIImage(contentsOfFile: url.path)
         }
         return UIImage(named: source)
+    }
+
+    private func sandboxFileURL(_ source: String) -> URL? {
+        guard let uri = URLComponents(string: source),
+              uri.scheme?.lowercased() == "pam-file",
+              uri.host == nil || uri.host?.isEmpty == true,
+              !uri.path.isEmpty else {
+            return nil
+        }
+        let base = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+            .appendingPathComponent("pam-files", isDirectory: true)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let relative = String(uri.path.drop(while: { $0 == "/" }))
+        let candidate = base
+            .appendingPathComponent(relative)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        guard candidate.path.hasPrefix(base.path + "/"),
+              FileManager.default.fileExists(atPath: candidate.path) else {
+            return nil
+        }
+        return candidate
     }
 
     private func loadImagePlaceholder(

--- a/packages/native/src/FileReference.php
+++ b/packages/native/src/FileReference.php
@@ -13,4 +13,19 @@ final readonly class FileReference
         public int $size,
     ) {
     }
+
+    /**
+     * Returns an opaque renderer source for the file inside the application sandbox.
+     *
+     * The native renderer resolves this URI without exposing an absolute device path.
+     */
+    public function uri(): string
+    {
+        $segments = array_map(
+            static fn (string $segment): string => rawurlencode($segment),
+            explode('/', str_replace('\\', '/', ltrim($this->path, '/'))),
+        );
+
+        return 'pam-file:///' . implode('/', $segments);
+    }
 }

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1817,6 +1817,7 @@ $assert(
     count($pickedFiles) === 2
         && $pickedFiles[0] instanceof FileReference
         && $pickedFiles[0]->path === 'imports/photo-one.jpg'
+        && $pickedFiles[0]->uri() === 'pam-file:///imports/photo-one.jpg'
         && $pickedFiles[1]->mimeType === 'image/webp'
         && $pickedFiles[1]->size === 2_048,
     'Files pickMany must decode every native file reference in selection order.',


### PR DESCRIPTION
## Summary
- expose safe `pam-file:///` renderer URIs from `FileReference`
- resolve sandbox images on Android and iOS without absolute device paths
- reject authorities, traversal, missing files, and keep Android I/O off the UI thread
- document immediate picked-image rendering and cover PHP/Android behavior

## Validation
- `php packages/native/tests/run.php`
- `composer validate --strict` in `packages/native`
- `./gradlew :app:testDebugUnitTest :app:lintDebug`
- iOS compilation delegated to the repository CI because Swift is unavailable on this Linux host