### PR TITLE
feat(audio): stream recorder telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.26 - 2026-07-29
+
+- Add cross-platform `AudioRecorder::watch()` telemetry with coalesced native
+  duration and normalized amplitude samples on Android and iOS.
+- Stop recorder observations automatically when a recording is stopped,
+  cancelled or the runtime closes.
+
 ## 0.5.25 - 2026-07-29
 
 - Add guarded `count()` and strict-capable `in_array()` collection helpers to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.25"
+version = "0.5.26"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.25"
+version = "0.5.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.25"
+version = "0.5.26"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/AudioRecorderModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/AudioRecorderModule.kt
@@ -5,13 +5,20 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.media.MediaRecorder
 import android.os.SystemClock
+import android.os.Handler
+import android.os.Looper
 import androidx.core.content.ContextCompat
 import dev.pam.nativeapp.protocol.WireMap
 import dev.pam.nativeapp.protocol.WireValue
 import java.io.File
 import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class AudioRecorderModule(private val context: Context) : NativeModule, AutoCloseable {
+    private val main = Handler(Looper.getMainLooper())
+    private val nextWatchId = AtomicInteger(1)
+    private val watches = ConcurrentHashMap<Int, RecorderWatch>()
     private var recorder: MediaRecorder? = null
     private var output: File? = null
     private var startedAt = 0L
@@ -23,6 +30,12 @@ internal class AudioRecorderModule(private val context: Context) : NativeModule,
                 "stop" -> stop(completion)
                 "cancel" -> cancel(completion)
                 "discard" -> discard(payload, completion)
+                "watch" -> watch(payload, completion)
+                "next" -> recorderWatch(payload).channel.next(completion)
+                "unwatch" -> {
+                    stopWatch(subscription(payload))
+                    completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))
+                }
                 else -> error("Unknown audio recorder method $method")
             }
         }.onFailure { error ->
@@ -62,6 +75,7 @@ internal class AudioRecorderModule(private val context: Context) : NativeModule,
         val active = recorder ?: error("No audio recording is active")
         val file = output ?: error("Audio recording output is unavailable")
         val durationMs = (SystemClock.elapsedRealtime() - startedAt).coerceAtLeast(0L)
+        stopWatches()
         recorder = null
         output = null
         startedAt = 0L
@@ -105,7 +119,63 @@ internal class AudioRecorderModule(private val context: Context) : NativeModule,
         completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))
     }
 
