### PR TITLE
fix(android): reveal focused input above keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.10 - 2026-08-04
+
+- Reveal the focused input automatically when padding-mode Android keyboard
+  avoidance owns a contained vertical scroll view.
+- Preserve a 16 dp focus clearance and honor `keyboardVerticalOffset` as extra
+  space for adjacent form actions, with API 26–36 instrumentation coverage.
+
 ## 0.6.9 - 2026-08-04
 
 - Normalize declarative `ScrollView` deceleration aliases so `normal` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.9"
+version = "0.6.10"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.9"
+version = "0.6.10"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamScrollContainerInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamScrollContainerInstrumentedTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import dev.pam.nativeapp.PamTestActivity
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -171,6 +172,51 @@ class PamScrollContainerInstrumentedTest {
             instrumentation.waitForIdleSync()
             onMain(instrumentation) {
                 assertEquals(200, scroll.snapshotOffsetPixels().second)
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
+    @Test
+    fun keyboardInsetScrollsFocusedFormTargetIntoVisibleViewport() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var scroll: PamScrollContainer
+            lateinit var input: View
+            onMain(instrumentation) {
+                scroll = PamScrollContainer(activity)
+                val column = FrameLayout(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        1_000,
+                    )
+                }
+                input = View(activity)
+                column.addView(
+                    input,
+                    FrameLayout.LayoutParams(300, 80).apply { topMargin = 720 },
+                )
+                scroll.insert(column)
+                activity.host.addView(scroll, FrameLayout.LayoutParams(300, 400))
+                relayout(activity.host)
+
+                scroll.setKeyboardAvoidanceInset(200)
+                relayout(activity.host)
+                scroll.ensureKeyboardTargetVisible(input)
+            }
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                val targetLocation = IntArray(2)
+                val scrollLocation = IntArray(2)
+                input.getLocationOnScreen(targetLocation)
+                scroll.getLocationOnScreen(scrollLocation)
+                val visibleBottom =
+                    scrollLocation[1] + scroll.height - scroll.keyboardAvoidanceInsetPixels()
+
+                assertTrue(scroll.snapshotOffsetPixels().second > 0)
+                assertTrue(targetLocation[1] + input.height <= visibleBottom)
             }
         } finally {
             activity.finish()

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
@@ -4808,9 +4808,12 @@ class PamRenderer(
             }
             state.keyboardAvoidingScrollId = scrollId
         }
-        scroll?.second?.setKeyboardAvoidanceInset(
-            keyboard,
-        )
+        scroll?.second?.let { container ->
+            container.setKeyboardAvoidanceInset(keyboard)
+            if (keyboard > 0) {
+                state.keyboardFocusedInput?.let(container::ensureKeyboardTargetVisible)
+            }
+        }
         if (keyboard > 0) {
             view.post { restoreKeyboardAvoidingInput(state) }
         }

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamScrollContainer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamScrollContainer.kt
@@ -255,6 +255,32 @@ internal class PamScrollContainer(context: Context) : FrameLayout(context) {
 
     fun keyboardAvoidanceInsetPixels(): Int = keyboardAvoidanceInsetPx
 
+    fun ensureKeyboardTargetVisible(target: View) {
+        if (keyboardAvoidanceInsetPx <= 0 || horizontal) return
+        activeScroll.post {
+            if (
+                !isAttachedToWindow ||
+                !target.isAttachedToWindow ||
+                !isDescendantOfContent(target)
+            ) {
+                return@post
+            }
+            val rect = Rect(0, 0, target.width, target.height)
+            content.offsetDescendantRectToMyCoords(target, rect)
+            val current = primaryCurrentOffset()
+            val clearance = dp(KEYBOARD_TARGET_CLEARANCE_DP)
+            val visibleEnd = current +
+                (activeScroll.height - keyboardAvoidanceInsetPx).coerceAtLeast(0)
+            val next = when {
+                rect.bottom + clearance > visibleEnd ->
+                    current + rect.bottom + clearance - visibleEnd
+                rect.top - clearance < current -> rect.top - clearance
+                else -> current
+            }
+            if (next != current) scrollToPrimary(next.coerceAtLeast(0))
+        }
+    }
+
     fun setOnViewportChanged(listener: ((Float, Float) -> Unit)?) {
         viewportChanged = listener
     }
@@ -409,6 +435,15 @@ internal class PamScrollContainer(context: Context) : FrameLayout(context) {
         (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
             .hideSoftInputFromWindow(focused.windowToken, 0)
         focused.clearFocus()
+    }
+
+    private fun isDescendantOfContent(target: View): Boolean {
+        var current: View? = target
+        while (current != null) {
+            if (current === content) return true
+            current = current.parent as? View
+        }
+        return false
     }
 
     private fun configurable(): ConfigurableScroll =
@@ -702,6 +737,7 @@ internal class PamScrollContainer(context: Context) : FrameLayout(context) {
         const val KEYBOARD_DISMISS_NONE = 1
         const val KEYBOARD_DISMISS_INTERACTIVE = 3
         const val NORMAL_DECELERATION_RATE = 0.985f
+        const val KEYBOARD_TARGET_CLEARANCE_DP = 16f
 
         fun adjustedVelocity(velocity: Int, rate: Float): Int =
             (velocity * (rate / NORMAL_DECELERATION_RATE)).roundToInt()

--- a/docs/android-safe-area.md
+++ b/docs/android-safe-area.md
@@ -19,6 +19,10 @@ their actual on-screen bounds.
 - `KeyboardAvoidingView` calculates overlap from window and view geometry. IME
   movement does not assume a fixed keyboard height or subtract a manufacturer
   navigation bar twice.
+- Padding-mode keyboard avoidance gives a contained vertical `ScrollView` the
+  overlap inset and automatically reveals its focused input with 16 dp of
+  clearance. `keyboardVerticalOffset` can reserve additional space for a form
+  CTA that must remain visible with the field.
 - While a panning container is translated, touch coordinates are remapped to
   its visible descendants. With the IME closed only text inputs use the
   geometry-aware fallback, preventing touches from leaking through a modal to

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.9';
+    public const string SDK_VERSION = '0.6.10';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -5075,8 +5075,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.9',
-    'The runtime SDK contract must match the 0.6.9 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.10',
+    'The runtime SDK contract must match the 0.6.10 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- reveal the focused descendant inside padding-mode keyboard avoidance
- preserve 16 dp clearance while honoring keyboardVerticalOffset
- document and instrument the behavior across the Android CI matrix

## Validation
- PHP SDK tests
- Rust workspace tests
- Android unit tests and androidTest compilation
- connected API 36 instrumentation (6/6)