### PR TITLE
fix: decode typed event arguments in expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.13 - 2026-08-04
+
+- Decode explicitly passed `$event` expression arguments into `GestureEvent`
+  when the target method uses that type, enabling contextual handlers such as
+  `moveLayer($id, $event)` without exposing the binary wire payload.
+
 ## 0.6.12 - 2026-08-04
 
 - Reject malformed `p-for` directives during template compilation instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.12"
+version = "0.6.13"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.12"
+version = "0.6.13"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/docs/gestures.md
+++ b/docs/gestures.md
@@ -39,6 +39,23 @@ Templates use the same native contract:
 </GestureDetector>
 ```
 
+Handlers that also need item context may pass `$event` explicitly. PAM decodes
+the wire payload according to the method's `GestureEvent` type instead of
+exposing the encoded transport string:
+
+```xml
+<GestureDetector on:gestureEnd="moveLayer($layer['id'], $event)">
+    <Card />
+</GestureDetector>
+```
+
+```php
+public function moveLayer(string $layerId, GestureEvent $event): void
+{
+    $this->commitLayer($layerId, $event->translationX, $event->translationY);
+}
+```
+
 ## Native transforms
 
 For direct-manipulation surfaces such as image galleries, enable

--- a/packages/native/src/Internal/TemplateExpression.php
+++ b/packages/native/src/Internal/TemplateExpression.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Pam\Native\Internal;
 
+use Pam\Native\GestureEvent;
 use ReflectionMethod;
+use ReflectionNamedType;
 use ReflectionProperty;
 use RuntimeException;
 use Stringable;
@@ -501,6 +503,21 @@ final class TemplateExpression
         $method = new ReflectionMethod($this->scope, $name);
         if (!$method->isPublic()) {
             throw new RuntimeException("Template method {$name} must be public.");
+        }
+
+        foreach ($method->getParameters() as $index => $parameter) {
+            if (!array_key_exists($index, $arguments)) {
+                break;
+            }
+            $type = $parameter->getType();
+            if (
+                $type instanceof ReflectionNamedType
+                && !$type->isBuiltin()
+                && $type->getName() === GestureEvent::class
+                && is_string($arguments[$index])
+            ) {
+                $arguments[$index] = GestureEvent::fromPayload($arguments[$index]);
+            }
         }
 
         return $method->invokeArgs($this->scope, $arguments);

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.12';
+    public const string SDK_VERSION = '0.6.13';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -68,6 +68,7 @@ use Pam\Native\Internal\CompiledTemplateNode;
 use Pam\Native\Internal\ScopedStyleCompiler;
 use Pam\Native\Internal\ComponentLifecycle;
 use Pam\Native\Internal\TemplateCompiler;
+use Pam\Native\Internal\TemplateExpression;
 use Pam\Native\Internal\TemplateRenderer;
 use Pam\Native\Internal\TreeEncoder;
 use Pam\Native\Internal\Wire;
@@ -920,9 +921,16 @@ $assert(
 );
 $templateGestureScope = new class {
     public ?GestureEvent $event = null;
+    public string $layerId = '';
 
     public function changed(GestureEvent $event): void
     {
+        $this->event = $event;
+    }
+
+    public function changedLayer(string $layerId, GestureEvent $event): void
+    {
+        $this->layerId = $layerId;
         $this->event = $event;
     }
 };
@@ -940,6 +948,22 @@ $templatePinch = TemplateRenderer::render(
     ),
     null,
     [],
+);
+$explicitGesturePayload = Wire::map([
+    'type' => GestureType::Pan->value,
+    'state' => GestureState::Ended->value,
+    'translationX' => 42.0,
+]);
+TemplateExpression::evaluate(
+    'changedLayer("layer-1", $event)',
+    $templateGestureScope,
+    ['event' => $explicitGesturePayload],
+);
+$assert(
+    $templateGestureScope->layerId === 'layer-1'
+        && $templateGestureScope->event instanceof GestureEvent
+        && $templateGestureScope->event->translationX === 42.0,
+    'Explicit expression event arguments must honor typed GestureEvent parameters.',
 );
 $invalidForRejected = false;
 try {
@@ -5125,8 +5149,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.12',
-    'The runtime SDK contract must match the 0.6.12 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.13',
+    'The runtime SDK contract must match the 0.6.13 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- decode explicit `$event` expression arguments into `GestureEvent` based on the target method type
- document contextual gesture handlers
- bump the SDK contract to 0.6.13

## Verification
- `php packages/native/tests/run.php`
- `cargo test --workspace -q`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `./android/gradlew -p android testDebugUnitTest lintDebug assembleRelease`