+    private fun watch(payload: ByteArray, completion: ModuleCompletion) {
+        require(recorder != null) { "No audio recording is active" }
+        val interval = ((WireMap.decode(payload)["intervalMs"] as? WireValue.Integer)?.value ?: 100)
+            .coerceIn(50, 1_000)
+        val id = nextWatchId.getAndIncrement()
+        val channel = WatchChannel()
+        lateinit var runnable: Runnable
+        runnable = Runnable {
+            val active = recorder
+            if (!watches.containsKey(id) || active == null) {
+                stopWatch(id)
+                return@Runnable
+            }
+            val amplitude = runCatching { active.maxAmplitude }.getOrDefault(0)
+                .toDouble()
+                .div(32_767.0)
+                .coerceIn(0.0, 1.0)
+            channel.offer(
+                WireMap.encode(
+                    mapOf(
+                        "durationMs" to WireValue.Integer(
+                            (SystemClock.elapsedRealtime() - startedAt).coerceAtLeast(0L),
+                        ),
+                        "amplitude" to WireValue.Decimal(amplitude),
+                    ),
+                ),
+            )
+            main.postDelayed(runnable, interval)
+        }
+        watches[id] = RecorderWatch(channel, runnable)
+        main.post(runnable)
+        completion.complete(
+            ModuleResultStatus.SUCCESS,
+            WireMap.encode(mapOf("subscription" to WireValue.Integer(id.toLong()))),
+        )
+    }
+
+    private fun subscription(payload: ByteArray): Int =
+        ((WireMap.decode(payload)["subscription"] as? WireValue.Integer)?.value
+            ?: error("Audio recorder subscription is required")).toInt()
+
+    private fun recorderWatch(payload: ByteArray): RecorderWatch =
+        watches[subscription(payload)] ?: error("Audio recorder observation not found")
+
+    private fun stopWatch(id: Int) {
+        watches.remove(id)?.let {
+            main.removeCallbacks(it.runnable)
+            it.channel.close()
+        }
+    }
+
+    private fun stopWatches() {
+        watches.keys.toList().forEach(::stopWatch)
+    }
+
     private fun release(deleteOutput: Boolean) {
+        stopWatches()
         recorder?.let { active ->
             runCatching { active.stop() }
             runCatching { active.reset() }
@@ -120,4 +190,9 @@ internal class AudioRecorderModule(private val context: Context) : NativeModule,
     override fun close() {
         release(deleteOutput = true)
     }
+
+    private data class RecorderWatch(
+        val channel: WatchChannel,
+        val runnable: Runnable,
+    )
 }

--- a/ios/Sources/PamNative/Modules/AudioRecorderModule.swift
+++ b/ios/Sources/PamNative/Modules/AudioRecorderModule.swift
@@ -4,6 +4,8 @@ import Foundation
 final class AudioRecorderModule: NSObject, NativeModule, ClosableNativeModule, AVAudioRecorderDelegate {
     private var recorder: AVAudioRecorder?
     private var outputURL: URL?
+    private var nextWatchId = 1
+    private var watches: [Int: RecorderWatch] = [:]
 
     func invoke(method: String, payload: Data, completion: @escaping ModuleCompletion) {
         DispatchQueue.main.async {
@@ -19,6 +21,13 @@ final class AudioRecorderModule: NSObject, NativeModule, ClosableNativeModule, A
                     completion(.success, Data())
                 case "discard":
                     completion(.success, try self.discard(payload))
+                case "watch":
+                    try self.watch(payload, completion)
+                case "next":
+                    try self.recorderWatch(payload).channel.next(completion)
+                case "unwatch":
+                    self.stopWatch(try self.subscription(payload))
+                    completion(.success, Data())
                 default:
                     throw AudioRecorderError.message("Unknown audio recorder method \(method)")
                 }
@@ -64,6 +73,7 @@ final class AudioRecorderModule: NSObject, NativeModule, ClosableNativeModule, A
             throw AudioRecorderError.message("No audio recording is active")
         }
         let durationMs = max(0, Int64(active.currentTime * 1_000))
+        stopWatches()
         active.stop()
         recorder = nil
         outputURL = nil
@@ -81,6 +91,7 @@ final class AudioRecorderModule: NSObject, NativeModule, ClosableNativeModule, A
     }
 
     private func release(deleteOutput: Bool) {
+        stopWatches()
         recorder?.stop()
         recorder = nil
         if deleteOutput, let outputURL {
@@ -88,6 +99,68 @@ final class AudioRecorderModule: NSObject, NativeModule, ClosableNativeModule, A
         }
         outputURL = nil
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func watch(_ payload: Data, _ completion: @escaping ModuleCompletion) throws {
+        guard recorder != nil else {
+            throw AudioRecorderError.message("No audio recording is active")
+        }
+        let values = try WireMap.decode(payload)
+        let requested: Int64
+        if case let .integer(value)? = values["intervalMs"] {
+            requested = value
+        } else {
+            requested = 100
+        }
+        let interval = min(max(requested, 50), 1_000)
+        let id = nextWatchId
+        nextWatchId += 1
+        let channel = WatchChannel()
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        watches[id] = RecorderWatch(channel: channel, timer: timer)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(Int(interval)))
+        timer.setEventHandler { [weak self, weak channel] in
+            guard let self, let active = self.recorder else {
+                self?.stopWatch(id)
+                return
+            }
+            active.updateMeters()
+            let power = active.averagePower(forChannel: 0)
+            let amplitude = min(max(pow(10.0, Double(power) / 20.0), 0), 1)
+            let data = try? WireMap.encode([
+                "durationMs": .integer(max(0, Int64(active.currentTime * 1_000))),
+                "amplitude": .decimal(amplitude),
+            ])
+            if let data { channel?.offer(data) }
+        }
+        timer.resume()
+        completion(.success, try WireMap.encode(["subscription": .integer(Int64(id))]))
+    }
+
+    private func subscription(_ payload: Data) throws -> Int {
+        let values = try WireMap.decode(payload)
+        guard case let .integer(value)? = values["subscription"] else {
+            throw AudioRecorderError.message("Audio recorder subscription is required")
+        }
+        return Int(value)
+    }
+
+    private func recorderWatch(_ payload: Data) throws -> RecorderWatch {
+        let id = try subscription(payload)
+        guard let watch = watches[id] else {
+            throw AudioRecorderError.message("Audio recorder observation not found")
+        }
+        return watch
+    }
+
+    private func stopWatch(_ id: Int) {
+        guard let watch = watches.removeValue(forKey: id) else { return }
+        watch.timer.cancel()
+        watch.channel.close()
+    }
+
+    private func stopWatches() {
+        Array(watches.keys).forEach(stopWatch)
     }
 
     private func discard(_ payload: Data) throws -> Data {
@@ -130,6 +203,11 @@ final class AudioRecorderModule: NSObject, NativeModule, ClosableNativeModule, A
             self.release(deleteOutput: true)
         }
     }
