### PR TITLE
feat(templates): add collection expression helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.25 - 2026-07-29
+
+- Add guarded `count()` and strict-capable `in_array()` collection helpers to
+  declarative template expressions, enabling efficient derived list state
+  without duplicating membership flags into every rendered item.
+
 ## 0.5.24 - 2026-07-29
 
 - Keep the resolved Android sandbox file URI after the media-cache pass instead

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.24"
+version = "0.5.25"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.24"
+version = "0.5.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.24"
+version = "0.5.25"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/packages/native/src/Internal/TemplateExpression.php
+++ b/packages/native/src/Internal/TemplateExpression.php
@@ -348,6 +348,31 @@ final class TemplateExpression
     /** @param list<mixed> $arguments */
     private function invoke(string $name, array $arguments): mixed
     {
+        $builtIn = strtolower($name);
+        if ($builtIn === 'count') {
+            if (count($arguments) !== 1 || (!is_array($arguments[0]) && !$arguments[0] instanceof \Countable)) {
+                throw new RuntimeException('Template count() expects exactly one countable value.');
+            }
+
+            return count($arguments[0]);
+        }
+        if ($builtIn === 'in_array') {
+            if (
+                (count($arguments) !== 2 && count($arguments) !== 3)
+                || !is_array($arguments[1])
+                || (isset($arguments[2]) && !is_bool($arguments[2]))
+            ) {
+                throw new RuntimeException(
+                    'Template in_array() expects a needle, an array, and an optional strict boolean.',
+                );
+            }
+
+            return in_array(
+                $arguments[0],
+                $arguments[1],
+                $arguments[2] ?? false,
+            );
+        }
         if ($this->scope === null || !method_exists($this->scope, $name)) {
             throw new RuntimeException("Template method {$name} does not exist.");
         }

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.5.24';
+    public const string SDK_VERSION = '0.5.25';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2670,6 +2670,25 @@ $assert(
     ) === true,
     'Template logical OR must consume its right operand when the left operand is true.',
 );
+$assert(
+    \Pam\Native\Internal\TemplateExpression::evaluate(
+        'count($selected)',
+        null,
+        ['selected' => ['message-1', 'message-2']],
+    ) === 2,
+    'Template expressions must expose the safe count() collection helper.',
+);
+$assert(
+    \Pam\Native\Internal\TemplateExpression::evaluate(
+        'in_array($messageId, $selected, true)',
+        null,
+        [
+            'messageId' => 'message-2',
+            'selected' => ['message-1', 'message-2'],
+        ],
+    ) === true,
+    'Template expressions must expose strict in_array() membership checks.',
+);
 
 TemplateRegistry::reset();
 App::components($pamPhpDirectory, $pamPhpCache);
@@ -3002,8 +3021,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.5.24',
-    'The runtime SDK contract must match the 0.5.24 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.5.25',
+    'The runtime SDK contract must match the 0.5.25 package release.',
 );
 
 $bottomSheet = BottomSheet::make(


### PR DESCRIPTION
## Summary
- expose guarded count() and in_array() helpers in declarative template expressions
- add regression coverage for collection count and strict membership
- bump the synchronized SDK/runtime version to 0.5.25

## Validation
- php packages/native/tests/run.php
- PHP lint across packages/native/src and packages/native/tests
- cargo test --workspace
- git diff --check