### PR TITLE
fix(android): sync native input before actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.28 - 2026-07-29
+
+- Flush focused `sync="native"` input values before press actions so handlers
+  always receive the exact text visible on screen without per-keystroke bridge
+  traffic.
+- Let Android's IME consume Back inside PAM modals before dispatching the
+  modal's route-close callback.
+
 ## 0.5.27 - 2026-07-29
 
 - Let media capture callers handle camera unavailability and user cancellation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.5.27"
+version = "0.5.28"
 dependencies = [
  "pam-native-protocol",
 ]
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.5.27"
+version = "0.5.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.27"
+version = "0.5.28"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamModalHost.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamModalHost.kt
@@ -17,6 +17,7 @@ import android.view.ViewGroup
 import android.view.ViewOutlineProvider
 import android.view.VelocityTracker
 import android.view.Window
+import android.view.WindowInsets
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.window.OnBackInvokedCallback
@@ -378,8 +379,24 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
     }
 
     private fun requestCloseFromBack() {
+        if (hideVisibleKeyboard()) return
         (context as? PamActivity)?.suppressNextPamBack()
         requestClose()
+    }
+
+    private fun hideVisibleKeyboard(): Boolean {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) {
+            return false
+        }
+        val focused = dialog?.currentFocus ?: return false
+        val decor = dialog?.window?.decorView ?: return false
+        if (decor.rootWindowInsets?.isVisible(WindowInsets.Type.ime()) != true) {
+            return false
+        }
+        val keyboard = context.getSystemService(Context.INPUT_METHOD_SERVICE)
+            as? InputMethodManager
+        keyboard?.hideSoftInputFromWindow(focused.windowToken, 0)
+        return true
     }
 
     @Suppress("DEPRECATION")

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
@@ -2271,6 +2271,7 @@ class PamRenderer(
             view.setOnLongClickListener(null)
             view.setCallbacks(
                 onPress = state.callback(PropKey.ON_PRESS) {
+                    flushFocusedNativeInputs()
                     dispatch(state.id, EVENT_PRESS)
                 },
                 onLongPress = state.callback(PropKey.ON_LONG_PRESS) {
@@ -2289,7 +2290,10 @@ class PamRenderer(
             configurePressable(view, state)
         } else if (state.kind != NodeKind.CUSTOM_VIEW) {
             if (state.properties[PropKey.ON_PRESS] != null) {
-                view.setOnClickListener { dispatch(state.id, EVENT_PRESS) }
+                view.setOnClickListener {
+                    flushFocusedNativeInputs()
+                    dispatch(state.id, EVENT_PRESS)
+                }
             } else {
                 view.setOnClickListener(null)
             }
@@ -3330,6 +3334,29 @@ class PamRenderer(
         state.pendingChange = null
         if (state.properties[PropKey.ON_CHANGE] != null) {
             dispatch(state.id, EVENT_CHANGE, state.nativeValue)
+        }
+    }
+
+    /**
+     * Native-synced inputs intentionally avoid a PHP round trip per keystroke.
+     * Drain their current value before another control fires so the following
+     * action observes exactly what is visible in the focused editor.
+     */
+    private fun flushFocusedNativeInputs() {
+        val pending = buildList {
+            for (index in 0 until nodes.size()) {
+                val state = nodes.valueAt(index)
+                if (
+                state.inputSyncMode() == INPUT_SYNC_NATIVE &&
+                    state.properties[PropKey.ON_CHANGE] != null &&
+                    (views[state.id] as? EditText)?.hasFocus() == true
+                ) {
+                    add(state)
+                }
+            }
+        }
+        pending.forEach { state ->
+            if (nodes[state.id] === state) dispatchInput(state)
         }
     }
 

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.5.26';
+    public const string SDK_VERSION = '0.5.28';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -3044,8 +3044,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.5.26',
-    'The runtime SDK contract must match the 0.5.26 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.5.28',
+    'The runtime SDK contract must match the 0.5.28 package release.',
 );
 
 $bottomSheet = BottomSheet::make(


### PR DESCRIPTION
## Summary
- flush focused `sync="native"` values before press handlers
- let the Android IME consume Back before a PAM modal closes
- release contract 0.5.28

## Validation
- PHP SDK suite and 1,000-frame deterministic fuzz
- Rust workspace: 34 tests
- Android unit/compile gates
- Android API 36 emulator: 13/13 instrumented tests