### PR TITLE
feat: expose shared elements in PAM templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.69 - 2026-08-10
+
+- Added typed `shared-transition` and `shared-transition-style` attributes to
+  PAM `Image` and `MediaPlayer` templates. Feed, gallery and other declarative
+  media screens can now participate in Shared Elements 2 without dropping down
+  to programmatic element construction.
+
 ## 0.6.68 - 2026-08-10
 
 - Added the Laravel-inspired `Route::` navigation facade for composable native

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.68"
+version = "0.6.69"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.68"
+version = "0.6.69"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.68"
+version = "0.6.69"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/android/pam-native.properties
+++ b/android/pam-native.properties
@@ -4,5 +4,5 @@ applicationName=Pam Native
 minSdk=26
 targetSdk=36
 versionCode=35
-versionName=0.6.68
+versionName=0.6.69
 abis=arm64-v8a,x86_64

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -204,6 +204,17 @@ Image::make($thumbnail)
     ->sharedTransition("post-media:{$postId}", $style);
 ```
 
+The same contract is available in PAM templates. A bound style remains a typed
+PHP value and is encoded before it reaches the retained tree:
+
+```php
+<Image
+    :source="$thumbnail"
+    :shared-transition="'post-media:'.$postId"
+    :shared-transition-style="$sharedStyle"
+/>
+```
+
 `timing()` uses native ease-in-out movement. `spring()` adds bounded damping,
 stiffness and mass. Resize modes are `Scale`, `Clip` and `None`; crossfade uses
 separate source and destination snapshots so asynchronous image changes do not

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -51,6 +51,7 @@ use Pam\Native\SafeAreaMode;
 use Pam\Native\ScrollKeyboardDismissMode;
 use Pam\Native\ScrollTargetAlignment;
 use Pam\Native\ScrollOverScrollMode;
+use Pam\Native\Navigation\SharedTransitionStyle;
 use Pam\Native\StatusBarAppearance;
 use Pam\Native\TemplateRegistry;
 use Pam\Native\TemplateException;
@@ -1292,6 +1293,18 @@ final class TemplateRenderer
         Image|MediaPlayer $element,
         array $values,
     ): Image|MediaPlayer {
+        if (isset($values['sharedTransition'])) {
+            $style = $values['sharedTransitionStyle'] ?? null;
+            if ($style !== null && !$style instanceof SharedTransitionStyle) {
+                throw new InvalidArgumentException(
+                    'Media sharedTransitionStyle must be a SharedTransitionStyle.',
+                );
+            }
+            $element = $element->sharedTransition(
+                self::stringValue($values['sharedTransition'], 'Media sharedTransition'),
+                $style,
+            );
+        }
         if (array_key_exists('cache', $values)) {
             $element = $element->cache(self::mediaCachePolicy($values['cache']));
         }

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.68';
+    public const string SDK_VERSION = '0.6.69';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -5790,8 +5790,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.68',
-    'The runtime SDK contract must match the 0.6.68 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.69',
+    'The runtime SDK contract must match the 0.6.69 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,
@@ -5991,6 +5991,23 @@ $assert(
         && $cachedTagImage->properties()[PropKey::MediaCacheMaxBytes->value] === 67_108_864
         && $cachedTagImage->properties()[PropKey::MediaResizeHeight->value] === 512,
     'Tag media-cache attributes must normalize kebab-case values and bounded units.',
+);
+$templateSharedStyle = SharedTransitionStyle::spring(durationMs: 360, damping: 0.8)
+    ->resize(SharedTransitionResizeMode::Clip)
+    ->crossFade();
+$sharedTagImage = TemplateRenderer::render(
+    TemplateCompiler::compile(
+        '<Image source="post.webp" shared-transition="post:42" '.
+        ':shared-transition-style="$sharedStyle" />',
+    ),
+    null,
+    ['sharedStyle' => $templateSharedStyle],
+);
+$assert(
+    $sharedTagImage->properties()[PropKey::SharedTransitionTag->value] === 'post:42'
+        && $sharedTagImage->properties()[PropKey::SharedTransitionConfig->value]
+            === $templateSharedStyle->toJson(),
+    'PAM templates must expose typed shared-element tags and motion styles.',
 );
 
 $hardenedWebView = WebView::make('https://example.com/app')


### PR DESCRIPTION
Adds typed shared-transition and shared-transition-style attributes for declarative Image and MediaPlayer templates, with PHP tests and documentation. Prepares v0.6.69 so the feed/gallery integration can use Shared Elements 2 directly.