### PR TITLE
fix(layout): guard packaged font intrinsic widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.5 - 2026-08-03
+
+- Preserve a subpixel safety guard for intrinsic text measured from packaged
+  TTF/OTF advances. This prevents Android `TextView` from wrapping a final word
+  into a clipped second line when platform hinting rounds the run fractionally
+  wider than the font's ideal advance sum.
+- Cover packaged-font intrinsic measurement with a regression fixture based on
+  a compact chat bubble whose full final word must remain on one line.
+
 ## 0.6.4 - 2026-08-03
 
 - Expose the device's IANA time-zone identifier through `DeviceInfo::timeZone`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.4"
+version = "0.6.5"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/crates/pam-native-engine/src/layout.rs
+++ b/crates/pam-native-engine/src/layout.rs
@@ -1800,7 +1800,12 @@ fn measured_text_width(
         }
     }
     if glyph_advances.is_some() {
-        return width;
+        // TTF advances describe the ideal unhinted run. Android's TextView can
+        // round a hinted run a fraction wider when it builds its StaticLayout.
+        // Without the same sub-pixel guard used by the fallback estimator, an
+        // intrinsically-sized label can wrap its last word while the engine
+        // still reserves one line of height, clipping that word completely.
+        return if width > 0.0 { width + 0.5 } else { 0.0 };
     }
     // Bounding-box based em classes need a small conversion to platform glyph
     // advances. The old broad classes plus a 6% safety margin substantially
@@ -3499,7 +3504,36 @@ mod tests {
 
         assert_eq!(
             measured_text_width("Seguidores", font_size, 0.0, Some(&advances)),
-            expected,
+            expected + 0.5,
+        );
+    }
+
+    #[test]
+    fn loaded_font_intrinsic_width_keeps_platform_subpixel_guard() {
+        let advances = BTreeMap::from([
+            (' ', 0.25),
+            ('?', 0.54),
+            ('Q', 0.61),
+            ('a', 0.54),
+            ('c', 0.49),
+            ('e', 0.54),
+            ('m', 0.78),
+            ('o', 0.56),
+            ('p', 0.56),
+            ('r', 0.32),
+            ('u', 0.56),
+        ]);
+        let label = "Quer comprar ?";
+        let raw = label
+            .chars()
+            .map(|character| advances[&character] * 16.0)
+            .sum::<f32>();
+        let intrinsic = measured_text_width(label, 16.0, 0.0, Some(&advances));
+
+        assert!((intrinsic - raw - 0.5).abs() < 0.01);
+        assert_eq!(
+            wrapped_text_lines_with_metrics(label, 16.0, 0.0, intrinsic, Some(&advances)),
+            vec![label],
         );
     }
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -225,7 +225,10 @@ Before the first native mount, the Rust layout engine reads each selected TTF
 or OTF face directly from the extracted application assets and caches its
 normalized glyph advances. Intrinsic widths, wrapping, accessibility font
 scaling, and flex centering therefore use the metrics of the font Android and
-iOS actually render. A missing or unsupported face falls back to PAM's
+iOS actually render. PAM retains a half-point subpixel guard around the ideal
+advance sum because platform hinting can round a native text run fractionally
+wider; this keeps the native widget's wrapping decision consistent with the
+height reserved by the engine. A missing or unsupported face falls back to PAM's
 allocation-free generic estimator; layout never waits for a native measurement
 round trip and does not visibly correct itself after mount.
 Android converts retained logical frames to physical pixels by rounding their

--- a/docs/runtime-performance.md
+++ b/docs/runtime-performance.md
@@ -83,6 +83,9 @@ changes. Fixed-size text boxes additionally bypass intrinsic measurement for
 text/font changes because their resolved geometry cannot change. Tests compare
 incremental output byte-for-byte with a complete layout and require a deep
 two-branch fixture to visit less than one quarter of its retained nodes.
+Packaged-font advances include a bounded half-point platform guard so Android
+hinting cannot create a native wrap that the retained Rust height did not
+reserve; this remains deterministic and requires no measurement bridge call.
 
 ## Compiled metadata
 

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.4';
+    public const string SDK_VERSION = '0.6.5';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4973,8 +4973,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.4',
-    'The runtime SDK contract must match the 0.6.4 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.5',
+    'The runtime SDK contract must match the 0.6.5 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary

- retain a 0.5pt platform hinting guard for packaged TTF/OTF advances
- prevent Android TextView from wrapping and clipping a final word inside intrinsically-sized content
- add regression coverage and document the deterministic measurement contract
- bump the synchronized SDK/runtime version to 0.6.5

## Validation

- `php packages/native/tests/run.php`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Android: `./gradlew testDebugUnitTest lintDebug assembleDebug`
- API 36 ZeChat emulator: compact outgoing message renders the complete `Quer comprar ?` line