### PR TITLE
feat: materialize remote media in file sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.17 - 2026-08-04
+
+- Add bounded, atomic `Files::download()` support on Android and iOS for
+  materializing HTTPS media into the PAM sandbox as a typed `FileReference`.
+
 ## 0.6.16 - 2026-08-04
 
 - Canonicalize the Android file-sandbox root before deriving returned relative

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.16"
+version = "0.6.17"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.16"
+version = "0.6.17"
 edition = "2024"
 rust-version = "1.88"
 license = "BUSL-1.1"

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
@@ -14,6 +14,8 @@ import java.io.File
 import java.io.FileOutputStream
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.net.HttpURLConnection
+import java.net.URI
 import java.util.Base64
 import java.util.UUID
 import java.util.concurrent.Executors
@@ -30,6 +32,7 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
                 "read" -> executor.execute { read(payload, completion) }
                 "write" -> executor.execute { write(payload, completion) }
                 "copyAsset" -> executor.execute { copyAsset(payload, completion) }
+                "download" -> executor.execute { download(payload, completion) }
                 "stat" -> executor.execute { stat(payload, completion) }
                 "list" -> executor.execute { list(payload, completion) }
                 "delete" -> executor.execute { delete(payload, completion) }
@@ -130,6 +133,63 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
                 temporary.delete()
             }
             completion.success(file, mimeFor(file))
+        }.onFailure { completion.failure(it) }
+    }
+
+    private fun download(payload: ByteArray, completion: ModuleCompletion) {
+        runCatching {
+            val values = WireMap.decode(payload)
+            val uri = URI(values.requiredText("url"))
+            require(uri.scheme.equals("https", ignoreCase = true) && !uri.host.isNullOrBlank()) {
+                "Download URL must be an absolute HTTPS URL"
+            }
+            require(uri.userInfo == null) { "Download URL cannot contain credentials" }
+            val maximumBytes = values.integer("maximumBytes", MAX_IMPORT_BYTES)
+            require(maximumBytes in 1..MAX_DOWNLOAD_BYTES) { "Invalid download size limit" }
+            val file = resolve(values.requiredText("path"))
+            file.parentFile?.mkdirs()
+            val temporary = File(file.parentFile, "${file.name}.tmp-${UUID.randomUUID()}")
+            val connection = uri.toURL().openConnection() as HttpURLConnection
+            try {
+                connection.instanceFollowRedirects = false
+                connection.connectTimeout = 15_000
+                connection.readTimeout = 30_000
+                connection.requestMethod = "GET"
+                connection.setRequestProperty("Accept-Encoding", "identity")
+                connection.connect()
+                require(connection.responseCode in 200..299) {
+                    "Download failed with HTTP ${connection.responseCode}"
+                }
+                val declaredSize = connection.contentLengthLong
+                require(declaredSize < 0 || declaredSize <= maximumBytes) {
+                    "Download exceeds configured size limit"
+                }
+                connection.inputStream.use { input ->
+                    temporary.outputStream().use { output ->
+                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        var total = 0L
+                        while (true) {
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            total += read
+                            require(total <= maximumBytes) { "Download exceeds configured size limit" }
+                            output.write(buffer, 0, read)
+                        }
+                    }
+                }
+                Files.move(
+                    temporary.toPath(),
+                    file.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+                val mime = connection.contentType?.substringBefore(';')?.trim()
+                    ?.takeIf(String::isNotEmpty) ?: mimeFor(file)
+                completion.success(file, mime)
+            } finally {
+                connection.disconnect()
+                temporary.delete()
+            }
         }.onFailure { completion.failure(it) }
     }
 
@@ -381,6 +441,7 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
         const val MAX_PICK_LIMIT = 50
         const val MAX_READ_BYTES = 1024 * 1024L
         const val MAX_IMPORT_BYTES = 64L * 1024L * 1024L
+        const val MAX_DOWNLOAD_BYTES = 256L * 1024L * 1024L
         const val MAX_MULTI_IMPORT_BYTES = 256L * 1024L * 1024L
     }
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -54,6 +54,13 @@ Files::copyAsset(
     fn (FileReference $file) => $this->storySource = $file->uri(),
 );
 
