### PR TITLE
fix(media): expose capture failures to callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.27 - 2026-07-29
+
+- Let media capture callers handle camera unavailability and user cancellation
+  through an optional failure callback instead of crashing the PHP runtime.
+
 ## 0.5.26 - 2026-07-29
 
 - Add cross-platform `AudioRecorder::watch()` telemetry with coalesced native

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.26"
+version = "0.5.27"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.26"
+version = "0.5.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.26"
+version = "0.5.27"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/packages/native/src/System/MediaCapture.php
+++ b/packages/native/src/System/MediaCapture.php
@@ -18,15 +18,26 @@ final class MediaCapture
     {
     }
 
-    /** @param Closure(FileReference): void $callback */
-    public static function capture(CaptureType $type, Closure $callback): int
-    {
+    /**
+     * @param Closure(FileReference): void $callback
+     * @param Closure(string): void|null $failure
+     */
+    public static function capture(
+        CaptureType $type,
+        Closure $callback,
+        ?Closure $failure = null,
+    ): int {
         return NativeModules::call(
             'files',
             'capture',
             ['type' => $type->value],
-            static function ($result) use ($callback): void {
+            static function ($result) use ($callback, $failure): void {
                 if ($result->status === ModuleResultStatus::Failure) {
+                    if ($failure !== null) {
+                        $failure($result->payload);
+
+                        return;
+                    }
                     throw new RuntimeException($result->payload);
                 }
                 $values = Wire::decodeMap($result->payload);

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -16,6 +16,7 @@ use Pam\Native\AsyncStatus;
 use Pam\Native\AsyncValue;
 use Pam\Native\Component;
 use Pam\Native\Contact;
+use Pam\Native\CaptureType;
 use Pam\Native\EventKind;
 use Pam\Native\FileReference;
 use Pam\Native\FontStyle;
@@ -98,6 +99,7 @@ use Pam\Native\Restorable;
 use Pam\Native\State;
 use Pam\Native\Store\Attributes\Computed as StoreComputed;
 use Pam\Native\Store\ActionPolicy;
+use Pam\Native\System\MediaCapture;
 use Pam\Native\Store\Store;
 use Pam\Native\Store\StoreChangeKind;
 use Pam\Native\Store\StoreMiddleware;
@@ -1731,6 +1733,27 @@ $assert(
         && $moduleResult->succeeded()
         && $moduleResult->values() === ['message' => 'fast'],
     'Public native module facade did not decode its result.',
+);
+
+$captureError = null;
+$captureSucceeded = false;
+$captureRequestId = MediaCapture::capture(
+    CaptureType::Photo,
+    static function (FileReference $_) use (&$captureSucceeded): void {
+        $captureSucceeded = true;
+    },
+    static function (string $message) use (&$captureError): void {
+        $captureError = $message;
+    },
+);
+Runtime::dispatchModuleResult(
+    $captureRequestId,
+    ModuleResultStatus::Failure->value,
+    'Camera is unavailable.',
+);
+$assert(
+    !$captureSucceeded && $captureError === 'Camera is unavailable.',
+    'Media capture failures must reach the optional failure callback.',
 );
 
 $location = null;


### PR DESCRIPTION
## Summary
- add an optional media-capture failure callback
- keep the existing exception behavior when no failure callback is provided
- cover camera unavailability/cancellation delivery in the PHP SDK suite
- prepare v0.5.27

## Validation
- `php packages/native/tests/run.php`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `./android/gradlew -p android :app:testDebugUnitTest :plugin-api:testDebugUnitTest`