### PR TITLE
feat: compose positioned image text layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.14 - 2026-08-04
+
+- Add bounded, normalized positioned text-layer compositing to
+  `ImageEditor::render()`, including scale, radian rotation, color and integer
+  presentation style for editable social-media compositions.
+
 ## 0.6.13 - 2026-08-04
 
 - Decode explicitly passed `$event` expression arguments into `GestureEvent`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.13"
+version = "0.6.14"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.13"
+version = "0.6.14"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/ImageEditorModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/ImageEditorModule.kt
@@ -8,8 +8,12 @@ import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.graphics.Matrix
 import android.graphics.Paint
+import android.graphics.RectF
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
 import dev.pam.nativeapp.render.PamDrawingCodec
 import dev.pam.nativeapp.render.PamDrawingStroke
 import dev.pam.nativeapp.protocol.WireMap
@@ -17,6 +21,7 @@ import dev.pam.nativeapp.protocol.WireValue
 import java.io.File
 import java.io.FileOutputStream
 import java.util.concurrent.Executors
+import org.json.JSONArray
 import kotlin.math.floor
 import kotlin.math.min
 
@@ -68,8 +73,10 @@ internal class ImageEditorModule(context: Context) : NativeModule, AutoCloseable
         if (filtered !== cropped) cropped.recycle()
         val adjusted = adjust(filtered, values.integer("brightness"), values.integer("contrast"), values.integer("saturation"))
         if (adjusted !== filtered) filtered.recycle()
-        val withText = compose(adjusted, values.text("overlayText").trim().take(120), false)
-        if (withText !== adjusted) adjusted.recycle()
+        val layered = composeTextLayers(adjusted, values.text("textLayers"))
+        if (layered !== adjusted) adjusted.recycle()
+        val withText = compose(layered, values.text("overlayText").trim().take(120), false)
+        if (withText !== layered) layered.recycle()
         val composed = compose(withText, values.text("sticker").trim().take(8), true)
         if (composed !== withText) withText.recycle()
         val resized = resize(composed, maxWidth, maxHeight)
@@ -189,6 +196,61 @@ internal class ImageEditorModule(context: Context) : NativeModule, AutoCloseable
         }
         val baseline = source.height * (if (sticker) 0.48f else 0.72f) - (paint.ascent() + paint.descent()) / 2f
         Canvas(output).drawText(value, source.width / 2f, baseline, paint)
+        return output
+    }
+
+    private fun composeTextLayers(source: Bitmap, encoded: String): Bitmap {
+        val layers = runCatching { JSONArray(encoded) }.getOrNull() ?: return source
+        if (layers.length() == 0) return source
+        val output = source.copy(Bitmap.Config.ARGB_8888, true)
+        val canvas = Canvas(output)
+        repeat(layers.length().coerceAtMost(80)) { index ->
+            val layer = layers.optJSONObject(index) ?: return@repeat
+            val text = layer.optString("text").trim().take(500)
+            if (text.isEmpty()) return@repeat
+            val scale = layer.optDouble("scale", 1.0).toFloat().coerceIn(0.25f, 4f)
+            val textSize = (source.width * 0.055f * scale).coerceIn(18f, source.width * 0.22f)
+            val paint = TextPaint(Paint.ANTI_ALIAS_FLAG or Paint.SUBPIXEL_TEXT_FLAG).apply {
+                color = runCatching { android.graphics.Color.parseColor(layer.optString("color", "#FFFFFF")) }
+                    .getOrDefault(android.graphics.Color.WHITE)
+                this.textSize = textSize
+                textAlign = Paint.Align.LEFT
+                typeface = android.graphics.Typeface.DEFAULT_BOLD
+                if (layer.optInt("styleType", 1) == 1) {
+                    setShadowLayer(textSize * 0.09f, 0f, textSize * 0.06f, 0xCC000000.toInt())
+                }
+            }
+            val width = (source.width * 0.78f).toInt().coerceAtLeast(1)
+            val layout = StaticLayout.Builder.obtain(text, 0, text.length, paint, width)
+                .setAlignment(Layout.Alignment.ALIGN_CENTER)
+                .setIncludePad(false)
+                .setMaxLines(8)
+                .build()
+            val padding = textSize * 0.36f
+            val boxWidth = layout.width + padding * 2
+            val boxHeight = layout.height + padding * 2
+            val centerX = layer.optDouble("x", 0.5).toFloat().coerceIn(0f, 1f) * source.width
+            val centerY = layer.optDouble("y", 0.5).toFloat().coerceIn(0f, 1f) * source.height
+            canvas.save()
+            canvas.translate(centerX, centerY)
+            canvas.rotate(Math.toDegrees(layer.optDouble("rotation", 0.0)).toFloat())
+            val style = layer.optInt("styleType", 1).coerceIn(1, 3)
+            if (style != 1) {
+                val box = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                    color = if (style == 2) 0xEFFFFFFF.toInt() else 0xB3101318.toInt()
+                    this.style = Paint.Style.FILL
+                }
+                canvas.drawRoundRect(
+                    RectF(-boxWidth / 2, -boxHeight / 2, boxWidth / 2, boxHeight / 2),
+                    textSize * 0.28f,
+                    textSize * 0.28f,
+                    box,
+                )
+            }
+            canvas.translate(-layout.width / 2f, -layout.height / 2f)
+            layout.draw(canvas)
+            canvas.restore()
+        }
         return output
     }
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -718,6 +718,33 @@ Pass the emitted string to `System\ImageEditor::render(drawing: $drawing)` to
 flatten it before crop, rotation, filters, resize, and JPEG encoding on the
 native worker.
 
