### PR TITLE
feat: materialize bundled assets in file sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.15 - 2026-08-04
+
+- Add `Files::copyAsset()` for atomically materializing packaged project assets
+  in the application file sandbox without transporting base64 bytes through
+  PHP, with traversal protection and Android/iOS implementations.
+
 ## 0.6.14 - 2026-08-04
 
 - Add bounded, normalized positioned text-layer compositing to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.14"
+version = "0.6.15"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.14"
+version = "0.6.15"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
@@ -12,6 +12,8 @@ import dev.pam.nativeapp.protocol.WireMap
 import dev.pam.nativeapp.protocol.WireValue
 import java.io.File
 import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.Base64
 import java.util.UUID
 import java.util.concurrent.Executors
@@ -27,6 +29,7 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
             when (method) {
                 "read" -> executor.execute { read(payload, completion) }
                 "write" -> executor.execute { write(payload, completion) }
+                "copyAsset" -> executor.execute { copyAsset(payload, completion) }
                 "stat" -> executor.execute { stat(payload, completion) }
                 "list" -> executor.execute { list(payload, completion) }
                 "delete" -> executor.execute { delete(payload, completion) }
@@ -103,6 +106,30 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
             file.parentFile?.mkdirs()
             file.writeBytes(bytes)
             completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))
+        }.onFailure { completion.failure(it) }
+    }
+
+    private fun copyAsset(payload: ByteArray, completion: ModuleCompletion) {
+        runCatching {
+            val values = WireMap.decode(payload)
+            val assetPath = normalizedBundledAssetPath(values.requiredText("assetPath"))
+            val file = resolve(values.requiredText("path"))
+            file.parentFile?.mkdirs()
+            val temporary = File(file.parentFile, "${file.name}.tmp-${UUID.randomUUID()}")
+            try {
+                activity.assets.open("pam/$assetPath").use { input ->
+                    temporary.outputStream().use { output -> input.copyTo(output) }
+                }
+                Files.move(
+                    temporary.toPath(),
+                    file.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            } finally {
+                temporary.delete()
+            }
+            completion.success(file, mimeFor(file))
         }.onFailure { completion.failure(it) }
     }
 
@@ -358,4 +385,15 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
     }
 
     private data class ImportedFile(val file: File, val mime: String, val name: String)
+}
+
+internal fun normalizedBundledAssetPath(path: String): String {
+    val normalized = path.trim().replace('\\', '/')
+    require(normalized.isNotEmpty() && !normalized.startsWith('/') && normalized.length <= 1_024) {
+        "Invalid bundled asset path"
+    }
+    require(normalized.split('/').none { it.isEmpty() || it == "." || it == ".." }) {
+        "Bundled asset path escapes application bundle"
+    }
+    return normalized
 }

--- a/android/app/src/test/java/dev/pam/nativeapp/AssetInstallerTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/AssetInstallerTest.kt
@@ -1,5 +1,6 @@
 package dev.pam.nativeapp
 
+import dev.pam.nativeapp.modules.normalizedBundledAssetPath
 import java.nio.file.Files
 import kotlin.io.path.createDirectory
 import kotlin.io.path.createFile
