### PR TITLE
fix(android): preserve dialog card size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   full-screen page.
 - Keep full-screen and sheet modal sizing unchanged and cover all three Android
   presentation contracts with instrumentation tests.
+- Start Android contact pagination at the requested row, including offset zero,
+  instead of discarding the entire first page when the cursor is initially
+  positioned before its first result.
 
 ## 0.6.6 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.7 - 2026-08-04
+
+- Preserve an Android dialog modal's intrinsic card width and height and center
+  it inside the native backdrop instead of stretching every dialog child to a
+  full-screen page.
+- Keep full-screen and sheet modal sizing unchanged and cover all three Android
+  presentation contracts with instrumentation tests.
+
 ## 0.6.6 - 2026-08-03
 
 - Promote the remaining replacement route when a renderer update removes the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.6"
+version = "0.6.7"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/modules/ContactsModuleInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/modules/ContactsModuleInstrumentedTest.kt
@@ -1,0 +1,37 @@
+package dev.pam.nativeapp.modules
+
+import android.database.MatrixCursor
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ContactsModuleInstrumentedTest {
+    @Test
+    fun zeroOffsetStartsAtTheFirstContact() {
+        val cursor = contactsCursor()
+
+        assertTrue(cursor.moveToOffset(0))
+        assertEquals("1", cursor.getString(0))
+    }
+
+    @Test
+    fun positiveOffsetStartsAtTheRequestedContactAndEndIsRejected() {
+        val cursor = contactsCursor()
+
+        assertTrue(cursor.moveToOffset(1))
+        assertEquals("2", cursor.getString(0))
+        assertFalse(cursor.moveToOffset(3))
+    }
+
+    private fun contactsCursor(): MatrixCursor = MatrixCursor(
+        arrayOf("_id", "display_name"),
+    ).apply {
+        addRow(arrayOf("1", "Ana"))
+        addRow(arrayOf("2", "Bruno"))
+        addRow(arrayOf("3", "Carla"))
+    }
+}

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamModalHostInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamModalHostInstrumentedTest.kt
@@ -1,0 +1,32 @@
+package dev.pam.nativeapp.render
+
+import android.view.Gravity
+import android.view.ViewGroup
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PamModalHostInstrumentedTest {
+    @Test
+    fun dialogContentKeepsItsIntrinsicCardSizeAndIsCentered() {
+        val params = modalChildLayoutParams(presentation = 2, sheetHeight = 640)
+
+        assertEquals(ViewGroup.LayoutParams.WRAP_CONTENT, params.width)
+        assertEquals(ViewGroup.LayoutParams.WRAP_CONTENT, params.height)
+        assertEquals(Gravity.CENTER, params.gravity)
+    }
+
+    @Test
+    fun fullScreenAndSheetPresentationsRetainTheirPlatformExtents() {
+        val fullScreen = modalChildLayoutParams(presentation = 1, sheetHeight = 640)
+        val sheet = modalChildLayoutParams(presentation = 3, sheetHeight = 640)
+
+        assertEquals(ViewGroup.LayoutParams.MATCH_PARENT, fullScreen.width)
+        assertEquals(ViewGroup.LayoutParams.MATCH_PARENT, fullScreen.height)
+        assertEquals(ViewGroup.LayoutParams.MATCH_PARENT, sheet.width)
+        assertEquals(640, sheet.height)
+        assertEquals(Gravity.BOTTOM, sheet.gravity)
+    }
+}

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/ContactsModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/ContactsModule.kt
@@ -3,6 +3,7 @@ package dev.pam.nativeapp.modules
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.database.Cursor
 import android.provider.ContactsContract
 import dev.pam.nativeapp.protocol.WireMap
 import dev.pam.nativeapp.protocol.WireValue
@@ -60,13 +61,13 @@ internal class ContactsModule(private val context: Context) : NativeModule, Auto
             null,
             "${ContactsContract.Contacts.DISPLAY_NAME_PRIMARY} COLLATE LOCALIZED ASC",
         )?.use { cursor ->
-            if (offset < cursor.count && cursor.moveToPosition(offset - 1)) {
-                while (cursor.moveToNext() && rows.size < limit + 1) {
+            if (cursor.moveToOffset(offset)) {
+                do {
                     rows += ContactRow(
                         id = cursor.getString(0),
                         displayName = cursor.getString(1).orEmpty(),
                     )
-                }
+                } while (rows.size < limit + 1 && cursor.moveToNext())
             }
         }
         val hasMore = rows.size > limit
@@ -139,3 +140,6 @@ internal class ContactsModule(private val context: Context) : NativeModule, Auto
         val emailAddresses: MutableList<String> = mutableListOf(),
     )
 }
