### PR TITLE
feat: add native SMS composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.8 - 2026-08-04
+
+- Add `Sms::isAvailable()` and `Sms::compose()` for querying platform support
+  and opening a pre-addressed native SMS draft without sending automatically.
+- Restrict Android drafts to `ACTION_SENDTO` with the `smsto:` scheme so only
+  messaging applications can handle the request, and use MessageUI's native
+  composer on iOS.
+- Validate recipient count, recipient length and draft size in the PHP SDK and
+  both native hosts, with PHP and Android regression coverage.
+
 ## 0.6.7 - 2026-08-04
 
 - Preserve an Android dialog modal's intrinsic card width and height and center

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Add `Sms::isAvailable()` and `Sms::compose()` for querying platform support
   and opening a pre-addressed native SMS draft without sending automatically.
 - Restrict Android drafts to `ACTION_SENDTO` with the `smsto:` scheme so only
-  messaging applications can handle the request, and use MessageUI's native
-  composer on iOS.
+  messaging applications can handle the request, declare the corresponding
+  Android package-visibility query, and use MessageUI's native composer on iOS.
 - Validate recipient count, recipient length and draft size in the PHP SDK and
   both native hosts, with PHP and Android regression coverage.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.7"
+version = "0.6.8"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.7"
+version = "0.6.8"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/modules/SmsModuleInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/modules/SmsModuleInstrumentedTest.kt
@@ -1,0 +1,33 @@
+package dev.pam.nativeapp.modules
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SmsModuleInstrumentedTest {
+    @Test
+    fun composerIntentTargetsOnlySmsAppsAndCarriesDraft() {
+        val intent = SmsModule.smsIntent(
+            listOf("+5511999990000", "+5511888880000"),
+            "Convite do Zé Chat",
+        )
+
+        assertEquals(Intent.ACTION_SENDTO, intent.action)
+        assertEquals("smsto", intent.data?.scheme)
+        assertEquals(
+            "+5511999990000;+5511888880000",
+            intent.data?.schemeSpecificPart,
+        )
+        assertEquals("Convite do Zé Chat", intent.getStringExtra("sms_body"))
+    }
+
+    @Test
+    fun emptyBodyDoesNotAddAnSmsExtra() {
+        val intent = SmsModule.smsIntent(listOf("+5511999990000"), "")
+
+        assertEquals(false, intent.hasExtra("sms_body"))
+    }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,10 @@
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="geo" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="smsto" />
+        </intent>
     </queries>
 
     <application

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/NativeModuleRegistry.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/NativeModuleRegistry.kt
@@ -21,6 +21,7 @@ class NativeModuleRegistry(context: Context) : AutoCloseable {
         (context as? dev.pam.nativeapp.PamActivity)?.let(::PermissionsModule)
     private val sensors = SensorsModule(context)
     private val contacts = ContactsModule(context)
+    private val sms = (context as? android.app.Activity)?.let(::SmsModule)
     private val mediaLibrary = MediaLibraryModule(context)
     private val location = LocationModule(context)
     private val audioRecorder = AudioRecorderModule(context)
@@ -40,6 +41,7 @@ class NativeModuleRegistry(context: Context) : AutoCloseable {
         permissions?.let { put("permissions", it) }
         put("sensors", sensors)
         put("contacts", contacts)
+        sms?.let { put("sms", it) }
         put("media-library", mediaLibrary)
         put("location", location)
         put("audio-recorder", audioRecorder)

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/SmsModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/SmsModule.kt
@@ -1,0 +1,69 @@
+package dev.pam.nativeapp.modules
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import dev.pam.nativeapp.protocol.WireMap
+import dev.pam.nativeapp.protocol.WireValue
+
+internal class SmsModule(private val activity: Activity) : NativeModule {
+    private val main = Handler(Looper.getMainLooper())
+
+    override fun invoke(method: String, payload: ByteArray, completion: ModuleCompletion) {
+        main.post {
+            runCatching {
+                when (method) {
+                    "isAvailable" -> availability(completion)
+                    "compose" -> compose(payload, completion)
+                    else -> error("Unknown SMS method $method")
+                }
+            }.onFailure { error ->
+                completion.complete(
+                    ModuleResultStatus.FAILURE,
+                    (error.message ?: "SMS operation failed").toByteArray(),
+                )
+            }
+        }
+    }
+
+    private fun availability(completion: ModuleCompletion) {
+        val available = smsIntent(listOf("0"), "").resolveActivity(activity.packageManager) != null
+        completion.complete(
+            ModuleResultStatus.SUCCESS,
+            WireMap.encode(mapOf("available" to WireValue.Flag(available))),
+        )
+    }
+
+    private fun compose(payload: ByteArray, completion: ModuleCompletion) {
+        val values = WireMap.decode(payload)
+        val recipients = values.text("recipients").lineSequence()
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .distinct()
+            .toList()
+        require(recipients.isNotEmpty()) { "SMS requires at least one recipient" }
+        require(recipients.size <= 50) { "SMS supports at most 50 recipients" }
+        require(recipients.all { it.toByteArray().size <= 128 }) { "SMS recipient is too long" }
+        val body = values.text("body")
+        require(body.toByteArray().size <= 10_000) { "SMS body is too long" }
+        val intent = smsIntent(recipients, body)
+        require(intent.resolveActivity(activity.packageManager) != null) {
+            "No SMS application is available"
+        }
+        activity.startActivity(intent)
+        completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))
+    }
+
+    companion object {
+        internal fun smsIntent(recipients: List<String>, body: String): Intent =
+            Intent(Intent.ACTION_SENDTO).apply {
+                data = Uri.fromParts("smsto", recipients.joinToString(";"), null)
+                if (body.isNotEmpty()) putExtra("sms_body", body)
+            }
+    }
+
+    private fun Map<String, WireValue>.text(key: String): String =
+        (this[key] as? WireValue.Text)?.value ?: ""
+}

--- a/docs/components.md
+++ b/docs/components.md
@@ -416,6 +416,33 @@ subsequent offsets start exactly at the requested contact. This makes the
 default `Contacts::all()` call and explicit paginated reads use the same
 zero-based contract on Android and iOS.
 
+## SMS drafts
+
+Use `Sms::isAvailable()` before presenting an invite action when the product
+requires an SMS app. `Sms::compose()` opens the platform composer with the
+recipients and body already filled; it never sends a message automatically.
+
+```php
+use Pam\Native\System\Sms;
+
+Sms::isAvailable(function (bool $available): void {
+    if (!$available) {
+        return;
+    }
+
+    Sms::compose(
+        ['+5511999990000'],
+        'Vem conversar comigo no Zé Chat!',
+    );
+});
+```
+
+Android uses an `ACTION_SENDTO` intent constrained to the `smsto:` scheme, so
+the chooser cannot offer unrelated share targets. iOS presents
+`MFMessageComposeViewController`. Applications should provide an unavailable
+state because emulators, tablets and devices without a configured messaging
+service can legitimately return `false`.
+
 ## Declarative scroll views
 
 `ScrollView` accepts one or many direct children in `.pam.php` templates. PAM

--- a/ios/Sources/PamNative/Modules/NativeModuleRegistry.swift
+++ b/ios/Sources/PamNative/Modules/NativeModuleRegistry.swift
@@ -14,6 +14,7 @@ public final class NativeModuleRegistry: @unchecked Sendable {
     private let permissions = PermissionsModule()
     private let sensors = SensorsModule()
     private let contacts = ContactsModule()
+    private let sms = SmsModule()
     private let location = LocationModule()
     private let audioRecorder = AudioRecorderModule()
     private let imageEditor = ImageEditorModule()
@@ -34,6 +35,7 @@ public final class NativeModuleRegistry: @unchecked Sendable {
             "permissions": permissions,
             "sensors": sensors,
             "contacts": contacts,
+            "sms": sms,
             "location": location,
             "audio-recorder": audioRecorder,
             "image-editor": imageEditor,

--- a/ios/Sources/PamNative/Modules/SmsModule.swift
+++ b/ios/Sources/PamNative/Modules/SmsModule.swift
@@ -1,0 +1,91 @@
+import Foundation
+import MessageUI
+import UIKit
+
+final class SmsModule: NSObject, NativeModule, MFMessageComposeViewControllerDelegate {
+    func invoke(method: String, payload: Data, completion: @escaping ModuleCompletion) {
+        switch method {
+        case "isAvailable":
+            do {
+                completion(.success, try WireMap.encode([
+                    "available": .flag(MFMessageComposeViewController.canSendText()),
+                ]))
+            } catch {
+                completion(.failure, Data(error.localizedDescription.utf8))
+            }
+        case "compose":
+            compose(payload: payload, completion: completion)
+        default:
+            completion(.failure, Data("Unknown SMS method \(method)".utf8))
+        }
+    }
+
+    private func compose(payload: Data, completion: @escaping ModuleCompletion) {
+        do {
+            let values = try WireMap.decode(payload)
+            guard case let .text(rawRecipients)? = values["recipients"] else {
+                throw SmsError.invalidRecipients
+            }
+            let recipients = rawRecipients
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            guard (1...50).contains(recipients.count),
+                  recipients.allSatisfy({ $0.utf8.count <= 128 }) else {
+                throw SmsError.invalidRecipients
+            }
+            let body: String
+            if case let .text(value)? = values["body"] { body = value } else { body = "" }
+            guard body.utf8.count <= 10_000 else { throw SmsError.bodyTooLong }
+            guard MFMessageComposeViewController.canSendText() else {
+                throw SmsError.unavailable
+            }
+            DispatchQueue.main.async { [weak self] in
+                guard let self, let presenter = Self.presenter() else {
+                    completion(.failure, Data(SmsError.noPresenter.localizedDescription.utf8))
+                    return
+                }
+                let controller = MFMessageComposeViewController()
+                controller.messageComposeDelegate = self
+                controller.recipients = recipients
+                controller.body = body
+                presenter.present(controller, animated: true) {
+                    completion(.success, Data())
+                }
+            }
+        } catch {
+            completion(.failure, Data(error.localizedDescription.utf8))
+        }
+    }
+
+    func messageComposeViewController(
+        _ controller: MFMessageComposeViewController,
+        didFinishWith result: MessageComposeResult
+    ) {
+        controller.dismiss(animated: true)
+    }
+
+    private static func presenter() -> UIViewController? {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        var controller = scenes.flatMap(\.windows).first(where: \.isKeyWindow)?.rootViewController
+            ?? scenes.flatMap(\.windows).first(where: { !$0.isHidden })?.rootViewController
+        while let presented = controller?.presentedViewController { controller = presented }
+        return controller
+    }
+}
+
+private enum SmsError: LocalizedError {
+    case invalidRecipients
+    case bodyTooLong
+    case unavailable
+    case noPresenter
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRecipients: return "SMS requires between 1 and 50 valid recipients"
+        case .bodyTooLong: return "SMS body exceeds 10000 bytes"
+        case .unavailable: return "SMS is unavailable"
+        case .noPresenter: return "No view controller is available for SMS"
+        }
+    }
+}

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.7';
+    public const string SDK_VERSION = '0.6.8';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/System/Sms.php
+++ b/packages/native/src/System/Sms.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\System;
+
+use Closure;
+use InvalidArgumentException;
+use Pam\Native\Internal\Wire;
+use Pam\Native\ModuleResultStatus;
+use Pam\Native\Modules\NativeModules;
+use RuntimeException;
+
+final class Sms
+{
+    private function __construct()
+    {
+    }
+
+    /** @param Closure(bool): void $callback */
+    public static function isAvailable(Closure $callback): int
+    {
+        return NativeModules::call(
+            'sms',
+            'isAvailable',
+            [],
+            static function ($result) use ($callback): void {
+                if ($result->status === ModuleResultStatus::Failure) {
+                    throw new RuntimeException($result->payload);
+                }
+                $values = Wire::decodeMap($result->payload);
+                $callback((bool) ($values['available'] ?? false));
+            },
+        );
+    }
+
+    /**
+     * Opens the platform SMS composer without sending a message automatically.
+     *
+     * @param list<string> $recipients
+     */
+    public static function compose(
+        array $recipients,
+        string $body = '',
+        ?Closure $opened = null,
+    ): int {
+        $normalized = [];
+        foreach ($recipients as $recipient) {
+            $recipient = trim($recipient);
+            if ($recipient === '') {
+                continue;
+            }
+            if (str_contains($recipient, "\n") || str_contains($recipient, "\r")) {
+                throw new InvalidArgumentException('SMS recipients cannot contain line breaks.');
+            }
+            if (strlen($recipient) > 128) {
+                throw new InvalidArgumentException('SMS recipient exceeds 128 bytes.');
+            }
+            $normalized[] = $recipient;
+        }
+        $normalized = array_values(array_unique($normalized));
+        if ($normalized === [] || count($normalized) > 50) {
+            throw new InvalidArgumentException('SMS requires between 1 and 50 recipients.');
+        }
+        if (strlen($body) > 10_000) {
+            throw new InvalidArgumentException('SMS body exceeds 10000 bytes.');
+        }
+
+        return NativeModules::call(
+            'sms',
+            'compose',
+            ['recipients' => implode("\n", $normalized), 'body' => $body],
+            static function ($result) use ($opened): void {
+                if ($result->status === ModuleResultStatus::Failure) {
+                    throw new RuntimeException($result->payload);
+                }
+                $opened?->__invoke();
+            },
+        );
+    }
+}

--- a/packages/native/src/System/Sms.php
+++ b/packages/native/src/System/Sms.php
@@ -18,14 +18,19 @@ final class Sms
     }
 
     /** @param Closure(bool): void $callback */