@@ -11,6 +12,15 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AssetInstallerTest {
+    @Test
+    fun validatesBundledAssetPaths() {
+        assertEquals("assets/stories/background.webp", normalizedBundledAssetPath(" assets/stories/background.webp "))
+        listOf("", "/absolute.png", "../secret", "assets/../secret", "assets//image.png").forEach { path ->
+            val result = runCatching { normalizedBundledAssetPath(path) }
+            assertTrue("Expected unsafe path to fail: $path", result.isFailure)
+        }
+    }
+
     @Test
     fun keepsActiveAndNewestRollbackRelease() {
         val root = Files.createTempDirectory("pam-releases-test")

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -35,6 +35,7 @@ pinning and cache events.
 
 ```php
 use Pam\Native\CaptureType;
+use Pam\Native\FileReference;
 use Pam\Native\MediaPickerType;
 use Pam\Native\PermissionKind;
 use Pam\Native\PermissionStatus;
@@ -46,6 +47,12 @@ use Pam\Native\System\Permissions;
 Files::write('drafts/message.txt', 'Hello', function (): void {
     Files::read('drafts/message.txt', fn (string $text) => $this->show($text));
 });
+
+Files::copyAsset(
+    'assets/templates/story.webp',
+    'drafts/story.webp',
+    fn (FileReference $file) => $this->storySource = $file->uri(),
+);
 
 Files::pick(MediaPickerType::Image, function ($file): void {
     $this->selectedPath = $file->path;

--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -64,6 +64,13 @@ are bounded to 64 MiB. `Files::stat()` returns typed metadata,
 `Files::delete()` removes a single sandbox file. Directory deletion and paths
 escaping the application sandbox are rejected.
 
+`Files::copyAsset()` copies a project-relative packaged asset directly into a
+sandbox-relative destination on the native file worker and returns its typed
+`FileReference`. It does not base64-encode the asset or move its bytes through
+PHP, so packaged editor templates and other large immutable resources can be
+materialized safely. Absolute paths, empty segments and traversal are rejected
+for both the asset and destination.
+
 The system document picker does not require broad storage permission.
 Applications that call `MediaLibrary` request `PermissionKind::Photos`;
 Android 13+ reports image/video access and Android 14+ selected-photo access

--- a/ios/Sources/PamNative/Modules/FilesModule.swift
+++ b/ios/Sources/PamNative/Modules/FilesModule.swift
@@ -25,6 +25,8 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
                 queue.async { self.read(payload, completion) }
             case "write":
                 queue.async { self.write(payload, completion) }
+            case "copyAsset":
+                queue.async { self.copyAsset(payload, completion) }
             case "stat":
                 queue.async { self.stat(payload, completion) }
             case "list":
@@ -130,6 +132,39 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
             )
             try data.write(to: destination, options: .atomic)
             completion(.success, Data())
+        } catch { completion(.failure, Data(error.localizedDescription.utf8)) }
+    }
+
+    private func copyAsset(_ payload: Data, _ completion: @escaping ModuleCompletion) {
+        do {
+            let values = try WireMap.decode(payload)
+            guard case let .text(assetPath)? = values["assetPath"],
+                  case let .text(path)? = values["path"],
+                  let bundledPath = try normalizedPamAssetPath("asset://\(assetPath)"),
+                  let resourceRoot = Bundle.main.resourceURL else {
+                throw FileModuleError("Invalid bundled asset payload")
+            }
+            let source = resourceRoot.appendingPathComponent(bundledPath, isDirectory: false)
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: source.path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue else {
+                throw FileModuleError("Bundled asset does not exist")
+            }
+            let destination = try resolve(path)
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let temporary = destination.deletingLastPathComponent()
+                .appendingPathComponent("\(destination.lastPathComponent).tmp-\(UUID().uuidString)")
+            defer { try? FileManager.default.removeItem(at: temporary) }
+            try FileManager.default.copyItem(at: source, to: temporary)
+            if FileManager.default.fileExists(atPath: destination.path) {
+                _ = try FileManager.default.replaceItemAt(destination, withItemAt: temporary)
+            } else {
+                try FileManager.default.moveItem(at: temporary, to: destination)
+            }
+            completion(.success, try WireMap.encode(reference(destination)))
         } catch { completion(.failure, Data(error.localizedDescription.utf8)) }
     }
 

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.14';
+    public const string SDK_VERSION = '0.6.15';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/System/Files.php
+++ b/packages/native/src/System/Files.php
@@ -11,6 +11,7 @@ use Pam\Native\MediaPickerType;
 use Pam\Native\ModuleResultStatus;
 use Pam\Native\Modules\NativeModules;
 use JsonException;
+use InvalidArgumentException;
 use RuntimeException;
 
 final class Files
@@ -37,6 +38,18 @@ final class Files
             'write',
             ['path' => $path, 'data' => base64_encode($contents)],
             static fn (array $_): mixed => $callback?->__invoke(),
+        );
+    }
+
+    /** @param Closure(FileReference): void $callback */
+    public static function copyAsset(string $assetPath, string $destination, Closure $callback): int
+    {
+        $assetPath = self::assetPath($assetPath);
+
+        return self::invoke(
+            'copyAsset',
+            ['assetPath' => $assetPath, 'path' => $destination],
+            static fn (array $values): mixed => $callback(self::reference($values)),
         );
     }
 
@@ -72,6 +85,24 @@ final class Files
             ['path' => $path],
             static fn (array $_): mixed => $callback?->__invoke(),
         );
+    }
+
+    private static function assetPath(string $path): string
+    {
+        $path = str_replace('\\', '/', trim($path));
+        if (
+            $path === ''
+            || str_starts_with($path, '/')
+            || strlen($path) > 1_024
+            || array_any(
+                explode('/', $path),
+                static fn (string $segment): bool => $segment === '' || $segment === '.' || $segment === '..',
+            )
+        ) {
+            throw new InvalidArgumentException('Bundled asset path must be safe and project-relative.');
+        }
+
+        return $path;
     }
 
     /** @param Closure(FileReference): void $callback */

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2844,6 +2844,50 @@ $assert(
     'Files pickMany must decode every native file reference in selection order.',
 );
 
+$copiedAsset = null;
+$copyAssetRequest = Files::copyAsset(
+    'assets/templates/story.webp',
+    'drafts/story.webp',
+    static function (FileReference $file) use (&$copiedAsset): void {
+        $copiedAsset = $file;
+    },
+);
+$copyAssetCall = TestDiagnostics::$moduleCall;
+$assert(
+    $copyAssetCall !== null
+        && $copyAssetCall['requestId'] === $copyAssetRequest
+        && $copyAssetCall['module'] === 'files'
+        && $copyAssetCall['method'] === 'copyAsset'
+        && Wire::decodeMap($copyAssetCall['payload']) === [
+            'assetPath' => 'assets/templates/story.webp',
+            'path' => 'drafts/story.webp',
+        ],
+    'Files copyAsset must emit safe project and sandbox paths.',
+);
+Runtime::dispatchModuleResult(
+    $copyAssetRequest,
+    ModuleResultStatus::Success->value,
+    Wire::map([
+        'path' => 'drafts/story.webp',
+        'name' => 'story.webp',
+        'mimeType' => 'image/webp',
+        'size' => 75_446,
+    ]),
+);
+$assert(
+    $copiedAsset instanceof FileReference
+        && $copiedAsset->path === 'drafts/story.webp'
+        && $copiedAsset->mimeType === 'image/webp',
+    'Files copyAsset must return the materialized typed file reference.',
+);
+$unsafeAssetRejected = false;
+try {
+    Files::copyAsset('../secret', 'drafts/secret', static function (FileReference $_): void {});
+} catch (InvalidArgumentException) {
+    $unsafeAssetRejected = true;
+}
+$assert($unsafeAssetRejected, 'Files copyAsset must reject traversal before crossing the bridge.');
+
 $importedFile = null;
 $importUriRequest = Files::importUri(
     'content://media/external/images/media/42',
@@ -5149,8 +5193,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.14',
-    'The runtime SDK contract must match the 0.6.14 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.15',
+    'The runtime SDK contract must match the 0.6.15 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- add typed Files::copyAsset() to copy packaged project assets directly into the writable sandbox
- implement atomic, traversal-safe Android and iOS native copies
- document the capability and bump the SDK contract to 0.6.15

## Validation
- php packages/native/tests/run.php
- cargo check --offline
- cargo fmt --all -- --check
- android/gradlew :app:testDebugUnitTest
- android/gradlew :app:assembleDebug

This unblocks media editors that need a packaged template as a writable FileReference without transporting base64 bytes through PHP.