### PR TITLE
feat: complete typed imperative navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.70 - 2026-08-10
+
+- Completed typed imperative navigation: `Navigator`, `NavigationAction`,
+  `NavigationRef`, legacy `Router`, bottom/top tabs and drawers now accept the
+  same string-backed route enums as `Route::screen()` and `Route::to()`. Route
+  names are normalized before lookup, persistence, events and native dispatch.
+
 ## 0.6.69 - 2026-08-10
 
 - Added typed `shared-transition` and `shared-transition-style` attributes to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.69"
+version = "0.6.70"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.69"
+version = "0.6.70"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.69"
+version = "0.6.70"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/android/pam-native.properties
+++ b/android/pam-native.properties
@@ -4,5 +4,5 @@ applicationName=Pam Native
 minSdk=26
 targetSdk=36
 versionCode=35
-versionName=0.6.69
+versionName=0.6.70
 abis=arm64-v8a,x86_64

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -54,10 +54,19 @@ Route::stack('main', AppRoute::Home, static function (): void {
 });
 
 Route::to(AppRoute::Product, productId: 42, preview: true)->push();
+
+$navigator->push(AppRoute::Product, ['productId' => 42]);
+$navigator->navigate(AppRoute::Home);
+$navigator->replace(AppRoute::Product);
+$navigator->reset(AppRoute::Home);
+$navigator->preload(AppRoute::Product);
 ```
 
 `pushRoute()`, `navigateRoute()`, `replaceRoute()`, `Route::screen()`,
-`Route::modal()` and `Route::to()` accept the same string-backed enum cases.
+`Route::modal()`, `Route::to()`, lower-level `Navigator` operations,
+`NavigationAction`, tabs and drawer selectors accept the same string-backed
+enum cases. The persisted and native wire state always receives the normalized
+string value.
 Integer-backed enums are rejected as route names because route identity is
 persisted and linked by stable textual names.
 

--- a/packages/native/src/Navigation/DrawerNavigator.php
+++ b/packages/native/src/Navigation/DrawerNavigator.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Pam\Native\Navigation;
 
+use BackedEnum;
 use Closure;
 use InvalidArgumentException;
 use Pam\Native\AccessibilityRole;
 use Pam\Native\Renderable;
 use Pam\Native\Restorable;
+use Pam\Native\Routing\RouteName;
 use Pam\Native\State;
 use Pam\Native\Style;
 use Pam\Native\UI\Column;
@@ -46,7 +48,7 @@ final class DrawerNavigator implements Renderable, Restorable, NavigationStatePr
      * @param list<NavigationDrawerItem> $routes
      */
     public function __construct(
-        string $initialRoute,
+        string|BackedEnum $initialRoute,
         array $routes,
         private readonly DrawerType $type = DrawerType::Front,
         private readonly DrawerPosition $position = DrawerPosition::Automatic,
@@ -72,6 +74,7 @@ final class DrawerNavigator implements Renderable, Restorable, NavigationStatePr
         private readonly int $dividerColor = 0xFFE2E8F0,
         private readonly ?Closure $customContent = null,
     ) {
+        $initialRoute = RouteName::value($initialRoute);
         if ($routes === []) {
             throw new InvalidArgumentException(
                 'Drawer navigation requires at least one route.',
@@ -100,8 +103,9 @@ final class DrawerNavigator implements Renderable, Restorable, NavigationStatePr
         }
     }
 
-    public function navigate(string $name): bool
+    public function navigate(string|BackedEnum $name): bool
     {
+        $name = RouteName::value($name);
         foreach ($this->routes as $index => $route) {
             if ($route->name !== $name) {
                 continue;

--- a/packages/native/src/Navigation/NavigationAction.php
+++ b/packages/native/src/Navigation/NavigationAction.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Pam\Native\Navigation;
 
+use BackedEnum;
 use InvalidArgumentException;
+use Pam\Native\Routing\RouteName;
 
 final readonly class NavigationAction
 {
@@ -23,15 +25,15 @@ final readonly class NavigationAction
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public static function navigate(string $route, array $params = [], bool $merge = false): self
+    public static function navigate(string|BackedEnum $route, array $params = [], bool $merge = false): self
     {
-        return new self(NavigationActionType::Navigate, $route, $params, merge: $merge);
+        return new self(NavigationActionType::Navigate, RouteName::value($route), $params, merge: $merge);
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public static function push(string $route, array $params = []): self
+    public static function push(string|BackedEnum $route, array $params = []): self
     {
-        return new self(NavigationActionType::Push, $route, $params);
+        return new self(NavigationActionType::Push, RouteName::value($route), $params);
     }
 
     public static function pop(): self
@@ -45,20 +47,20 @@ final readonly class NavigationAction
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public static function replace(string $route, array $params = []): self
+    public static function replace(string|BackedEnum $route, array $params = []): self
     {
-        return new self(NavigationActionType::Replace, $route, $params);
+        return new self(NavigationActionType::Replace, RouteName::value($route), $params);
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public static function reset(string $route, array $params = []): self
+    public static function reset(string|BackedEnum $route, array $params = []): self
     {
-        return new self(NavigationActionType::Reset, $route, $params);
+        return new self(NavigationActionType::Reset, RouteName::value($route), $params);
     }
 
-    public static function popTo(string $route): self
+    public static function popTo(string|BackedEnum $route): self
     {
-        return new self(NavigationActionType::PopTo, $route);
+        return new self(NavigationActionType::PopTo, RouteName::value($route));
     }
 
     public static function popToTop(): self
@@ -79,9 +81,9 @@ final readonly class NavigationAction
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public static function preload(string $route, array $params = []): self
+    public static function preload(string|BackedEnum $route, array $params = []): self
     {
-        return new self(NavigationActionType::Preload, $route, $params);
+        return new self(NavigationActionType::Preload, RouteName::value($route), $params);
     }
 
     public function source(string $key): self

--- a/packages/native/src/Navigation/NavigationRef.php
+++ b/packages/native/src/Navigation/NavigationRef.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pam\Native\Navigation;
 
+use BackedEnum;
 /**
  * Stable imperative handle for notification handlers, deep-link adapters and
  * code which runs before the navigation tree mounts. Pre-mount actions are
@@ -42,7 +43,7 @@ final class NavigationRef
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public function navigate(string $route, array $params = [], bool $merge = false): bool
+    public function navigate(string|BackedEnum $route, array $params = [], bool $merge = false): bool
     {
         return $this->dispatch(NavigationAction::navigate($route, $params, $merge));
     }

--- a/packages/native/src/Navigation/Navigator.php
+++ b/packages/native/src/Navigation/Navigator.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Pam\Native\Navigation;
 
+use BackedEnum;
 use Closure;
 use InvalidArgumentException;
 use Pam\Native\Component;
 use Pam\Native\Renderable;
 use Pam\Native\Restorable;
+use Pam\Native\Routing\RouteName;
 use ReflectionFunction;
 
 final class Navigator extends Component implements Restorable, NavigationStateProvider, NavigationBackHandler, NavigationObservable, NavigationActionHandler, NavigationLinkHandler
@@ -61,7 +63,7 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
      * @param array<array-key, mixed> $routes
      */
     public function __construct(
-        string $initialRoute,
+        string|BackedEnum $initialRoute,
         array $routes,
         string $persistenceKey = 'main',
         private NavigationTransition $transition = NavigationTransition::PlatformDefault,
@@ -79,6 +81,7 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
         array $optionGroups = [],
     )
     {
+        $initialRoute = RouteName::value($initialRoute);
         $validated = [];
 
         foreach ($routes as $name => $route) {
@@ -198,8 +201,9 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public function push(string $route, array $params = []): void
+    public function push(string|BackedEnum $route, array $params = []): void
     {
+        $route = RouteName::value($route);
         if (!isset($this->routes[$route])) {
             throw new InvalidArgumentException("Route {$route} is not registered.");
         }
@@ -424,8 +428,9 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public function replace(string $route, array $params = []): void
+    public function replace(string|BackedEnum $route, array $params = []): void
     {
+        $route = RouteName::value($route);
         if (!isset($this->routes[$route])) {
             throw new InvalidArgumentException("Route {$route} is not registered.");
         }
@@ -448,8 +453,9 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public function reset(string $route, array $params = []): void
+    public function reset(string|BackedEnum $route, array $params = []): void
     {
+        $route = RouteName::value($route);
         if (!isset($this->routes[$route])) {
             throw new InvalidArgumentException("Route {$route} is not registered.");
         }
@@ -472,8 +478,9 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public function navigate(string $route, array $params = [], bool $merge = false): void
+    public function navigate(string|BackedEnum $route, array $params = [], bool $merge = false): void
     {
+        $route = RouteName::value($route);
         if (!isset($this->routes[$route])) {
             throw new InvalidArgumentException("Route {$route} is not registered.");
         }
@@ -566,8 +573,9 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public function preload(string $route, array $params = []): bool
+    public function preload(string|BackedEnum $route, array $params = []): bool
     {
+        $route = RouteName::value($route);
         if (!isset($this->routes[$route])) return false;
         $validatedParams = self::validatedParams($params);
         $entry = [
@@ -591,8 +599,9 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
         $this->preloaded = [];
     }
 
-    public function popTo(string $route): bool
+    public function popTo(string|BackedEnum $route): bool
     {
+        $route = RouteName::value($route);
         if ($route === $this->currentRoute()) {
             return true;
         }
@@ -698,8 +707,9 @@ final class Navigator extends Component implements Restorable, NavigationStatePr
     }
 
     /** @param array<string, string|int|float|bool|null> $params */
-    public function routeAvailable(string $route, array $params = []): bool
+    public function routeAvailable(string|BackedEnum $route, array $params = []): bool
     {
+        $route = RouteName::value($route);
         if (!isset($this->routes[$route])) return false;
         $guard = $this->routeGuards[$route] ?? null;
         return $guard === null || $guard(new RouteContext($route, self::validatedParams($params))) === true;

--- a/packages/native/src/Navigation/Router.php
+++ b/packages/native/src/Navigation/Router.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Pam\Native\Navigation;
 
+use BackedEnum;
 use Closure;
 use InvalidArgumentException;
+use Pam\Native\Routing\RouteName;
 
 final class Router
 {
+    private readonly string $initialRoute;
     /** @var array<string, Closure> */
     private array $routes = [];
     private string $persistenceKey = 'main';
@@ -32,40 +35,42 @@ final class Router
     private array $linkingPrefixes = [];
     private ?Closure $linkFilter = null;
 
-    private function __construct(private readonly string $initialRoute)
+    private function __construct(string|BackedEnum $initialRoute)
     {
-        if ($initialRoute === '') {
+        $this->initialRoute = RouteName::value($initialRoute);
+        if ($this->initialRoute === '') {
             throw new InvalidArgumentException('The initial route cannot be empty.');
         }
     }
 
-    public static function stack(string $initialRoute): self
+    public static function stack(string|BackedEnum $initialRoute): self
     {
         return new self($initialRoute);
     }
 
-    public static function tabs(string $initialTab): TabRouter
+    public static function tabs(string|BackedEnum $initialTab): TabRouter
     {
-        return new TabRouter($initialTab);
+        return new TabRouter(RouteName::value($initialTab));
     }
 
-    public static function topTabs(string $initialTab): TopTabRouter
+    public static function topTabs(string|BackedEnum $initialTab): TopTabRouter
     {
-        return new TopTabRouter($initialTab);
+        return new TopTabRouter(RouteName::value($initialTab));
     }
 
-    public static function drawer(string $initialRoute): DrawerRouter
+    public static function drawer(string|BackedEnum $initialRoute): DrawerRouter
     {
-        return new DrawerRouter($initialRoute);
+        return new DrawerRouter(RouteName::value($initialRoute));
     }
 
     public function route(
-        string $name,
+        string|BackedEnum $name,
         Closure $screen,
         ScreenOptions|ScreenOptionsPatch|Closure|null $options = null,
         ?Closure $getId = null,
     ): self
     {
+        $name = RouteName::value($name);
         if ($name === '') {
             throw new InvalidArgumentException('Route names cannot be empty.');
         }
@@ -101,15 +106,17 @@ final class Router
     }
 
     /** @param Closure(RouteContext): bool $guard */
-    public function guard(string $route, Closure $guard): self
+    public function guard(string|BackedEnum $route, Closure $guard): self
     {
+        $route = RouteName::value($route);
         $copy = clone $this;
         $copy->routeGuards[$route] = $guard;
         return $copy;
     }
 
-    public function guardFallback(string $route): self
+    public function guardFallback(string|BackedEnum $route): self
     {
+        $route = RouteName::value($route);
         $copy = clone $this;
         $copy->guardFallback = $route;
         return $copy;
@@ -146,10 +153,10 @@ final class Router
         return $copy;
     }
 
-    public function deepLink(string $pattern, string $route): self
+    public function deepLink(string $pattern, string|BackedEnum $route): self
     {
         $copy = clone $this;
-        $copy->deepLinks[] = new DeepLink($pattern, $route);
+        $copy->deepLinks[] = new DeepLink($pattern, RouteName::value($route));
 
         return $copy;
     }

--- a/packages/native/src/Navigation/TabNavigator.php
+++ b/packages/native/src/Navigation/TabNavigator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pam\Native\Navigation;
 
+use BackedEnum;
 use InvalidArgumentException;
 use Pam\Native\AccessibilityRole;
 use Pam\Native\HapticFeedback;
@@ -11,6 +12,7 @@ use Pam\Native\Overflow;
 use Pam\Native\PropKey;
 use Pam\Native\Renderable;
 use Pam\Native\Restorable;
+use Pam\Native\Routing\RouteName;
 use Pam\Native\State;
 use Pam\Native\Style;
 use Pam\Native\System\Haptics;
@@ -47,7 +49,7 @@ final class TabNavigator implements Renderable, Restorable, NavigationStateProvi
      * @param list<NavigationTab> $tabs
      */
     public function __construct(
-        string $initialTab,
+        string|BackedEnum $initialTab,
         array $tabs,
         private readonly TabPresentation $presentation = TabPresentation::Adaptive,
         private readonly string $persistenceKey = 'tabs',
@@ -58,6 +60,7 @@ final class TabNavigator implements Renderable, Restorable, NavigationStateProvi
         private readonly TabBackBehavior $backBehavior = TabBackBehavior::FirstRoute,
         private readonly bool $popToTopOnBlur = false,
     ) {
+        $initialTab = RouteName::value($initialTab);
         if ($tabs === [] || count($tabs) > 5) {
             throw new InvalidArgumentException('Tab navigation requires between one and five destinations.');
         }
@@ -82,8 +85,9 @@ final class TabNavigator implements Renderable, Restorable, NavigationStateProvi
         }
     }
 
-    public function select(string $name): bool
+    public function select(string|BackedEnum $name): bool
     {
+        $name = RouteName::value($name);
         foreach ($this->tabs as $index => $tab) {
             if ($tab->name !== $name) {
                 continue;
@@ -123,7 +127,7 @@ final class TabNavigator implements Renderable, Restorable, NavigationStateProvi
         return $this->tabs[$this->selected - 1]->name;
     }
 
-    public function jumpTo(string $name): bool
+    public function jumpTo(string|BackedEnum $name): bool
     {
         return $this->select($name);
     }

--- a/packages/native/src/Navigation/TopTabNavigator.php
+++ b/packages/native/src/Navigation/TopTabNavigator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pam\Native\Navigation;
 
+use BackedEnum;
 use Closure;
 use InvalidArgumentException;
 use Pam\Native\AccessibilityRole;
@@ -13,6 +14,7 @@ use Pam\Native\GestureEvent;
 use Pam\Native\GestureType;
 use Pam\Native\Renderable;
 use Pam\Native\Restorable;
+use Pam\Native\Routing\RouteName;
 use Pam\Native\State;
 use Pam\Native\Style;
 use Pam\Native\TextAlignment;
@@ -42,7 +44,7 @@ final class TopTabNavigator implements Renderable, Restorable, NavigationStatePr
 
     /** @param list<NavigationTab> $tabs */
     public function __construct(
-        string $initialTab,
+        string|BackedEnum $initialTab,
         array $tabs,
         private readonly string $persistenceKey = 'top-tabs',
         private readonly bool $swipeEnabled = true,
@@ -53,6 +55,7 @@ final class TopTabNavigator implements Renderable, Restorable, NavigationStatePr
         private readonly int $inactiveColor = 0xFF64748B,
         private readonly int $indicatorColor = 0xFF2563EB,
     ) {
+        $initialTab = RouteName::value($initialTab);
         if ($tabs === []) throw new InvalidArgumentException('Top tabs require at least one destination.');
         $names = array_map(static fn (NavigationTab $tab): string => $tab->name, $tabs);
         if (count(array_unique($names)) !== count($names)) throw new InvalidArgumentException('Top tab names must be unique.');
@@ -65,8 +68,9 @@ final class TopTabNavigator implements Renderable, Restorable, NavigationStatePr
         if (!$this->lazy) foreach ($this->tabs as $tab) $this->instance($tab);
     }
 
-    public function jumpTo(string $name): bool
+    public function jumpTo(string|BackedEnum $name): bool
     {
+        $name = RouteName::value($name);
         foreach ($this->tabs as $index => $tab) {
             if ($tab->name !== $name) continue;
             $next = $index + 1;

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.69';
+    public const string SDK_VERSION = '0.6.70';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4888,16 +4888,16 @@ $assert(
 );
 
 $navigator = new Navigator(
-    initialRoute: 'home',
+    initialRoute: TypedRouteTestName::Home,
     routes: [
         'home' => static fn () => Screen::make(Text::make('Home')),
-        'details' => static fn () => Screen::make(Text::make('Details')),
+        'product' => static fn () => Screen::make(Text::make('Product')),
     ],
     transition: NavigationTransition::Fade,
     transitionDurationMs: 300,
 );
 $assert($navigator->render()->toElement()->kind() === NodeKind::NavigationHost, 'Navigator must render a native host.');
-$navigator->push('details');
+$navigator->push(TypedRouteTestName::Product);
 $pushed = $navigator->render()->toElement();
 $assert(count($pushed->children()) === 2, 'Push must retain both screens for the native transition.');
 $assert(
@@ -4920,6 +4920,24 @@ $assert(
     $settledPop->properties()[PropKey::NavigationOperation->value] === NavigationOperation::Idle->value,
     'Settled pop must restore the native host operation to idle.',
 );
+$navigator->preload(TypedRouteTestName::Product);
+$navigator->navigate(TypedRouteTestName::Product, ['id' => 7]);
+$assert($navigator->currentRoute() === 'product', 'Navigator::navigate must accept string-backed route enums.');
+$navigator->replace(TypedRouteTestName::Home);
+$assert($navigator->currentRoute() === 'home', 'Navigator::replace must accept string-backed route enums.');
+$navigator->reset(TypedRouteTestName::Product);
+$assert($navigator->currentRoute() === 'product', 'Navigator::reset must accept string-backed route enums.');
+$assert(
+    NavigationAction::push(TypedRouteTestName::Home)->route === 'home'
+        && NavigationAction::navigate(TypedRouteTestName::Product)->route === 'product'
+        && NavigationAction::replace(TypedRouteTestName::Home)->route === 'home'
+        && NavigationAction::reset(TypedRouteTestName::Product)->route === 'product'
+        && NavigationAction::preload(TypedRouteTestName::Home)->route === 'home',
+    'Imperative navigation actions must normalize string-backed route enums.',
+);
+$navigator->navigate(TypedRouteTestName::Home);
+$navigator->push(TypedRouteTestName::Product);
+$assert($navigator->popTo(TypedRouteTestName::Home), 'Navigator::popTo must accept string-backed route enums.');
 $systemBackConsumed = false;
 $navigator->interceptSystemBack(static function () use (&$systemBackConsumed): bool {
     $systemBackConsumed = true;
@@ -5790,8 +5808,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.69',
-    'The runtime SDK contract must match the 0.6.69 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.70',
+    'The runtime SDK contract must match the 0.6.70 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary\n\n- accepts string-backed route enums across Navigator push/navigate/replace/reset/preload/popTo and availability checks\n- normalizes enums in NavigationAction and NavigationRef before serialization/dispatch\n- extends typed destinations to legacy Router, bottom tabs, top tabs and drawer selectors\n- documents the end-to-end typed contract and prepares v0.6.70\n\n## Validation\n\n- php packages/native/tests/run.php\n- cargo test -p pam-native-protocol\n- cargo check --workspace\n- PHP lint for navigation sources