### PR TITLE
fix(navigation): retain visible route after pop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.6 - 2026-08-03
+
+- Promote the remaining replacement route when a renderer update removes the
+  currently active Android route after a completed pop. This prevents a valid
+  navigation stack from becoming an entirely blank native surface.
+- Return the PHP navigator operation to `Idle` after native transition
+  completion instead of leaving a settled pop encoded in later renders.
+- Cover active-route replacement and settled-pop finalization with Android and
+  PHP regression tests.
+
 ## 0.6.5 - 2026-08-03
 
 - Preserve a subpixel safety guard for intrinsic text measured from packaged

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.5"
+version = "0.6.6"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
@@ -19,6 +19,42 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class PamNavigationHostInstrumentedTest {
     @Test
+    fun replacingTheActiveRoutePromotesTheRemainingReplacement() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var navigation: PamNavigationHost
+            lateinit var active: View
+            lateinit var replacement: View
+            onMain(instrumentation) {
+                navigation = PamNavigationHost(activity)
+                activity.host.addView(navigation)
+                active = View(activity)
+                replacement = View(activity)
+                navigation.insert(active, 0)
+                navigation.insert(replacement, 1)
+
+                assertEquals(View.VISIBLE, active.visibility)
+                assertEquals(View.INVISIBLE, replacement.visibility)
+
+                navigation.removeRoute(active)
+            }
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                assertSame(replacement, navigation.getChildAt(0))
+                assertTrue(navigation.isActiveRoute(replacement))
+                assertEquals(View.VISIBLE, replacement.visibility)
+                assertEquals(
+                    View.IMPORTANT_FOR_ACCESSIBILITY_AUTO,
+                    replacement.importantForAccessibility,
+                )
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
+    @Test
     fun nativeTabHostRetainsAllScenesWhenSelectionChanges() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val activity = launchActivity(instrumentation)

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamNavigationHost.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamNavigationHost.kt
@@ -134,6 +134,18 @@ internal class PamNavigationHost(context: Context) : FrameLayout(context) {
 
     override fun onViewRemoved(child: View) {
         super.onViewRemoved(child)
+        if (child === activeRoute) {
+            activeRoute = null
+            if (childCount > 0) {
+                getChildAt(childCount - 1).also { replacement ->
+                    replacement.visibility = View.VISIBLE
+                    replacement.importantForAccessibility =
+                        View.IMPORTANT_FOR_ACCESSIBILITY_AUTO
+                    setActiveRoute(replacement)
+                    applyRoutePresentation(replacement)
+                }
+            }
+        }
         if (suppressControllerRemoval) return
         val fragment = routeControllers.remove(child) ?: return
         fragmentManager()?.takeUnless(FragmentManager::isStateSaved)?.let { manager ->

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -108,6 +108,9 @@ integer-backed enums and are rendered natively with transform
 and opacity. Android's disabled-animation accessibility setting is respected,
 horizontal transitions automatically mirror in RTL layouts, and only the
 incoming screen remains reachable by TalkBack during and after a transition.
+When the native transition completes, the outgoing route is released and the
+host returns to the `Idle` operation before subsequent renders. A completed
+pop is therefore never replayed against the remaining single-screen host.
 
 ## Adaptive tabs
 

--- a/packages/native/src/Navigation/Navigator.php
+++ b/packages/native/src/Navigation/Navigator.php
@@ -1054,7 +1054,11 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
     private function finalizeOutgoingRoute(): void
     {
         $entry = $this->outgoing;
-        if ($entry === null) return;
+        if ($entry === null) {
+            $this->operation = NavigationOperation::Idle;
+
+            return;
+        }
         $key = $this->entryKey($entry);
         $instance = $this->routeInstances[$key] ?? null;
         if ($instance instanceof NavigationLifecycleAware) {
@@ -1069,6 +1073,7 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
             );
         }
         $this->outgoing = null;
+        $this->operation = NavigationOperation::Idle;
     }
 
     private function observeChildNavigator(string $key, Renderable $instance): void

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.5';
+    public const string SDK_VERSION = '0.6.6';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4276,6 +4276,18 @@ $assert($navigator->pop(), 'Navigator must pop a secondary route.');
 $popped = $navigator->render()->toElement();
 $assert(count($popped->children()) === 2, 'Pop must retain its outgoing screen until native animation completes.');
 $assert($navigator->currentRoute() === 'home', 'Pop must reveal the previous route.');
+$transitionEnd = $popped->events()[EventKind::AnimationComplete->value] ?? null;
+$assert($transitionEnd instanceof Closure, 'Navigator must expose native transition completion.');
+$transitionEnd('');
+$settledPop = $navigator->render()->toElement();
+$assert(
+    count($settledPop->children()) === 1,
+    'Settled pop must release its outgoing route.',
+);
+$assert(
+    $settledPop->properties()[PropKey::NavigationOperation->value] === NavigationOperation::Idle->value,
+    'Settled pop must restore the native host operation to idle.',
+);
 $systemBackConsumed = false;
 $navigator->interceptSystemBack(static function () use (&$systemBackConsumed): bool {
     $systemBackConsumed = true;
@@ -4973,8 +4985,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.5',
-    'The runtime SDK contract must match the 0.6.5 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.6',
+    'The runtime SDK contract must match the 0.6.6 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- promote a replacement route when renderer reconciliation removes the active Android route
- settle PHP navigation operations back to Idle after transition completion
- document and test both sides of the pop lifecycle

## Verification
- php packages/native/tests/run.php
- cargo test --workspace
- ./gradlew :app:testDebugUnitTest
- ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.pam.nativeapp.render.PamNavigationHostInstrumentedTest
- physical emulator verification in ZeChat: ChatDetails -> Back restores Chat instead of a blank activity