-    public static function isAvailable(Closure $callback): int
+    public static function isAvailable(Closure $callback, ?Closure $failed = null): int
     {
         return NativeModules::call(
             'sms',
             'isAvailable',
             [],
-            static function ($result) use ($callback): void {
+            static function ($result) use ($callback, $failed): void {
                 if ($result->status === ModuleResultStatus::Failure) {
+                    if ($failed !== null) {
+                        $failed($result->payload);
+
+                        return;
+                    }
                     throw new RuntimeException($result->payload);
                 }
                 $values = Wire::decodeMap($result->payload);
@@ -43,6 +48,7 @@ final class Sms
         array $recipients,
         string $body = '',
         ?Closure $opened = null,
+        ?Closure $failed = null,
     ): int {
         $normalized = [];
         foreach ($recipients as $recipient) {
@@ -70,8 +76,13 @@ final class Sms
             'sms',
             'compose',
             ['recipients' => implode("\n", $normalized), 'body' => $body],
-            static function ($result) use ($opened): void {
+            static function ($result) use ($opened, $failed): void {
                 if ($result->status === ModuleResultStatus::Failure) {
+                    if ($failed !== null) {
+                        $failed($result->payload);
+
+                        return;
+                    }
                     throw new RuntimeException($result->payload);
                 }
                 $opened?->__invoke();

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -148,6 +148,7 @@ use Pam\Native\System\Clipboard;
 use Pam\Native\System\Contacts;
 use Pam\Native\System\DeviceInfo;
 use Pam\Native\System\Sensors;
+use Pam\Native\System\Sms;
 use Pam\Native\System\Location;
 use Pam\Native\System\Files;
 use Pam\Native\System\MediaLibrary;
@@ -2999,6 +3000,54 @@ $assert(
     'MediaLibrary albums must decode typed album metadata.',
 );
 
+$smsAvailable = null;
+$smsAvailabilityRequest = Sms::isAvailable(
+    static function (bool $available) use (&$smsAvailable): void {
+        $smsAvailable = $available;
+    },
+);
+$smsAvailabilityCall = TestDiagnostics::$moduleCall;
+$assert(
+    $smsAvailabilityCall !== null
+        && $smsAvailabilityCall['requestId'] === $smsAvailabilityRequest
+        && $smsAvailabilityCall['module'] === 'sms'
+        && $smsAvailabilityCall['method'] === 'isAvailable',
+    'SMS facade must query platform availability.',
+);
+Runtime::dispatchModuleResult(
+    $smsAvailabilityRequest,
+    ModuleResultStatus::Success->value,
+    Wire::map(['available' => true]),
+);
+$assert($smsAvailable === true, 'SMS facade must decode platform availability.');
+
+$smsOpened = false;
+$smsComposeRequest = Sms::compose(
+    [' +55 11 99999-0000 ', '+55 11 99999-0000'],
+    'Convite do Zé Chat',
+    static function () use (&$smsOpened): void {
+        $smsOpened = true;
+    },
+);
+$smsComposeCall = TestDiagnostics::$moduleCall;
+$assert(
+    $smsComposeCall !== null
+        && $smsComposeCall['requestId'] === $smsComposeRequest
+        && $smsComposeCall['module'] === 'sms'
+        && $smsComposeCall['method'] === 'compose'
+        && Wire::decodeMap($smsComposeCall['payload']) === [
+            'recipients' => '+55 11 99999-0000',
+            'body' => 'Convite do Zé Chat',
+        ],
+    'SMS facade must normalize recipients and encode the draft.',
+);
+Runtime::dispatchModuleResult(
+    $smsComposeRequest,
+    ModuleResultStatus::Success->value,
+    '',
+);
+$assert($smsOpened, 'SMS facade must report a presented composer.');
+
 $incomingShare = null;
 $incomingShareRequestId = IncomingShares::initial(
     static function (?IncomingShare $share) use (&$incomingShare): void {
@@ -4985,8 +5034,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.7',
-    'The runtime SDK contract must match the 0.6.7 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.8',
+    'The runtime SDK contract must match the 0.6.8 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -3047,6 +3047,23 @@ Runtime::dispatchModuleResult(
     '',
 );
 $assert($smsOpened, 'SMS facade must report a presented composer.');
+$smsFailure = '';
+$smsFailureRequest = Sms::compose(
+    ['+5511999990000'],
+    'Convite',
+    failed: static function (string $message) use (&$smsFailure): void {
+        $smsFailure = $message;
+    },
+);
+Runtime::dispatchModuleResult(
+    $smsFailureRequest,
+    ModuleResultStatus::Failure->value,
+    'SMS unavailable',
+);
+$assert(
+    $smsFailure === 'SMS unavailable',
+    'SMS facade must expose recoverable native failures to applications.',
+);
 
 $incomingShare = null;
 $incomingShareRequestId = IncomingShares::initial(


### PR DESCRIPTION
## Summary
- expose PHP SMS availability and draft-composer APIs
- open SMS-only Android intents and the native iOS MessageUI composer
- validate payloads and add PHP/Android regression coverage

## Verification
- PHP SDK suite
- Rust workspace suite (serial)
- Android debug and AndroidTest compilation
- SMS instrumentation tests on API 36