### PR TITLE
fix: validate template contracts at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.12 - 2026-08-04
+
+- Reject malformed `p-for` directives during template compilation instead of
+  deferring the deterministic failure until the component renders on-device.
+- Validate that declarative `GestureDetector` trees resolve to exactly one
+  child across conditional branches, while accepting complete mutually
+  exclusive `p-if`/`p-else-if`/`p-else` chains.
+
 ## 0.6.11 - 2026-08-04
 
 - Measure dialog-modal cards at their authored percentage or fixed width and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.11"
+version = "0.6.12"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.11"
+version = "0.6.12"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/docs/components.md
+++ b/docs/components.md
@@ -132,6 +132,16 @@ current one-based number. Zero and negative integers render nothing:
 </Column>
 ```
 
+`p-for` syntax is validated while the component template is compiled. Invalid
+indexed forms such as `$item, $index in $items` fail the build; use the loop
+value itself, enrich the presented item with an integer index, or use an integer
+source when an explicit one-based number is needed.
+
+`GestureDetector` must resolve to exactly one native child for every state.
+Wrap layered content in a `View`, or use a complete `p-if`/`p-else-if`/`p-else`
+chain when the child type changes. The compiler rejects zero-child and
+multi-child detector trees before they reach a device.
+
 `v-if`, `v-else-if`, `v-else`, and `v-for` remain accepted temporarily when
 migrating existing components. They are deprecated aliases; new code and
 editor metadata use the distinctive `p-*` PAM directives.

--- a/packages/native/src/Internal/TemplateCompiler.php
+++ b/packages/native/src/Internal/TemplateCompiler.php
@@ -152,7 +152,107 @@ final class TemplateCompiler
             );
         }
 
+        self::validateContracts($root);
+
         return $root;
+    }
+
+    private static function validateContracts(CompiledTemplateNode $node): void
+    {
+        $forAttribute = self::directiveAttribute($node, 'p-for', 'v-for');
+        if ($forAttribute !== null) {
+            $directive = $node->attributes[$forAttribute];
+            if (
+                !is_string($directive)
+                || preg_match(
+                    '/^\s*\$?([A-Za-z_][A-Za-z0-9_]*)\s+in\s+(.+)\s*$/D',
+                    $directive,
+                ) !== 1
+            ) {
+                throw new RuntimeException(
+                    "{$forAttribute} must use \"\$item in \$items\" syntax at {$node->source}:{$node->line}:{$node->column}.",
+                );
+            }
+        }
+
+        if ($node->name === 'GestureDetector') {
+            [$minimum, $maximum] = self::renderedChildBounds($node->children);
+            if ($minimum !== 1 || $maximum !== 1) {
+                throw new RuntimeException(
+                    "GestureDetector must resolve to exactly one child at {$node->source}:{$node->line}:{$node->column}.",
+                );
+            }
+        }
+
+        foreach ($node->children as $child) {
+            self::validateContracts($child);
+        }
+    }
+
+    /**
+     * @param list<CompiledTemplateNode> $children
+     * @return array{int, int}
+     */
+    private static function renderedChildBounds(array $children): array
+    {
+        $minimum = 0;
+        $maximum = 0;
+        $count = count($children);
+
+        for ($index = 0; $index < $count; $index++) {
+            $child = $children[$index];
+            if (self::hasDirective($child, 'p-for', 'v-for')) {
+                return [0, PHP_INT_MAX];
+            }
+            if (self::hasDirective($child, 'p-if', 'v-if')) {
+                $hasElse = false;
+                while ($index + 1 < $count) {
+                    $next = $children[$index + 1];
+                    if (self::hasDirective($next, 'p-else-if', 'v-else-if')) {
+                        $index++;
+                        continue;
+                    }
+                    if (self::hasDirective($next, 'p-else', 'v-else')) {
+                        $index++;
+                        $hasElse = true;
+                    }
+                    break;
+                }
+                $minimum += $hasElse ? 1 : 0;
+                $maximum++;
+                continue;
+            }
+            if (
+                self::hasDirective($child, 'p-else-if', 'v-else-if')
+                || self::hasDirective($child, 'p-else', 'v-else')
+            ) {
+                return [0, PHP_INT_MAX];
+            }
+            $minimum++;
+            $maximum++;
+        }
+
+        return [$minimum, $maximum];
+    }
+
+    private static function hasDirective(
+        CompiledTemplateNode $node,
+        string $canonical,
+        string $legacy,
+    ): bool {
+        return self::directiveAttribute($node, $canonical, $legacy) !== null;
+    }
+
+    private static function directiveAttribute(
+        CompiledTemplateNode $node,
+        string $canonical,
+        string $legacy,
+    ): ?string {
+        if (array_key_exists($canonical, $node->attributes)) {
+            return $canonical;
+        }
+
+        return array_key_exists($legacy, $node->attributes) ? $legacy : null;
     }
 
     /**

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.11';
+    public const string SDK_VERSION = '0.6.12';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -941,6 +941,56 @@ $templatePinch = TemplateRenderer::render(
     null,
     [],
 );
+$invalidForRejected = false;
+try {
+    TemplateCompiler::compile(
+        '<Column><Text p-for="$item, $index in $items">Invalid</Text></Column>',
+        'invalid-indexed-loop.pam.php',
+    );
+} catch (RuntimeException $error) {
+    $invalidForRejected = str_contains($error->getMessage(), 'p-for must use');
+}
+$assert(
+    $invalidForRejected,
+    'Template compilation must reject invalid p-for syntax before runtime.',
+);
+$invalidLegacyForRejected = false;
+try {
+    TemplateCompiler::compile(
+        '<Column><Text v-for="$item, $index in $items">Invalid</Text></Column>',
+        'invalid-legacy-for.pam.php',
+    );
+} catch (RuntimeException $error) {
+    $invalidLegacyForRejected = str_contains($error->getMessage(), 'v-for must use');
+}
+$assert(
+    $invalidLegacyForRejected,
+    'Template compilation must also reject invalid legacy v-for syntax.',
+);
+$invalidGestureChildrenRejected = false;
+try {
+    TemplateCompiler::compile(
+        '<GestureDetector><Text>One</Text><Text>Two</Text></GestureDetector>',
+        'invalid-gesture-children.pam.php',
+    );
+} catch (RuntimeException $error) {
+    $invalidGestureChildrenRejected = str_contains(
+        $error->getMessage(),
+        'must resolve to exactly one child',
+    );
+}
+$assert(
+    $invalidGestureChildrenRejected,
+    'Template compilation must reject ambiguous GestureDetector children before runtime.',
+);
+TemplateCompiler::compile(
+    '<GestureDetector><Image p-if="$video" /><Text p-else>Image</Text></GestureDetector>',
+    'conditional-gesture-child.pam.php',
+);
+TemplateCompiler::compile(
+    '<GestureDetector><Image v-if="$video" /><Text v-else>Image</Text></GestureDetector>',
+    'legacy-conditional-gesture-child.pam.php',
+);
 $assert(
     $templatePinch->properties()[PropKey::GestureMinPointers->value] === 2
         && $templatePinch->properties()[PropKey::GestureMaxPointers->value] === 2,
@@ -5075,8 +5125,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.11',
-    'The runtime SDK contract must match the 0.6.11 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.12',
+    'The runtime SDK contract must match the 0.6.12 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- reject malformed `p-for`/legacy `v-for` syntax during template compilation
- enforce the exactly-one-child `GestureDetector` contract across canonical and legacy conditional chains
- document the contracts and bump the SDK to 0.6.12

## Verification
- `php packages/native/tests/run.php`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `android/gradlew testDebugUnitTest lintDebug assembleRelease`
- compiled all 55 ZeChat PAM component templates with the updated compiler