+`ImageEditor::render()` also accepts `textLayers`, a bounded list of positioned
+text maps for social-media compositions. Coordinates are normalized from `0`
+to `1`, rotation uses radians, scale is clamped from `0.25` to `4`, and
+`style_type` uses `ImageTextLayerStyle` (`1` plain, `2` filled card, `3`
+translucent card):
+
+```php
+ImageEditor::render(
+    source: $source,
+    cropRatio: ImageCropRatio::Story,
+    filter: ImageFilterType::Original,
+    quarterTurns: 0,
+    flipHorizontal: false,
+    overlayText: '',
+    callback: $done,
+    textLayers: [[
+        'color' => '#101318',
+        'rotation' => 0.0,
+        'scale' => 1.0,
+        'style_type' => 2,
+        'text' => 'Resposta',
+        'x' => 0.5,
+        'y' => 0.4,
+    ]],
+);
+```
+
 ## Generators
 
 ```bash

--- a/ios/Sources/PamNative/Modules/ImageEditorModule.swift
+++ b/ios/Sources/PamNative/Modules/ImageEditorModule.swift
@@ -55,6 +55,7 @@ final class ImageEditorModule: NativeModule {
             contrast: Int(values["contrast"]?.imageEditorInteger ?? 0),
             saturation: Int(values["saturation"]?.imageEditorInteger ?? 0)
         )
+        image = composeTextLayers(image, encoded: values["textLayers"]?.imageEditorText ?? "")
         image = compose(image, text: String((values["overlayText"]?.imageEditorText ?? "").prefix(120)), sticker: false)
         image = compose(image, text: String((values["sticker"]?.imageEditorText ?? "").prefix(8)), sticker: true)
         image = resize(
@@ -168,6 +169,92 @@ final class ImageEditorModule: NativeModule {
             let y = image.size.height * (sticker ? 0.48 : 0.72) - size / 2
             value.draw(in: CGRect(x: image.size.width * 0.07, y: y, width: image.size.width * 0.86, height: size * 2), withAttributes: attributes)
         }
+    }
+
+    private func composeTextLayers(_ image: UIImage, encoded: String) -> UIImage {
+        guard
+            let data = encoded.data(using: .utf8),
+            let raw = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+            !raw.isEmpty
+        else { return image }
+        return UIGraphicsImageRenderer(size: image.size).image { renderer in
+            image.draw(at: .zero)
+            let context = renderer.cgContext
+            raw.prefix(80).forEach { layer in
+                let text = String((layer["text"] as? String ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines).prefix(500))
+                guard !text.isEmpty else { return }
+                let scale = CGFloat(max(0.25, min(4, layer["scale"] as? Double ?? 1)))
+                let fontSize = max(18, min(image.size.width * 0.22, image.size.width * 0.055 * scale))
+                let styleType = max(1, min(3, layer["styleType"] as? Int ?? 1))
+                let paragraph = NSMutableParagraphStyle()
+                paragraph.alignment = .center
+                let shadow = NSShadow()
+                shadow.shadowColor = UIColor.black.withAlphaComponent(styleType == 1 ? 0.78 : 0)
+                shadow.shadowOffset = CGSize(width: 0, height: fontSize * 0.06)
+                shadow.shadowBlurRadius = fontSize * 0.09
+                let attributes: [NSAttributedString.Key: Any] = [
+                    .font: UIFont.boldSystemFont(ofSize: fontSize),
+                    .foregroundColor: textLayerColor(layer["color"] as? String),
+                    .paragraphStyle: paragraph,
+                    .shadow: shadow,
+                ]
+                let maximum = CGSize(width: image.size.width * 0.78, height: image.size.height * 0.5)
+                let measured = (text as NSString).boundingRect(
+                    with: maximum,
+                    options: [.usesLineFragmentOrigin, .usesFontLeading],
+                    attributes: attributes,
+                    context: nil
+                ).integral.size
+                let padding = fontSize * 0.36
+                let center = CGPoint(
+                    x: CGFloat(max(0, min(1, layer["x"] as? Double ?? 0.5))) * image.size.width,
+                    y: CGFloat(max(0, min(1, layer["y"] as? Double ?? 0.5))) * image.size.height
+                )
+                context.saveGState()
+                context.translateBy(x: center.x, y: center.y)
+                context.rotate(by: CGFloat(layer["rotation"] as? Double ?? 0))
+                let box = CGRect(
+                    x: -(measured.width + padding * 2) / 2,
+                    y: -(measured.height + padding * 2) / 2,
+                    width: measured.width + padding * 2,
+                    height: measured.height + padding * 2
+                )
+                if styleType != 1 {
+                    let color = styleType == 2
+                        ? UIColor.white.withAlphaComponent(0.94)
+                        : UIColor(red: CGFloat(16) / 255, green: CGFloat(19) / 255, blue: CGFloat(24) / 255, alpha: 0.70)
+                    color.setFill()
+                    UIBezierPath(roundedRect: box, cornerRadius: fontSize * 0.28).fill()
+                }
+                (text as NSString).draw(
+                    in: CGRect(x: -measured.width / 2, y: -measured.height / 2, width: measured.width, height: measured.height),
+                    withAttributes: attributes
+                )
+                context.restoreGState()
+            }
+        }
+    }
+
+    private func textLayerColor(_ value: String?) -> UIColor {
+        let text = (value ?? "#FFFFFF").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard text.hasPrefix("#") else { return .white }
+        let hex = String(text.dropFirst())
+        guard (hex.count == 6 || hex.count == 8), let raw = UInt64(hex, radix: 16) else { return .white }
+        if hex.count == 8 {
+            return UIColor(
+                red: CGFloat((raw >> 24) & 0xFF) / 255,
+                green: CGFloat((raw >> 16) & 0xFF) / 255,
+                blue: CGFloat((raw >> 8) & 0xFF) / 255,
+                alpha: CGFloat(raw & 0xFF) / 255
+            )
+        }
+        return UIColor(
+            red: CGFloat((raw >> 16) & 0xFF) / 255,
+            green: CGFloat((raw >> 8) & 0xFF) / 255,
+            blue: CGFloat(raw & 0xFF) / 255,
+            alpha: 1
+        )
     }
 
     private func composeDrawing(_ image: UIImage, drawing: String) -> UIImage {

--- a/packages/native/src/ImageTextLayerStyle.php
+++ b/packages/native/src/ImageTextLayerStyle.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native;
+
+enum ImageTextLayerStyle: int
+{
+    case Plain = 1;
+    case Filled = 2;
+    case Translucent = 3;
+}

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.13';
+    public const string SDK_VERSION = '0.6.14';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/System/ImageEditor.php
+++ b/packages/native/src/System/ImageEditor.php
@@ -6,9 +6,11 @@ namespace Pam\Native\System;
 
 use Closure;
 use InvalidArgumentException;
+use JsonException;
 use Pam\Native\FileReference;
 use Pam\Native\ImageCropRatio;
 use Pam\Native\ImageFilterType;
+use Pam\Native\ImageTextLayerStyle;
 use Pam\Native\Modules\NativeModules;
 
 final class ImageEditor
@@ -34,6 +36,7 @@ final class ImageEditor
         int $maxHeight = 0,
         int $outputQuality = 94,
         string $drawing = '',
+        array $textLayers = [],
     ): int {
         return NativeModules::call(
             'image-editor',
@@ -47,6 +50,7 @@ final class ImageEditor
                 'flipHorizontal' => $flipHorizontal ? 1 : 0,
                 'maxHeight' => max(0, $maxHeight),
                 'maxWidth' => max(0, $maxWidth),
+                'textLayers' => self::textLayers($textLayers),
                 'overlayText' => mb_substr(trim($overlayText), 0, 120),
                 'outputQuality' => max(1, min(100, $outputQuality)),
                 'path' => $source->path,
@@ -98,5 +102,43 @@ final class ImageEditor
         }
 
         return $value;
+    }
+
+    /** @param list<array<string, mixed>> $layers */
+    private static function textLayers(array $layers): string
+    {
+        if (count($layers) > 80) {
+            throw new InvalidArgumentException('Image editor accepts at most 80 text layers.');
+        }
+        $normalized = [];
+        foreach ($layers as $layer) {
+            if (!is_array($layer)) {
+                throw new InvalidArgumentException('Image editor text layers must be maps.');
+            }
+            $text = mb_substr(trim((string) ($layer['text'] ?? '')), 0, 500);
+            if ($text === '') {
+                continue;
+            }
+            $color = strtoupper(trim((string) ($layer['color'] ?? '#FFFFFF')));
+            if (preg_match('/^#[0-9A-F]{6}([0-9A-F]{2})?$/', $color) !== 1) {
+                $color = '#FFFFFF';
+            }
+            $normalized[] = [
+                'color' => $color,
+                'rotation' => max(-M_PI * 2, min(M_PI * 2, (float) ($layer['rotation'] ?? 0.0))),
+                'scale' => max(0.25, min(4.0, (float) ($layer['scale'] ?? 1.0))),
+                'styleType' => ImageTextLayerStyle::tryFrom(
+                    (int) ($layer['style_type'] ?? $layer['styleType'] ?? 1),
+                )?->value ?? ImageTextLayerStyle::Plain->value,
+                'text' => $text,
+                'x' => max(0.0, min(1.0, (float) ($layer['x'] ?? 0.5))),
+                'y' => max(0.0, min(1.0, (float) ($layer['y'] ?? 0.5))),
+            ];
+        }
+        try {
+            return json_encode($normalized, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        } catch (JsonException $error) {
+            throw new InvalidArgumentException('Image editor text layers are invalid.', previous: $error);
+        }
     }
 }

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -5149,8 +5149,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.13',
-    'The runtime SDK contract must match the 0.6.13 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.14',
+    'The runtime SDK contract must match the 0.6.14 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,
@@ -5167,11 +5167,37 @@ $assert(
         ) === [1, 2, 3, 4, 5]
         && array_map(
             static fn (ReflectionParameter $parameter): string => $parameter->getName(),
-            array_slice($imageEditorParameters, -4),
-        ) === ['maxWidth', 'maxHeight', 'outputQuality', 'drawing']
-        && $imageEditorParameters[count($imageEditorParameters) - 2]->getDefaultValue() === 94
-        && $imageEditorParameters[array_key_last($imageEditorParameters)]->getDefaultValue() === '',
-    'The image editor contract must expose typed transforms, bounded output and drawing.',
+            array_slice($imageEditorParameters, -5),
+        ) === ['maxWidth', 'maxHeight', 'outputQuality', 'drawing', 'textLayers']
+        && $imageEditorParameters[count($imageEditorParameters) - 3]->getDefaultValue() === 94
+        && $imageEditorParameters[count($imageEditorParameters) - 2]->getDefaultValue() === ''
+        && $imageEditorParameters[array_key_last($imageEditorParameters)]->getDefaultValue() === [],
+    'The image editor contract must expose typed transforms, bounded output, drawing and text layers.',
+);
+$textLayersMethod = new ReflectionMethod(\Pam\Native\System\ImageEditor::class, 'textLayers');
+$normalizedTextLayers = json_decode($textLayersMethod->invoke(null, [[
+    'color' => 'invalid',
+    'rotation' => 99,
+    'scale' => 9,
+    'style_type' => 2,
+    'text' => ' Resposta ',
+    'x' => -1,
+    'y' => 2,
+]]), true, 64, JSON_THROW_ON_ERROR);
+$normalizedTextLayer = $normalizedTextLayers[0] ?? [];
+$assert(
+    array_map(
+        static fn (\Pam\Native\ImageTextLayerStyle $case): int => $case->value,
+        \Pam\Native\ImageTextLayerStyle::cases(),
+    ) === [1, 2, 3]
+        && ($normalizedTextLayer['color'] ?? '') === '#FFFFFF'
+        && abs((float) ($normalizedTextLayer['rotation'] ?? 0) - M_PI * 2) < 0.000001
+        && (float) ($normalizedTextLayer['scale'] ?? 0) === 4.0
+        && ($normalizedTextLayer['styleType'] ?? 0) === 2
+        && ($normalizedTextLayer['text'] ?? '') === 'Resposta'
+        && (float) ($normalizedTextLayer['x'] ?? -1) === 0.0
+        && (float) ($normalizedTextLayer['y'] ?? -1) === 1.0,
+    'Image editor text layers must normalize bounds, color and integer presentation style.',
 );
 
 $bottomSheet = BottomSheet::make(


### PR DESCRIPTION
## Summary
- add bounded positioned text-layer compositing to ImageEditor
- implement matching Android and iOS renderers with scale, radian rotation, color and integer styles
- document the contract and bump PAM Native to 0.6.14

## Verification
- `php packages/native/tests/run.php`
- `cargo test --workspace -q`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `./android/gradlew -p android testDebugUnitTest lintDebug assembleRelease`