### PR TITLE
fix: canonicalize returned Android file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.16 - 2026-08-04
+
+- Canonicalize the Android file-sandbox root before deriving returned relative
+  paths, preventing `/data/user/0` and `/data/data` aliases from producing a
+  traversal-shaped `FileReference` after `Files::copyAsset()`.
+
 ## 0.6.15 - 2026-08-04
 
 - Add `Files::copyAsset()` for atomically materializing packaged project assets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.15"
+version = "0.6.16"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.15"
+version = "0.6.16"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
@@ -22,7 +22,7 @@ import org.json.JSONObject
 
 internal class FilesModule(private val activity: PamActivity) : NativeModule, AutoCloseable {
     private val executor = Executors.newSingleThreadExecutor()
-    private val root = File(activity.filesDir, "pam-files").apply { mkdirs() }
+    private val root = File(activity.filesDir, "pam-files").apply { mkdirs() }.canonicalFile
 
     override fun invoke(method: String, payload: ByteArray, completion: ModuleCompletion) {
         runCatching {
@@ -350,7 +350,7 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
             ModuleResultStatus.SUCCESS,
             WireMap.encode(
                 mapOf(
-                    "path" to WireValue.Text(file.relativeTo(root).path),
+                    "path" to WireValue.Text(relativeSandboxPath(root, file)),
                     "name" to WireValue.Text(displayName),
                     "mimeType" to WireValue.Text(mime),
                     "size" to WireValue.Integer(file.length()),
@@ -396,4 +396,13 @@ internal fun normalizedBundledAssetPath(path: String): String {
         "Bundled asset path escapes application bundle"
     }
     return normalized
+}
+
+internal fun relativeSandboxPath(root: File, file: File): String {
+    val canonicalRoot = root.canonicalFile
+    val canonicalFile = file.canonicalFile
+    require(canonicalFile.path.startsWith(canonicalRoot.path + File.separator)) {
+        "File path escapes sandbox"
+    }
+    return canonicalFile.relativeTo(canonicalRoot).path
 }

--- a/android/app/src/test/java/dev/pam/nativeapp/AssetInstallerTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/AssetInstallerTest.kt
@@ -1,6 +1,7 @@
 package dev.pam.nativeapp
 
 import dev.pam.nativeapp.modules.normalizedBundledAssetPath
+import dev.pam.nativeapp.modules.relativeSandboxPath
 import java.nio.file.Files
 import kotlin.io.path.createDirectory
 import kotlin.io.path.createFile
@@ -12,6 +13,25 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AssetInstallerTest {
+    @Test
+    fun derivesPathsAgainstCanonicalSandboxRoot() {
+        val parent = Files.createTempDirectory("pam-file-root-test")
+        try {
+            val canonicalRoot = parent.resolve("canonical").createDirectory()
+            val alias = parent.resolve("alias")
+            Files.createSymbolicLink(alias, canonicalRoot)
+            val child = canonicalRoot.resolve("story-responses").createDirectory()
+                .resolve("response.webp").createFile()
+
+            assertEquals(
+                "story-responses/response.webp",
+                relativeSandboxPath(alias.toFile(), child.toFile()),
+            )
+        } finally {
+            parent.toFile().deleteRecursively()
+        }
+    }
+
     @Test
     fun validatesBundledAssetPaths() {
         assertEquals("assets/stories/background.webp", normalizedBundledAssetPath(" assets/stories/background.webp "))

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.15';
+    public const string SDK_VERSION = '0.6.16';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -5193,8 +5193,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.15',
-    'The runtime SDK contract must match the 0.6.15 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.16',
+    'The runtime SDK contract must match the 0.6.16 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- canonicalize the Android file sandbox root before deriving returned relative paths
- prevent /data/user/0 and /data/data aliases from yielding traversal-shaped FileReference paths
- cover the alias case with a symlink regression and bump the SDK contract to 0.6.16

## Validation
- php packages/native/tests/run.php
- cargo check --offline
- cargo fmt --all -- --check
- android/gradlew :app:testDebugUnitTest :app:assembleDebug

Found physically while ZeChat copied a packaged Story response template with Files::copyAsset(); the editor correctly rejected the malformed pre-fix path.