+Files::download(
+    'https://cdn.example.com/posts/42.webp',
+    'drafts/shared-post.webp',
+    fn (FileReference $file) => $this->sharedPostSource = $file->uri(),
+    maximumBytes: 16 * 1_024 * 1_024,
+);
+
 Files::pick(MediaPickerType::Image, function ($file): void {
     $this->selectedPath = $file->path;
     $this->selectedImageSource = $file->uri();

--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -71,6 +71,13 @@ PHP, so packaged editor templates and other large immutable resources can be
 materialized safely. Absolute paths, empty segments and traversal are rejected
 for both the asset and destination.
 
+`Files::download()` materializes an absolute HTTPS resource at a
+sandbox-relative destination and returns a `FileReference` suitable for image
+editing, upload or durable app-owned use. Downloads run off the UI thread,
+reject embedded credentials and non-HTTPS URLs, enforce a caller-controlled
+size limit (64 MiB by default, 256 MiB maximum), and replace the destination
+atomically only after a successful transfer.
+
 The system document picker does not require broad storage permission.
 Applications that call `MediaLibrary` request `PermissionKind::Photos`;
 Android 13+ reports image/video access and Android 14+ selected-photo access

--- a/ios/Sources/PamNative/Modules/FilesModule.swift
+++ b/ios/Sources/PamNative/Modules/FilesModule.swift
@@ -567,7 +567,7 @@ private final class RemoteFileDownload: NSObject, URLSessionDownloadDelegate, @u
               url.user == nil,
               url.password == nil else {
             completionHandler(nil)
-            finish(.failure, Data("Download redirect must use HTTPS without credentials".utf8)))
+            finish(.failure, Data("Download redirect must use HTTPS without credentials".utf8))
             return
         }
         completionHandler(request)
@@ -615,10 +615,10 @@ private final class RemoteFileDownload: NSObject, URLSessionDownloadDelegate, @u
         if let error { finish(.failure, Data(error.localizedDescription.utf8)) }
     }
 
-    private func finish(_ status: (ModuleResultStatus, Data)) {
+    private func finish(_ status: ModuleResultStatus, _ data: Data) {
         guard !finished else { return }
         finished = true
-        completion(status.0, status.1)
+        completion(status, data)
         session?.finishTasksAndInvalidate()
         session = nil
     }

--- a/ios/Sources/PamNative/Modules/FilesModule.swift
+++ b/ios/Sources/PamNative/Modules/FilesModule.swift
@@ -27,6 +27,8 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
                 queue.async { self.write(payload, completion) }
             case "copyAsset":
                 queue.async { self.copyAsset(payload, completion) }
+            case "download":
+                queue.async { self.download(payload, completion) }
             case "stat":
                 queue.async { self.stat(payload, completion) }
             case "list":
@@ -165,6 +167,37 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
                 try FileManager.default.moveItem(at: temporary, to: destination)
             }
             completion(.success, try WireMap.encode(reference(destination)))
+        } catch { completion(.failure, Data(error.localizedDescription.utf8)) }
+    }
+
+    private func download(_ payload: Data, _ completion: @escaping ModuleCompletion) {
+        do {
+            let values = try WireMap.decode(payload)
+            guard case let .text(rawURL)? = values["url"],
+                  let url = URL(string: rawURL),
+                  url.scheme?.lowercased() == "https",
+                  url.host?.isEmpty == false,
+                  url.user == nil,
+                  url.password == nil,
+                  case let .text(path)? = values["path"] else {
+                throw FileModuleError("Download URL must be an absolute HTTPS URL without credentials")
+            }
+            let maximumBytes = values["maximumBytes"]?.integerValue ?? 64 * 1_024 * 1_024
+            guard maximumBytes > 0, maximumBytes <= 256 * 1_024 * 1_024 else {
+                throw FileModuleError("Invalid download size limit")
+            }
+            let destination = try resolve(path)
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            RemoteFileDownload.start(
+                url: url,
+                destination: destination,
+                root: root,
+                maximumBytes: maximumBytes,
+                completion: completion
+            )
         } catch { completion(.failure, Data(error.localizedDescription.utf8)) }
     }
 
