### PR TITLE
fix(android): restore modern status bar and disabled controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.3 - 2026-08-03
+
+- Honor dark status-bar icons on Android 15 and newer instead of silently
+  forcing light icons after the platform's edge-to-edge transition.
+- Cover active retained-route status-bar appearance changes on both modern and
+  legacy Android window APIs.
+- Compile static and bound `disabled` template attributes to the inverse native
+  enabled state so controls stop interaction and report their state correctly
+  to accessibility services.
+
 ## 0.6.1 - 2026-08-01
 
 - Add production plugin manifests for typed IDL fingerprints, Swift Package

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.2"
+version = "0.6.3"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamRendererInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamRendererInstrumentedTest.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.MotionEvent
 import android.view.TextureView
+import android.view.WindowInsetsController
 import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.TextView
@@ -65,6 +66,8 @@ class PamRendererInstrumentedTest {
                                     mapOf(
                                         PropKey.STATUS_BAR_COLOR to
                                             PropValue.Integer(Color.RED.toLong()),
+                                        PropKey.STATUS_BAR_STYLE to
+                                            PropValue.Integer(1L),
                                     ),
                                 ),
                             ),
@@ -77,6 +80,8 @@ class PamRendererInstrumentedTest {
                                     mapOf(
                                         PropKey.STATUS_BAR_COLOR to
                                             PropValue.Integer(Color.BLUE.toLong()),
+                                        PropKey.STATUS_BAR_STYLE to
+                                            PropValue.Integer(2L),
                                     ),
                                 ),
                             ),
@@ -109,6 +114,7 @@ class PamRendererInstrumentedTest {
                         activity.window.statusBarColor
                     },
                 )
+                assertStatusBarUsesDarkIcons(activity, false)
 
                 renderer.commit(
                     listOf(
@@ -136,11 +142,24 @@ class PamRendererInstrumentedTest {
                         activity.window.statusBarColor
                     },
                 )
+                assertStatusBarUsesDarkIcons(activity, true)
                 renderer.close()
             }
         } finally {
             activity.finish()
         }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun assertStatusBarUsesDarkIcons(activity: PamTestActivity, expected: Boolean) {
+        val enabled = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val appearance = activity.window.insetsController?.systemBarsAppearance ?: 0
+            appearance and WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS != 0
+        } else {
+            activity.window.decorView.systemUiVisibility and
+                View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR != 0
+        }
+        assertEquals(expected, enabled)
     }
 
     @Test

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
@@ -5040,8 +5040,7 @@ class PamRenderer(
         val decor = activity()?.window?.decorView ?: return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val controller = decor.windowInsetsController ?: return
-            val useDarkIcons =
-                value == STATUS_BAR_DARK && Build.VERSION.SDK_INT < 35
+            val useDarkIcons = value == STATUS_BAR_DARK
             controller.setSystemBarsAppearance(
                 if (useDarkIcons) {
                     WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS

--- a/docs/components.md
+++ b/docs/components.md
@@ -308,6 +308,15 @@ familiar `backgroundColor`/`barStyle` aliases, including `animated` and
 `translucent`.
 Android resolves those properties from the active retained stack route; hidden
 routes no longer override the system UI of the visible screen.
+`appearance="dark"` requests dark system icons on every supported Android
+version, including Android 15 and newer where edge-to-edge is enforced by the
+platform. Use it over a light status-bar background; `appearance="light"`
+keeps light icons for dark backgrounds.
+
+Interactive templates accept either `enabled` or the familiar inverse
+`disabled` attribute, including bound expressions. Disabled native controls
+stop pointer activation and expose the disabled state to platform
+accessibility services.
 
 CSS custom properties are declared in `:root`, may reference one another, and
 support nested fallbacks such as `var(--brand, var(--fallback, rebeccapurple))`.

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -1462,7 +1462,12 @@ final class TemplateRenderer
             $element = $element->testId(self::stringValue($attributes['testId'], 'Test ID'));
         }
 
-        if (isset($attributes['enabled'])) {
+        if (isset($attributes['disabled'])) {
+            $element = $element->enabled(!self::boolValue(
+                $attributes['disabled'],
+                'Disabled',
+            ));
+        } elseif (isset($attributes['enabled'])) {
             $element = $element->enabled(self::boolValue($attributes['enabled'], 'Enabled'));
         }
 

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.2';
+    public const string SDK_VERSION = '0.6.3';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1291,6 +1291,16 @@ $assert(
     $secureAliasElement->properties()[PropKey::Secure->value] === true,
     'Input secureTextEntry must remain a compatible alias for secure.',
 );
+$disabledAliasElement = TemplateRenderer::render(
+    TemplateCompiler::compile('<Pressable disabled="true" />'),
+    new class {
+    },
+    [],
+);
+$assert(
+    $disabledAliasElement->properties()[PropKey::Enabled->value] === false,
+    'Template disabled must invert to the native enabled property.',
+);
 $memoryDiskImage = TemplateRenderer::render(
     TemplateCompiler::compile('<Image source="https://example.test/image.webp" cachePolicy="memory-disk" />'),
     new class {
@@ -4960,8 +4970,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.2',
-    'The runtime SDK contract must match the 0.6.2 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.3',
+    'The runtime SDK contract must match the 0.6.3 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- honor dark status-bar icons on Android 15+
- compile `disabled` template attributes to the inverse native enabled state
- document both contracts and prepare PAM Native 0.6.3

## Validation
- PHP SDK tests
- Rust tests and Clippy
- Android unit tests, lint and debug assembly
- 26 Android instrumented renderer tests on API 36 emulator
- physical ZeChat status-bar screenshot evidence