### PR TITLE
fix: return HTTP transport failures to callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Deliver HTTP transport failures as status-zero `HttpResponse` values with a
+  typed error instead of throwing across the component runtime.
+
 ## 0.5.15 - 2026-07-29
 
 - Add typed `Files::pickMany()` on Android and iOS with native multi-selection,

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -220,6 +220,10 @@ Http::json(
     url: 'https://api.example.com/login',
     data: ['email' => $email, 'password' => $password],
     callback: function (HttpResponse $response): void {
+        if ($response->transportFailed()) {
+            // Status 0; inspect $response->error and keep offline work queued.
+            return;
+        }
         // Read $response->statusCode, $response->body and $response->successful().
     },
 );
@@ -238,7 +242,8 @@ Http::request(
 
 Production builds require HTTPS. Requests support GET, POST, PUT, PATCH and
 DELETE, up to 32 bounded single-line headers, a one MiB request body and timeout
-values from one to 120 seconds.
+values from one to 120 seconds. DNS, connectivity and timeout failures reach the
+same callback with status `0`; they never crash the component runtime.
 
 ## License
 

--- a/packages/native/src/Http/Http.php
+++ b/packages/native/src/Http/Http.php
@@ -169,13 +169,20 @@ final class Http
     {
         return static function (ModuleResultStatus $status, string $payload) use ($callback): void {
             if ($status === ModuleResultStatus::Failure) {
-                throw new RuntimeException($payload);
+                $callback(new HttpResponse(
+                    statusCode: 0,
+                    body: '',
+                    error: $payload,
+                ));
+
+                return;
             }
 
             $values = Wire::decodeMap($payload);
             $callback(new HttpResponse(
                 statusCode: (int) ($values['statusCode'] ?? 0),
                 body: (string) ($values['body'] ?? ''),
+                error: '',
             ));
         };
     }

--- a/packages/native/src/Http/HttpResponse.php
+++ b/packages/native/src/Http/HttpResponse.php
@@ -9,6 +9,7 @@ final readonly class HttpResponse
     public function __construct(
         public int $statusCode,
         public string $body,
+        public string $error = '',
     ) {
     }
 
@@ -16,5 +17,9 @@ final readonly class HttpResponse
     {
         return $this->statusCode >= 200 && $this->statusCode < 300;
     }
-}
 
+    public function transportFailed(): bool
+    {
+        return $this->statusCode === 0 && $this->error !== '';
+    }
+}

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1995,6 +1995,28 @@ $assert(
     'Generic HTTP request did not decode its response.',
 );
 
+$transportFailure = null;
+$transportFailureId = Http::get(
+    'https://offline.example.test',
+    static function (HttpResponse $response) use (&$transportFailure): void {
+        $transportFailure = $response;
+    },
+);
+Runtime::dispatchModuleResult(
+    $transportFailureId,
+    \Pam\Native\ModuleResultStatus::Failure->value,
+    'Unable to resolve host.',
+);
+$assert(
+    $transportFailure instanceof HttpResponse
+        && $transportFailure->statusCode === 0
+        && $transportFailure->body === ''
+        && $transportFailure->error === 'Unable to resolve host.'
+        && $transportFailure->transportFailed()
+        && !$transportFailure->successful(),
+    'HTTP transport failures must reach the callback without crashing the runtime.',
+);
+
 foreach (['post' => 'POST', 'put' => 'PUT', 'patch' => 'PATCH', 'delete' => 'DELETE'] as $helper => $method) {
     Http::{$helper}(
         'https://api.example.test/resource',


### PR DESCRIPTION
## Summary
- represent DNS/connectivity/timeout failures as status-zero HttpResponse values
- preserve exceptions for invalid request programming errors
- expose transportFailed() and a typed error string
- document offline queue usage and add regression coverage

## Validation
- php packages/native/tests/run.php