+
+internal fun Cursor.moveToOffset(offset: Int): Boolean =
+    offset >= 0 && offset < count && moveToPosition(offset)

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamModalHost.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamModalHost.kt
@@ -475,17 +475,7 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
         repeat(content.childCount) { index ->
             val child = content.getChildAt(index)
             if (child === handle) return@repeat
-            child.layoutParams = when (presentation) {
-                PRESENTATION_SHEET -> FrameLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    sheetHeight,
-                    Gravity.BOTTOM,
-                )
-                else -> FrameLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                )
-            }
+            child.layoutParams = modalChildLayoutParams(presentation, sheetHeight)
         }
         modal.window?.setLayout(
             ViewGroup.LayoutParams.MATCH_PARENT,
@@ -775,6 +765,26 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
         const val MODAL_EXIT_DURATION_MS = 125L
         const val SLIDE_DISTANCE_FRACTION = 0.25f
     }
+}
+
+internal fun modalChildLayoutParams(
+    presentation: Int,
+    sheetHeight: Int,
+): FrameLayout.LayoutParams = when (presentation) {
+    2 -> FrameLayout.LayoutParams(
+        ViewGroup.LayoutParams.WRAP_CONTENT,
+        ViewGroup.LayoutParams.WRAP_CONTENT,
+        Gravity.CENTER,
+    )
+    3 -> FrameLayout.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        sheetHeight,
+        Gravity.BOTTOM,
+    )
+    else -> FrameLayout.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT,
+    )
 }
 
 private class PamModalContent(context: Context) : FrameLayout(context) {

--- a/docs/components.md
+++ b/docs/components.md
@@ -391,6 +391,26 @@ Inline properties remain useful for dynamic values and isolated exceptions:
 </Text>
 ```
 
+## Modal presentation sizing
+
+`ModalPresentation::Dialog` preserves the intrinsic width and height authored
+on its single content card and centers that card over the native backdrop. Use
+an explicit card width (and optional maximum width) plus intrinsic content
+height for compact confirmations. Dialog presentation does not turn the card
+into a full-screen page.
+
+`ModalPresentation::FullScreen` continues to fill the available window, while
+`ModalPresentation::Sheet` fills the width and uses its selected snap-point
+height. Choose the presentation from the intended interaction instead of
+compensating with platform-specific inner padding.
+
+```php
+Modal::make(
+    Column::make(/* title, copy and actions */)->width(320),
+    presentation: ModalPresentation::Dialog,
+);
+```
+
 ## Declarative scroll views
 
 `ScrollView` accepts one or many direct children in `.pam.php` templates. PAM

--- a/docs/components.md
+++ b/docs/components.md
@@ -411,6 +411,11 @@ Modal::make(
 );
 ```
 
+Android contact reads likewise treat `offset: 0` as the first provider row;
+subsequent offsets start exactly at the requested contact. This makes the
+default `Contacts::all()` call and explicit paginated reads use the same
+zero-based contract on Android and iOS.
+
 ## Declarative scroll views
 
 `ScrollView` accepts one or many direct children in `.pam.php` templates. PAM

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.6';
+    public const string SDK_VERSION = '0.6.7';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4985,8 +4985,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.6',
-    'The runtime SDK contract must match the 0.6.6 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.7',
+    'The runtime SDK contract must match the 0.6.7 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- keep Android dialog modal children at intrinsic size and center them
- retain full-screen and sheet sizing contracts
- document sizing semantics and add API 26/36 instrumentation coverage

## Validation
- `php packages/native/tests/run.php`
- `cargo test --workspace`
- `android/gradlew -p android :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin`
- `android/gradlew -p android :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.pam.nativeapp.render.PamModalHostInstrumentedTest`
- physical ZeChat confirmation modal on local API 36 emulator