### PR TITLE
Persist audio recordings for durable outboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.19 - 2026-07-29
+
+- Persist completed audio recordings inside `pam-files/recordings` on Android
+  and iOS so voice-message outboxes survive process death and device restarts.
+- Expose the upload-ready sandbox `relativePath` while preserving the recording
+  URI for playback and guarded deletion.
+
 ## 0.5.18 - 2026-07-29
 
 - Deliver HTTP transport failures as status-zero `HttpResponse` values with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.18"
+version = "0.5.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.18"
+version = "0.5.19"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/README.md
+++ b/README.md
@@ -365,9 +365,10 @@ Permissions::requestKind(PermissionKind::LocationWhenInUse, function ($decision)
 Native work completes away from PHP rendering and returns typed coordinates,
 accuracy, altitude, speed, bearing and capture timestamp.
 
-Voice capture is also asynchronous and writes an AAC/M4A file in the
-application cache. Request microphone permission first, then stop returns a
-typed file reference with its real duration and byte size:
+Voice capture is also asynchronous and writes an AAC/M4A file in the durable
+`pam-files/recordings` sandbox. Request microphone permission first, then stop
+returns both a renderable URI and an upload-ready relative path with its real
+duration and byte size:
 
 ```php
 use Pam\Native\PermissionKind;
@@ -381,7 +382,7 @@ Permissions::requestKind(PermissionKind::Microphone, function ($decision): void 
 });
 
 AudioRecorder::stop(function ($recording): void {
-    upload($recording->uri, $recording->mimeType);
+    upload($recording->relativePath, $recording->mimeType);
     AudioRecorder::discard($recording->uri, static function (): void {});
 });
 ```

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/AudioRecorderModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/AudioRecorderModule.kt
@@ -40,7 +40,8 @@ internal class AudioRecorderModule(private val context: Context) : NativeModule,
                 PackageManager.PERMISSION_GRANTED,
         ) { "Microphone permission is required" }
 
