### PR TITLE
fix(layout): center intrinsic dialog cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.11 - 2026-08-04
+
+- Measure dialog-modal cards at their authored percentage or fixed width and
+  intrinsic content height in the shared layout engine, then center the result
+  in the viewport instead of assigning an implicit full-screen height.
+- Preserve explicit dialog dimensions, min/max constraints, edge-pinned portal
+  content and the existing full-screen/sheet presentation contracts.
+
 ## 0.6.10 - 2026-08-04
 
 - Reveal the focused input automatically when padding-mode Android keyboard

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.10"
+version = "0.6.11"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.10"
+version = "0.6.11"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/crates/pam-native-engine/src/layout.rs
+++ b/crates/pam-native-engine/src/layout.rs
@@ -354,15 +354,95 @@ fn layout_node(
         }
         return Ok(());
     }
-    if matches!(
-        node.kind,
-        NodeKind::Modal | NodeKind::RefreshControl | NodeKind::NavigationHost | NodeKind::TabHost
-    ) {
+    if node.kind == NodeKind::Modal {
+        let dialog = integer(node, PropKey::ModalPresentation).unwrap_or(2) == 2;
         for child in node_children {
             if !visible(child) {
                 continue;
             }
-            layout_node(context, child.id, inner, true, depth + 1, output)?;
+            if !dialog {
+                layout_node(context, child.id, inner, true, depth + 1, output)?;
+                continue;
+            }
+
+            let left = dimension(child, PropKey::Left, PropKey::LeftPercent, inner.width);
+            let right = dimension(child, PropKey::Right, PropKey::RightPercent, inner.width);
+            let top = dimension(child, PropKey::Top, PropKey::TopPercent, inner.height);
+            let bottom = dimension(child, PropKey::Bottom, PropKey::BottomPercent, inner.height);
+            let width = constrained(
+                dimension(child, PropKey::Width, PropKey::WidthPercent, inner.width)
+                    .or_else(|| match (left, right) {
+                        (Some(left), Some(right)) => Some((inner.width - left - right).max(0.0)),
+                        _ => None,
+                    })
+                    .unwrap_or(intrinsic_extent(
+                        context.children,
+                        child,
+                        Axis::Horizontal,
+                        inner.width,
+                        inner.height,
+                        context.text_scale,
+                        context.text_metrics,
+                        depth + 1,
+                    )?),
+                number(child, PropKey::MinWidth),
+                dimension(
+                    child,
+                    PropKey::MaxWidth,
+                    PropKey::MaxWidthPercent,
+                    inner.width,
+                ),
+            )?
+            .min(inner.width);
+            let height = constrained(
+                dimension(child, PropKey::Height, PropKey::HeightPercent, inner.height)
+                    .or_else(|| match (top, bottom) {
+                        (Some(top), Some(bottom)) => Some((inner.height - top - bottom).max(0.0)),
+                        _ => None,
+                    })
+                    .unwrap_or(intrinsic_extent(
+                        context.children,
+                        child,
+                        Axis::Vertical,
+                        width,
+                        inner.height,
+                        context.text_scale,
+                        context.text_metrics,
+                        depth + 1,
+                    )?),
+                number(child, PropKey::MinHeight),
+                dimension(
+                    child,
+                    PropKey::MaxHeight,
+                    PropKey::MaxHeightPercent,
+                    inner.height,
+                ),
+            )?
+            .min(inner.height);
+            layout_node(
+                context,
+                child.id,
+                Layout {
+                    x: inner.x + (inner.width - width) / 2.0,
+                    y: inner.y + (inner.height - height) / 2.0,
+                    width,
+                    height,
+                },
+                false,
+                depth + 1,
+                output,
+            )?;
+        }
+        return Ok(());
+    }
+    if matches!(
+        node.kind,
+        NodeKind::RefreshControl | NodeKind::NavigationHost | NodeKind::TabHost
+    ) {
+        for child in node_children {
+            if visible(child) {
+                layout_node(context, child.id, inner, true, depth + 1, output)?;
+            }
         }
         return Ok(());
     }
@@ -3085,6 +3165,75 @@ mod tests {
         assert_eq!(layouts[&4].width, 360.0);
         assert_eq!(layouts[&4].height, 640.0);
         assert_eq!(layouts[&5].y, 30.0);
+    }
+
+    #[test]
+    fn dialog_modal_centers_percent_width_card_at_intrinsic_height() {
+        let tree = Tree {
+            root: 1,
+            nodes: BTreeMap::from([
+                (1, node(1, 0, 0, NodeKind::Column, [])),
+                (
+                    2,
+                    node(
+                        2,
+                        1,
+                        0,
+                        NodeKind::Modal,
+                        [(PropKey::ModalPresentation, PropValue::Integer(2))],
+                    ),
+                ),
+                (
+                    3,
+                    node(
+                        3,
+                        2,
+                        0,
+                        NodeKind::Column,
+                        [
+                            (PropKey::WidthPercent, PropValue::Float(88.0)),
+                            (PropKey::Padding, PropValue::Float(20.0)),
+                            (PropKey::Gap, PropValue::Float(8.0)),
+                        ],
+                    ),
+                ),
+                (
+                    4,
+                    node(
+                        4,
+                        3,
+                        0,
+                        NodeKind::Text,
+                        [(PropKey::Height, PropValue::Float(40.0))],
+                    ),
+                ),
+                (
+                    5,
+                    node(
+                        5,
+                        3,
+                        1,
+                        NodeKind::Text,
+                        [(PropKey::Height, PropValue::Float(20.0))],
+                    ),
+                ),
+            ]),
+        };
+
+        let layouts = calculate(
+            &tree,
+            Size {
+                width: 360.0,
+                height: 640.0,
+            },
+        )
+        .expect("dialog intrinsic layout");
+        let card = layouts[&3];
+
+        assert!((card.width - 316.8).abs() < 0.001);
+        assert!((card.x - 21.6).abs() < 0.001);
+        assert_eq!(card.height, 108.0);
+        assert_eq!(card.y, 266.0);
     }
 
     #[test]

--- a/docs/components.md
+++ b/docs/components.md
@@ -397,7 +397,10 @@ Inline properties remain useful for dynamic values and isolated exceptions:
 on its single content card and centers that card over the native backdrop. Use
 an explicit card width (and optional maximum width) plus intrinsic content
 height for compact confirmations. Dialog presentation does not turn the card
-into a full-screen page.
+into a full-screen page. Percentage widths are resolved against the modal
+viewport before vertical intrinsic measurement, so wrapped copy and action rows
+produce the same compact centered card on Android and iOS. Explicit height,
+minimum/maximum constraints and edge-pinned portal content remain authoritative.
 
 `ModalPresentation::FullScreen` continues to fill the available window, while
 `ModalPresentation::Sheet` fills the width and uses its selected snap-point

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.10';
+    public const string SDK_VERSION = '0.6.11';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -5075,8 +5075,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.10',
-    'The runtime SDK contract must match the 0.6.10 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.11',
+    'The runtime SDK contract must match the 0.6.11 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- measure dialog children at authored fixed/percentage width and intrinsic content height
- center compact dialog frames while preserving explicit bounds, edge-pinned portals, sheets, and full-screen modals
- bump the PAM Native package/runtime contract to 0.6.11 and document the corrected behavior

## Validation
- `cargo test --workspace` (60 engine + 7 protocol tests)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `php packages/native/tests/run.php`
- `android/gradlew :app:testDebugUnitTest`
- API 36 `PamModalHostInstrumentedTest` (2 tests)
- `android/gradlew :app:lintDebug :app:assembleRelease`
- ZeChat API 36 physical reproduction: 88%-wide intrinsic delete confirmation is compact and centered