+}
+
+private struct RecorderWatch {
+    let channel: WatchChannel
+    let timer: DispatchSourceTimer
 }
 
 private enum AudioRecorderError: LocalizedError {

--- a/packages/native/src/AudioRecordingProgress.php
+++ b/packages/native/src/AudioRecordingProgress.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native;
+
+final readonly class AudioRecordingProgress
+{
+    public function __construct(
+        public int $durationMs,
+        public float $amplitude,
+    ) {
+    }
+}

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.5.25';
+    public const string SDK_VERSION = '0.5.26';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/System/AudioRecorder.php
+++ b/packages/native/src/System/AudioRecorder.php
@@ -6,6 +6,7 @@ namespace Pam\Native\System;
 
 use Closure;
 use Pam\Native\AudioRecording;
+use Pam\Native\AudioRecordingProgress;
 use Pam\Native\Internal\Wire;
 use Pam\Native\ModuleResultStatus;
 use Pam\Native\Modules\NativeModules;
@@ -13,6 +14,11 @@ use RuntimeException;
 
 final class AudioRecorder
 {
+    private static int $nextSubscription = 1;
+
+    /** @var array<int, array{callback: Closure, native: ?int}> */
+    private static array $subscriptions = [];
+
     private function __construct()
     {
     }
@@ -85,6 +91,83 @@ final class AudioRecorder
                     throw new RuntimeException($result->payload);
                 }
                 $callback();
+            },
+        );
+    }
+
+    /** @param Closure(AudioRecordingProgress): void $callback */
+    public static function watch(Closure $callback, int $intervalMs = 100): int
+    {
+        $subscription = self::$nextSubscription++;
+        self::$subscriptions[$subscription] = ['callback' => $callback, 'native' => null];
+        NativeModules::call(
+            'audio-recorder',
+            'watch',
+            ['intervalMs' => max(50, min(1_000, $intervalMs))],
+            static function ($result) use ($subscription): void {
+                if ($result->status === ModuleResultStatus::Failure) {
+                    unset(self::$subscriptions[$subscription]);
+                    throw new RuntimeException($result->payload);
+                }
+                $native = (int) (Wire::decodeMap($result->payload)['subscription'] ?? 0);
+                if (!isset(self::$subscriptions[$subscription])) {
+                    NativeModules::call(
+                        'audio-recorder',
+                        'unwatch',
+                        ['subscription' => $native],
+                        static fn ($result): null => null,
+                    );
+
+                    return;
+                }
+                self::$subscriptions[$subscription]['native'] = $native;
+                self::next($subscription);
+            },
+        );
+
+        return $subscription;
+    }
+
+    public static function unwatch(int $subscription): void
+    {
+        $watch = self::$subscriptions[$subscription] ?? null;
+        unset(self::$subscriptions[$subscription]);
+        if (is_array($watch) && is_int($watch['native'])) {
+            NativeModules::call(
+                'audio-recorder',
+                'unwatch',
+                ['subscription' => $watch['native']],
+                static fn ($result): null => null,
+            );
+        }
+    }
+
+    private static function next(int $subscription): void
+    {
+        $watch = self::$subscriptions[$subscription] ?? null;
+        if (!is_array($watch) || !is_int($watch['native'])) {
+            return;
+        }
+        NativeModules::call(
+            'audio-recorder',
+            'next',
+            ['subscription' => $watch['native']],
+            static function ($result) use ($subscription): void {
+                $watch = self::$subscriptions[$subscription] ?? null;
+                if (!is_array($watch)) {
+                    return;
+                }
+                if ($result->status === ModuleResultStatus::Failure) {
+                    unset(self::$subscriptions[$subscription]);
+
+                    return;
+                }
+                $values = Wire::decodeMap($result->payload);
+                ($watch['callback'])(new AudioRecordingProgress(
+                    durationMs: max(0, (int) ($values['durationMs'] ?? 0)),
+                    amplitude: max(0.0, min(1.0, (float) ($values['amplitude'] ?? 0.0))),
+                ));
+                self::next($subscription);
             },
         );
     }

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -3021,8 +3021,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.5.25',
-    'The runtime SDK contract must match the 0.5.25 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.5.26',
+    'The runtime SDK contract must match the 0.5.26 package release.',
 );
 
 $bottomSheet = BottomSheet::make(


### PR DESCRIPTION
## Summary
- add AudioRecorder::watch() duration and normalized amplitude snapshots
- implement coalesced native recorder observations on Android and iOS
- close observations automatically on stop, cancel, and runtime shutdown
- bump synchronized release version to 0.5.26

## Validation
- PHP SDK tests and lint
- cargo test --workspace
- Android app Kotlin compilation and unit tests
- git diff --check

Swift CLI is not installed in the local Linux environment; the GitHub macOS pipeline remains the authoritative Swift compile gate.