-        val file = File.createTempFile("pam-voice-", ".m4a", context.cacheDir)
+        val recordings = File(context.filesDir, "pam-files/recordings").apply { mkdirs() }
+        val file = File.createTempFile("pam-voice-", ".m4a", recordings)
         val next = MediaRecorder().apply {
             setAudioSource(MediaRecorder.AudioSource.MIC)
             setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
@@ -77,6 +78,7 @@ internal class AudioRecorderModule(private val context: Context) : NativeModule,
             WireMap.encode(
                 mapOf(
                     "uri" to WireValue.Text(file.toURI().toString()),
+                    "relativePath" to WireValue.Text("recordings/${file.name}"),
                     "fileName" to WireValue.Text(file.name),
                     "mimeType" to WireValue.Text("audio/mp4"),
                     "durationMs" to WireValue.Integer(durationMs),
@@ -95,8 +97,9 @@ internal class AudioRecorderModule(private val context: Context) : NativeModule,
         val uri = (WireMap.decode(payload)["uri"] as? WireValue.Text)?.value
             ?: error("Audio recording URI is required")
         val file = File(URI(uri)).canonicalFile
-        require(file.parentFile == context.cacheDir.canonicalFile && file.name.startsWith("pam-voice-")) {
-            "Audio recording URI is outside the recorder cache"
+        val recordings = File(context.filesDir, "pam-files/recordings").canonicalFile
+        require(file.parentFile == recordings && file.name.startsWith("pam-voice-")) {
+            "Audio recording URI is outside the recorder sandbox"
         }
         if (file.exists()) require(file.delete()) { "Unable to delete audio recording" }
         completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))

--- a/android/pam-native.properties
+++ b/android/pam-native.properties
@@ -4,5 +4,5 @@ applicationName=Pam Native
 minSdk=26
 targetSdk=36
 versionCode=11
-versionName=0.5.18
+versionName=0.5.19
 abis=arm64-v8a,x86_64

--- a/ios/Sources/PamNative/Modules/AudioRecorderModule.swift
+++ b/ios/Sources/PamNative/Modules/AudioRecorderModule.swift
@@ -38,8 +38,8 @@ final class AudioRecorderModule: NSObject, NativeModule, ClosableNativeModule, A
         }
         try session.setCategory(.playAndRecord, mode: .spokenAudio, options: [.defaultToSpeaker])
         try session.setActive(true)
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("pam-voice-\(UUID().uuidString).m4a")
+        let recordings = try recordingsDirectory()
+        let url = recordings.appendingPathComponent("pam-voice-\(UUID().uuidString).m4a")
         let next = try AVAudioRecorder(
             url: url,
             settings: [
@@ -72,6 +72,7 @@ final class AudioRecorderModule: NSObject, NativeModule, ClosableNativeModule, A
         let size = (attributes[.size] as? NSNumber)?.int64Value ?? 0
         return try WireMap.encode([
             "uri": .text(url.absoluteString),
+            "relativePath": .text("recordings/\(url.lastPathComponent)"),
             "fileName": .text(url.lastPathComponent),
             "mimeType": .text("audio/mp4"),
             "durationMs": .integer(durationMs),
@@ -95,16 +96,33 @@ final class AudioRecorderModule: NSObject, NativeModule, ClosableNativeModule, A
               let url = URL(string: uri) else {
             throw AudioRecorderError.message("Audio recording URI is required")
         }
-        let temporary = FileManager.default.temporaryDirectory.standardizedFileURL
+        let recordings = try recordingsDirectory().standardizedFileURL
         let file = url.standardizedFileURL
-        guard file.deletingLastPathComponent() == temporary,
+        guard file.deletingLastPathComponent() == recordings,
               file.lastPathComponent.hasPrefix("pam-voice-") else {
-            throw AudioRecorderError.message("Audio recording URI is outside the recorder cache")
+            throw AudioRecorderError.message("Audio recording URI is outside the recorder sandbox")
         }
         if FileManager.default.fileExists(atPath: file.path) {
             try FileManager.default.removeItem(at: file)
         }
         return Data()
+    }
+
+    private func recordingsDirectory() throws -> URL {
+        let support = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let recordings = support
+            .appendingPathComponent("pam-files", isDirectory: true)
+            .appendingPathComponent("recordings", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: recordings,
+            withIntermediateDirectories: true
+        )
+        return recordings
     }
 
     func close() {

--- a/packages/native/src/AudioRecording.php
+++ b/packages/native/src/AudioRecording.php
@@ -12,6 +12,7 @@ final readonly class AudioRecording
         public string $mimeType,
         public int $durationMs,
         public int $size,
+        public string $relativePath = '',
     ) {
     }
 }

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.5.18';
+    public const string SDK_VERSION = '0.5.19';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/System/AudioRecorder.php
+++ b/packages/native/src/System/AudioRecorder.php
@@ -51,6 +51,7 @@ final class AudioRecorder
                     mimeType: (string) ($values['mimeType'] ?? 'audio/mp4'),
                     durationMs: max(0, (int) ($values['durationMs'] ?? 0)),
                     size: max(0, (int) ($values['size'] ?? 0)),
+                    relativePath: (string) ($values['relativePath'] ?? ''),
                 ));
             },
         );

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1759,6 +1759,7 @@ Runtime::dispatchModuleResult(
     ModuleResultStatus::Success->value,
     Wire::map([
         'uri' => 'file:///tmp/pam-voice-test.m4a',
+        'relativePath' => 'recordings/pam-voice-test.m4a',
         'fileName' => 'pam-voice-test.m4a',
         'mimeType' => 'audio/mp4',
         'durationMs' => 2_400,
@@ -1769,6 +1770,7 @@ $assert(
     $recording instanceof AudioRecording
         && $recording->durationMs === 2_400
         && $recording->size === 19_200
+        && $recording->relativePath === 'recordings/pam-voice-test.m4a'
         && $recording->mimeType === 'audio/mp4',
     'Audio recorder facade did not decode the native recording.',
 );
@@ -2961,8 +2963,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.5.18',
-    'The runtime SDK contract must match the 0.5.18 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.5.19',
+    'The runtime SDK contract must match the 0.5.19 package release.',
 );
 
 $bottomSheet = BottomSheet::make(


### PR DESCRIPTION
## Summary
- store completed Android and iOS recordings in the durable pam-files sandbox
- expose an upload-ready relativePath while preserving URI compatibility
- guard deletion inside the recordings sandbox
- bump the core contract to 0.5.19

## Validation
- PHP SDK tests
- Android debug unit tests
- git diff --check