### PR TITLE
fix(scroll): normalize declarative deceleration rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.9 - 2026-08-04
+
+- Normalize declarative `ScrollView` deceleration aliases so `normal` and
+  `fast` encode as numeric protocol values accepted by both native hosts.
+- Clamp declarative numeric deceleration rates to the supported `0...1` range
+  and cover alias and numeric behavior with PHP SDK regressions.
+
 ## 0.6.8 - 2026-08-04
 
 - Add `Sms::isAvailable()` and `Sms::compose()` for querying platform support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.8"
+version = "0.6.9"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.8"
+version = "0.6.9"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/docs/components.md
+++ b/docs/components.md
@@ -468,6 +468,10 @@ The explicit PHP API remains intentionally lower-level:
 `Scroll::make($content)` receives exactly one content element. Use a `Row` or
 `Column` yourself when authoring an imperative element tree.
 
+Declarative scroll views accept `decelerationRate="normal"` (`0.985`) and
+`decelerationRate="fast"` (`0.9`) aliases as well as numeric values from `0`
+through `1`. Numeric values outside that range are clamped before encoding.
+
 Observed logical offsets can be restored without controlling the scroll on
 every render:
 

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -1994,6 +1994,17 @@ final class TemplateRenderer
                 'on-drag' => ScrollKeyboardDismissMode::OnDrag->value,
                 'interactive' => ScrollKeyboardDismissMode::Interactive->value,
             ]),
+            PropKey::ScrollDecelerationRate => match ($value) {
+                'normal' => 0.985,
+                'fast' => 0.9,
+                default => min(
+                    1.0,
+                    max(
+                        0.0,
+                        self::floatValue($value, 'ScrollView decelerationRate'),
+                    ),
+                ),
+            },
             PropKey::ActivitySize => match ($value) {
                 'small' => ActivityIndicatorSize::Small
                     ->densityIndependentPixels(),

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.8';
+    public const string SDK_VERSION = '0.6.9';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1882,6 +1882,7 @@ $nativeControlTemplate = TemplateRenderer::render(
         scrollRequest="9"
         pagingEnabled="true"
         snapToInterval="80"
+        decelerationRate="fast"
         overScrollMode="never"
         keyboardDismissMode="on-drag"
     >
@@ -1933,6 +1934,8 @@ $assert(
         && $templateScroll->properties()[PropKey::ScrollRequest->value] === 9
         && $templateScroll->properties()[PropKey::ScrollPagingEnabled->value] === true
         && $templateScroll->properties()[PropKey::ScrollSnapInterval->value] === 80
+        && $templateScroll
+            ->properties()[PropKey::ScrollDecelerationRate->value] === 0.9
         && $templateIndicator->properties()[PropKey::ActivityAnimating->value] === false
         && $templateIndicator
             ->properties()[PropKey::ActivityHidesWhenStopped->value] === false
@@ -1950,6 +1953,27 @@ $assert(
         && $templateDrawing->properties()[PropKey::DrawingClearRequest->value] === 4
         && $templateDrawing->properties()[PropKey::DrawingUndoRequest->value] === 5,
     'Native control tags must map to typed scroll, indicator, switch and drawing protocols.',
+);
+$normalDecelerationScroll = TemplateRenderer::render(
+    TemplateCompiler::compile(
+        '<ScrollView decelerationRate="normal"><Text>Normal</Text></ScrollView>',
+    ),
+    null,
+    [],
+);
+$boundedDecelerationScroll = TemplateRenderer::render(
+    TemplateCompiler::compile(
+        '<ScrollView decelerationRate="1.5"><Text>Bounded</Text></ScrollView>',
+    ),
+    null,
+    [],
+);
+$assert(
+    $normalDecelerationScroll
+        ->properties()[PropKey::ScrollDecelerationRate->value] === 0.985
+        && $boundedDecelerationScroll
+            ->properties()[PropKey::ScrollDecelerationRate->value] === 1.0,
+    'Declarative ScrollView deceleration rates must normalize named aliases and bound numeric values.',
 );
 
 $listElement = FlatList::make(['One', 'Two', 'Three'])
@@ -5051,8 +5075,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.8',
-    'The runtime SDK contract must match the 0.6.8 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.9',
+    'The runtime SDK contract must match the 0.6.9 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- accept `normal` and `fast` aliases for declarative ScrollView deceleration
- clamp numeric template values to the native 0...1 contract
- document and regression-test the behavior; bump SDK to 0.6.9

## Validation
- `php packages/native/tests/run.php`
- `cargo test --workspace`
- `./gradlew :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin`
- `git diff --check`