@@ -460,6 +493,135 @@ private struct FileModuleError: LocalizedError {
     let message: String
     init(_ message: String) { self.message = message }
     var errorDescription: String? { message }
+}
+
+private final class RemoteFileDownload: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let destination: URL
+    private let root: URL
+    private let maximumBytes: Int64
+    private let completion: ModuleCompletion
+    private var session: URLSession?
+    private var finished = false
+
+    private init(
+        destination: URL,
+        root: URL,
+        maximumBytes: Int64,
+        completion: @escaping ModuleCompletion
+    ) {
+        self.destination = destination
+        self.root = root
+        self.maximumBytes = maximumBytes
+        self.completion = completion
+    }
+
+    static func start(
+        url: URL,
+        destination: URL,
+        root: URL,
+        maximumBytes: Int64,
+        completion: @escaping ModuleCompletion
+    ) {
+        let delegate = RemoteFileDownload(
+            destination: destination,
+            root: root,
+            maximumBytes: maximumBytes,
+            completion: completion
+        )
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = false
+        configuration.httpShouldUsePipelining = true
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 120
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: queue)
+        delegate.session = session
+        session.downloadTask(with: url).resume()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        if totalBytesWritten > maximumBytes
+            || (totalBytesExpectedToWrite > maximumBytes && totalBytesExpectedToWrite > 0) {
+            downloadTask.cancel()
+            finish(.failure, Data("Download exceeds configured size limit".utf8))
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let url = request.url,
+              url.scheme?.lowercased() == "https",
+              url.host?.isEmpty == false,
+              url.user == nil,
+              url.password == nil else {
+            completionHandler(nil)
+            finish(.failure, Data("Download redirect must use HTTPS without credentials".utf8)))
+            return
+        }
+        completionHandler(request)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        do {
+            guard let response = downloadTask.response as? HTTPURLResponse,
+                  (200...299).contains(response.statusCode),
+                  response.url?.scheme?.lowercased() == "https" else {
+                throw FileModuleError(
+                    "Download failed with HTTP \((downloadTask.response as? HTTPURLResponse)?.statusCode ?? 0)"
+                )
+            }
+            let size = try location.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+            guard size <= maximumBytes else {
+                throw FileModuleError("Download exceeds configured size limit")
+            }
+            if FileManager.default.fileExists(atPath: destination.path) {
+                _ = try FileManager.default.replaceItemAt(destination, withItemAt: location)
+            } else {
+                try FileManager.default.moveItem(at: location, to: destination)
+            }
+            let relative = String(destination.standardizedFileURL.path.dropFirst(root.standardizedFileURL.path.count + 1))
+            finish(.success, try WireMap.encode([
+                "path": .text(relative),
+                "name": .text(destination.lastPathComponent),
+                "mimeType": .text(response.mimeType
+                    ?? UTType(filenameExtension: destination.pathExtension)?.preferredMIMEType
+                    ?? "application/octet-stream"),
+                "size": .integer(Int64(size)),
+            ]))
+        } catch { finish(.failure, Data(error.localizedDescription.utf8)) }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        if let error { finish(.failure, Data(error.localizedDescription.utf8)) }
+    }
+
+    private func finish(_ status: (ModuleResultStatus, Data)) {
+        guard !finished else { return }
+        finished = true
+        completion(status.0, status.1)
+        session?.finishTasksAndInvalidate()
+        session = nil
+    }
 }
 
 private extension WireValue {

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.16';
+    public const string SDK_VERSION = '0.6.17';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/System/Files.php
+++ b/packages/native/src/System/Files.php
@@ -53,6 +53,39 @@ final class Files
         );
     }
 
