### PR TITLE
feat(device): expose native time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.4 - 2026-08-03
+
+- Expose the device's IANA time-zone identifier through `DeviceInfo::timeZone`
+  on Android and iOS so applications can format API timestamps in local time.
+- Preserve source compatibility for manually constructed `DeviceInfo` values
+  with a documented `UTC` fallback when older native hosts omit the field.
+
 ## 0.6.3 - 2026-08-03
 
 - Honor dark status-bar icons on Android 15 and newer instead of silently

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.3"
+version = "0.6.4"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/SystemModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/SystemModule.kt
@@ -31,6 +31,7 @@ import dev.pam.nativeapp.protocol.WireMap
 import dev.pam.nativeapp.protocol.WireValue
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.Collections
+import java.util.TimeZone
 
 internal class SystemModule(private val context: Context) : AutoCloseable {
     private val main = Handler(Looper.getMainLooper())
@@ -245,6 +246,7 @@ internal class SystemModule(private val context: Context) : AutoCloseable {
                         "density" to WireValue.Decimal(density.toDouble()),
                         "appearance" to WireValue.Integer(appearance.toLong()),
                         "appState" to WireValue.Integer(appState.toLong()),
+                        "timeZone" to WireValue.Text(TimeZone.getDefault().id),
                         "safeAreaTop" to WireValue.Decimal(
                             safeTop / density.toDouble(),
                         ),

--- a/ios/Sources/PamNative/Modules/SystemModule.swift
+++ b/ios/Sources/PamNative/Modules/SystemModule.swift
@@ -129,6 +129,7 @@ public final class SystemModule: NativeModule, ClosableNativeModule, @unchecked 
                         "density": .decimal(Double(density)),
                         "appearance": .integer(Int64(appearance)),
                         "appState": .integer(Int64(appState)),
+                        "timeZone": .text(TimeZone.current.identifier),
                         "safeAreaTop": .decimal(Double(insets.top)),
                         "safeAreaRight": .decimal(Double(insets.right)),
                         "safeAreaBottom": .decimal(Double(insets.bottom)),

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -78,7 +78,8 @@ options are available through `SafeAreaView::edges()->mode()` and
 `KeyboardAvoidingView::verticalOffset()->avoidingEnabled()`.
 When custom chrome must size itself around those regions,
 `DeviceInfo::get()` exposes `safeAreaTop`, `safeAreaRight`, `safeAreaBottom`,
-and `safeAreaLeft` in logical points on Android and iOS.
+and `safeAreaLeft` in logical points plus the device's IANA `timeZone` identifier
+on Android and iOS.
 
 Pull-to-refresh is configured with `RefreshControl::colors()`,
 `progressBackgroundColor()`, `progressViewOffset()`, `enabled()` and `size()`.

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.3';
+    public const string SDK_VERSION = '0.6.4';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/System/DeviceInfo.php
+++ b/packages/native/src/System/DeviceInfo.php
@@ -25,6 +25,7 @@ final readonly class DeviceInfo
         public float $safeAreaRight = 0.0,
         public float $safeAreaBottom = 0.0,
         public float $safeAreaLeft = 0.0,
+        public string $timeZone = 'UTC',
     ) {
     }
 
@@ -50,6 +51,7 @@ final readonly class DeviceInfo
                     safeAreaRight: (float) ($values['safeAreaRight'] ?? 0.0),
                     safeAreaBottom: (float) ($values['safeAreaBottom'] ?? 0.0),
                     safeAreaLeft: (float) ($values['safeAreaLeft'] ?? 0.0),
+                    timeZone: (string) ($values['timeZone'] ?? 'UTC'),
                 ));
             },
         );

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -3259,11 +3259,13 @@ $deviceInfo = new DeviceInfo(
     safeAreaRight: 0.0,
     safeAreaBottom: 24.0,
     safeAreaLeft: 0.0,
+    timeZone: 'America/Sao_Paulo',
 );
 $assert(
     $deviceInfo->safeAreaTop === 32.0
-        && $deviceInfo->safeAreaBottom === 24.0,
-    'Device info must expose platform safe-area insets in logical points.',
+        && $deviceInfo->safeAreaBottom === 24.0
+        && $deviceInfo->timeZone === 'America/Sao_Paulo',
+    'Device info must expose platform safe-area insets and the IANA time-zone identifier.',
 );
 $legacyDeviceInfo = new DeviceInfo(
     width: 360.0,
@@ -3276,7 +3278,8 @@ $assert(
     $legacyDeviceInfo->safeAreaTop === 0.0
         && $legacyDeviceInfo->safeAreaRight === 0.0
         && $legacyDeviceInfo->safeAreaBottom === 0.0
-        && $legacyDeviceInfo->safeAreaLeft === 0.0,
+        && $legacyDeviceInfo->safeAreaLeft === 0.0
+        && $legacyDeviceInfo->timeZone === 'UTC',
     'Device info safe-area additions must preserve constructor compatibility.',
 );
 
@@ -4970,8 +4973,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.3',
-    'The runtime SDK contract must match the 0.6.3 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.4',
+    'The runtime SDK contract must match the 0.6.4 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- expose the device IANA time-zone identifier from Android and iOS
- decode it through the PHP DeviceInfo API with a backward-compatible UTC fallback
- document the capability and bump the SDK contract to 0.6.4

## Validation
- PHP SDK suite
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- Android unit tests, lint, app build, and plugin API build