+    /**
+     * Downloads an HTTPS resource into the PAM file sandbox.
+     *
+     * @param Closure(FileReference): void $callback
+     */
+    public static function download(
+        string $url,
+        string $destination,
+        Closure $callback,
+        int $maximumBytes = 67_108_864,
+    ): int {
+        $parts = parse_url($url);
+        if (
+            strlen($url) > 2_048
+            || !is_array($parts)
+            || strtolower((string) ($parts['scheme'] ?? '')) !== 'https'
+            || ($parts['host'] ?? '') === ''
+            || isset($parts['user'])
+            || isset($parts['pass'])
+        ) {
+            throw new InvalidArgumentException('Download URL must be an absolute HTTPS URL without credentials.');
+        }
+        if ($maximumBytes < 1 || $maximumBytes > 268_435_456) {
+            throw new InvalidArgumentException('Download limit must be between 1 byte and 256 MiB.');
+        }
+
+        return self::invoke(
+            'download',
+            ['url' => $url, 'path' => $destination, 'maximumBytes' => $maximumBytes],
+            static fn (array $values): mixed => $callback(self::reference($values)),
+        );
+    }
+
     /** @param Closure(FileReference): void $callback */
     public static function stat(string $path, Closure $callback): int
     {

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -2888,6 +2888,56 @@ try {
 }
 $assert($unsafeAssetRejected, 'Files copyAsset must reject traversal before crossing the bridge.');
 
+$downloadedFile = null;
+$downloadRequest = Files::download(
+    'https://cdn.example.test/media/story.webp',
+    'drafts/remote-story.webp',
+    static function (FileReference $file) use (&$downloadedFile): void {
+        $downloadedFile = $file;
+    },
+    8_388_608,
+);
+$downloadCall = TestDiagnostics::$moduleCall;
+$assert(
+    $downloadCall !== null
+        && $downloadCall['requestId'] === $downloadRequest
+        && $downloadCall['module'] === 'files'
+        && $downloadCall['method'] === 'download'
+        && Wire::decodeMap($downloadCall['payload']) === [
+            'url' => 'https://cdn.example.test/media/story.webp',
+            'path' => 'drafts/remote-story.webp',
+            'maximumBytes' => 8_388_608,
+        ],
+    'Files download must emit a bounded HTTPS sandbox download.',
+);
+Runtime::dispatchModuleResult(
+    $downloadRequest,
+    ModuleResultStatus::Success->value,
+    Wire::map([
+        'path' => 'drafts/remote-story.webp',
+        'name' => 'remote-story.webp',
+        'mimeType' => 'image/webp',
+        'size' => 82_944,
+    ]),
+);
+$assert(
+    $downloadedFile instanceof FileReference
+        && $downloadedFile->path === 'drafts/remote-story.webp'
+        && $downloadedFile->size === 82_944,
+    'Files download must decode the materialized typed file reference.',
+);
+$unsafeDownloadRejected = false;
+try {
+    Files::download(
+        'http://example.test/media.webp',
+        'drafts/media.webp',
+        static function (FileReference $_): void {},
+    );
+} catch (InvalidArgumentException) {
+    $unsafeDownloadRejected = true;
+}
+$assert($unsafeDownloadRejected, 'Files download must reject non-HTTPS URLs before crossing the bridge.');
+
 $importedFile = null;
 $importUriRequest = Files::importUri(
     'content://media/external/images/media/42',
@@ -5193,8 +5243,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.16',
-    'The runtime SDK contract must match the 0.6.16 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.17',
+    'The runtime SDK contract must match the 0.6.17 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- add bounded HTTPS Files::download API returning FileReference
- implement atomic Android and iOS sandbox downloads
- document the capability and advance the SDK to 0.6.17

## Validation
- php packages/native/tests/run.php
- cargo check --workspace
- cargo test --workspace
- android ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:lintDebug

Swift could not run locally because this Linux workstation has no Swift toolchain; CI covers the iOS build and tests.