### PR TITLE
release: PAM Native 0.6.78 with PHP 8.5 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  PAM_RUNTIME_RELEASE_TAG: v0.1.32
+  PAM_RUNTIME_RELEASE_TAG: v2.0.7
 
 defaults:
   run:
@@ -27,7 +27,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "8.4"
           - "8.5"
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/composer-package.yml
+++ b/.github/workflows/composer-package.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ inputs.release_tag }}
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           tools: composer:v2
       - name: Validate immutable Composer split
         env:
@@ -63,7 +63,7 @@ jobs:
           ref: ${{ inputs.release_tag }}
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           tools: composer:v2
       - name: Resolve and validate release
         id: release

--- a/.github/workflows/ecosystem-android.yml
+++ b/.github/workflows/ecosystem-android.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           tools: composer:v2
       - uses: actions/setup-java@v4
         with:
@@ -43,7 +43,7 @@ jobs:
         run: sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.1.12297006' 'cmake;3.22.1'
       - name: Install verified PAM CLI release
         env:
-          PAM_VERSION: v0.1.47
+          PAM_VERSION: v2.0.7
         run: |
           curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
             https://github.com/push-in/pam/releases/download/${PAM_VERSION}/install.sh | sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
   attestations: write
 
 env:
-  PAM_RUNTIME_RELEASE_TAG: v0.1.32
+  PAM_RUNTIME_RELEASE_TAG: v2.0.7
 
 defaults:
   run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   run on PAM's minimal verified PHP 8.5 extension profile.
 - Avoid PHP 8.5's null array-offset deprecation when reactive state is read
   outside an active component render.
+- Resolve PAM 2 runtime catalogs during Android source builds, require their
+  declared PHP 8.5 default and expose the selected immutable runtime to Gradle.
 
 - Make all four iOS, Android renderer, Android plugin API and PHP SDK release
   artifacts reproducible from the tagged commit. The release gate constructs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.6.78 - 2026-08-22
+
+- Make PHP 8.5 the SDK, showcase, certification and release-pipeline baseline,
+  and consume the verified PAM v2.0.7 mobile runtime by default.
+- Replace the incomplete Native CLI help summary with the complete contextual,
+  plugin, runtime, generator, Android and iOS command surface.
+- Collapse the duplicated onboarding section into one canonical Start Here flow
+  built around PAM, Composer and contextual project commands.
+- Remove the PHP SDK's implicit ctype dependency so templates and scoped styles
+  run on PAM's minimal verified PHP 8.5 extension profile.
+- Avoid PHP 8.5's null array-offset deprecation when reactive state is read
+  outside an active component render.
+
 - Make all four iOS, Android renderer, Android plugin API and PHP SDK release
   artifacts reproducible from the tagged commit. The release gate constructs
   each artifact twice, including an isolated clean Gradle rebuild of the AAR,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "0.6.77"
+version = "0.6.78"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.77"
+version = "0.6.78"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.77"
+version = "0.6.78"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.77"
+version = "0.6.78"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Documentation](https://img.shields.io/badge/docs-push--in.github.io-5b50d6?style=flat-square)](https://push-in.github.io/pam-docs/native/overview/)
 [![CI](https://img.shields.io/github/actions/workflow/status/push-in/pam-native/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/push-in/pam-native/actions/workflows/ci.yml)
-![PHP](https://img.shields.io/badge/PHP-8.4-777BB4?style=flat-square&logo=php&logoColor=white)
+![PHP](https://img.shields.io/badge/PHP-8.5-777BB4?style=flat-square&logo=php&logoColor=white)
 ![Android](https://img.shields.io/badge/Android-API%2026–36-3DDC84?style=flat-square&logo=android&logoColor=white)
 ![iOS](https://img.shields.io/badge/iOS-15%2B-000000?style=flat-square&logo=apple&logoColor=white)
 ![License](https://img.shields.io/badge/license-Apache--2.0-22c55e?style=flat-square)
@@ -99,45 +99,7 @@ final class ProductScreen extends Component
 }
 ```
 
-## Start here
-
-PAM Native is installed, built, run, and updated through the **PAM CLI**. You
-install PAM once; PAM then manages its private PHP runtime, Composer, the PAM
-Native SDK, native hosts, plugins, code generation, development sessions, and
-release builds for every project.
-
-### 1. Install PAM
-
-```bash
-curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
-  https://github.com/push-in/pam/releases/latest/download/install.sh | sh
-```
-
-Restart your terminal if requested, then verify the installation:
-
-```bash
-pam --version
-pam doctor
-```
-
-PAM includes and verifies Composer when it is first needed. You do not need a
-global Composer or a separate PHP installation for the normal workflow.
-
-### 2. Create a native application
-
-```bash
-pam init hello-native --template native
-cd hello-native
-pam doctor
-pam dev
-```
-
-Run `pam` without arguments for the guided project launcher. The explicit
-`pam mobile ...` commands remain available for CI and advanced multi-project
-automation, but inside a PAM Native project the short contextual commands are
-the primary interface.
-
-### 3. Grow and ship it
+### Grow and ship it
 
 ```bash
 pam make:screen Products

--- a/certification/android-ecosystem/composer.json
+++ b/certification/android-ecosystem/composer.json
@@ -4,8 +4,8 @@
     "type": "project",
     "license": "Apache-2.0",
     "require": {
-        "php": "^8.4",
-    "pushinbr/pam-native": ">=0.6.1 <1.0.0",
+        "php": "^8.5",
+        "pushinbr/pam-native": ">=0.6.1 <1.0.0",
     "pushinbr/pam-native-auth": ">=0.1.0 <1.0.0",
     "pushinbr/pam-native-background-transfer": ">=0.1.0 <1.0.0",
     "pushinbr/pam-native-bluetooth": ">=0.1.0 <1.0.0",

--- a/certification/android-ecosystem/composer.lock
+++ b/certification/android-ecosystem/composer.lock
@@ -4,31 +4,339 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37cd3679a7db1a9d635817d39ca56c62",
+    "content-hash": "94334afeb7fd25ed4e43823268a43aa1",
     "packages": [
         {
             "name": "pushinbr/pam-native",
-            "version": "v0.6.40",
+            "version": "v0.6.77",
             "source": {
                 "type": "git",
                 "url": "https://github.com/push-in/pam-native-php.git",
-                "reference": "bd8ef1bca452452a4399ee7b1be75a5d75e3327e"
+                "reference": "1ed215809cdc52db75460d9c63d4627ea6bb2007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/push-in/pam-native-php/zipball/bd8ef1bca452452a4399ee7b1be75a5d75e3327e",
-                "reference": "bd8ef1bca452452a4399ee7b1be75a5d75e3327e",
+                "url": "https://api.github.com/repos/push-in/pam-native-php/zipball/1ed215809cdc52db75460d9c63d4627ea6bb2007",
+                "reference": "1ed215809cdc52db75460d9c63d4627ea6bb2007",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.4"
             },
             "bin": [
+                "bin/pam-native",
                 "bin/pam-native-format",
-                "bin/pam-native-optimize"
+                "bin/pam-native-language-server",
+                "bin/pam-native-optimize",
+                "bin/pam-native-routes"
             ],
             "type": "library",
             "extra": {
+                "pam": {
+                    "commands": {
+                        "dev": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "dev"
+                            ],
+                            "description": "Start PAM Native development"
+                        },
+                        "run": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "run"
+                            ],
+                            "description": "Run the PAM Native application"
+                        },
+                        "logs": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "logs"
+                            ],
+                            "description": "Inspect PAM Native application logs"
+                        },
+                        "sign": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "sign"
+                            ],
+                            "description": "Validate PAM Native release signing"
+                        },
+                        "audit": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "audit"
+                            ],
+                            "description": "Audit native capabilities and platform authority"
+                        },
+                        "build": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "build"
+                            ],
+                            "description": "Build the PAM Native application"
+                        },
+                        "doctor": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "doctor"
+                            ],
+                            "description": "Diagnose the PAM Native project"
+                        },
+                        "format": {
+                            "script": "bin/pam-native-format",
+                            "description": "Format PAM Native components"
+                        },
+                        "mobile": {
+                            "bin": "bin/pam-native",
+                            "description": "Legacy alias for PAM Native tooling"
+                        },
+                        "native": {
+                            "bin": "bin/pam-native",
+                            "description": "Build, run and diagnose PAM Native applications"
+                        },
+                        "codegen": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "codegen"
+                            ],
+                            "description": "Generate native bindings"
+                        },
+                        "devices": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "devices"
+                            ],
+                            "description": "List native development targets"
+                        },
+                        "ios:dev": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:dev"
+                            ],
+                            "description": "Start PAM Native iOS development"
+                        },
+                        "ios:run": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:run"
+                            ],
+                            "description": "Run the PAM Native iOS application"
+                        },
+                        "package": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "package"
+                            ],
+                            "description": "Package the PAM Native application"
+                        },
+                        "prepare": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "prepare"
+                            ],
+                            "description": "Prepare the PAM Native Android host"
+                        },
+                        "profile": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "profile"
+                            ],
+                            "description": "Profile the PAM Native application"
+                        },
+                        "devtools": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "devtools"
+                            ],
+                            "description": "Open PAM Native development tools"
+                        },
+                        "ios:logs": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:logs"
+                            ],
+                            "description": "Stream PAM Native iOS logs"
+                        },
+                        "ios:sign": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:sign"
+                            ],
+                            "description": "Inspect PAM Native iOS signing"
+                        },
+                        "benchmark": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "benchmark"
+                            ],
+                            "description": "Benchmark the PAM Native application"
+                        },
+                        "ios:build": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:build"
+                            ],
+                            "description": "Build the PAM Native iOS application"
+                        },
+                        "ios:doctor": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:doctor"
+                            ],
+                            "description": "Diagnose the PAM Native iOS host"
+                        },
+                        "screenshot": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "screenshot"
+                            ],
+                            "description": "Capture a native device screenshot"
+                        },
+                        "diagnostics": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "diagnostics"
+                            ],
+                            "description": "Capture PAM Native diagnostics"
+                        },
+                        "ios:devices": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:devices"
+                            ],
+                            "description": "List iOS development targets"
+                        },
+                        "ios:package": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:package"
+                            ],
+                            "description": "Package the PAM Native iOS application"
+                        },
+                        "ios:prepare": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:prepare"
+                            ],
+                            "description": "Prepare the PAM Native iOS host"
+                        },
+                        "make:screen": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "make:screen"
+                            ],
+                            "description": "Generate a PAM Native screen"
+                        },
+                        "plugin:list": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "plugin:list"
+                            ],
+                            "description": "List installed PAM Native plugins"
+                        },
+                        "runtime:use": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:use"
+                            ],
+                            "description": "Select a native runtime"
+                        },
+                        "ios:devtools": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:devtools"
+                            ],
+                            "description": "Open PAM Native iOS development tools"
+                        },
+                        "runtime:info": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:info"
+                            ],
+                            "description": "Inspect the selected native runtime"
+                        },
+                        "runtime:list": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:list"
+                            ],
+                            "description": "List installed native runtimes"
+                        },
+                        "native:format": {
+                            "script": "bin/pam-native-format",
+                            "description": "Format PAM Native components"
+                        },
+                        "native:routes": {
+                            "script": "bin/pam-native-routes",
+                            "description": "Inspect PAM Native routes"
+                        },
+                        "plugin:doctor": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "plugin:doctor"
+                            ],
+                            "description": "Diagnose installed PAM Native plugins"
+                        },
+                        "ios:screenshot": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:screenshot"
+                            ],
+                            "description": "Capture an iOS screenshot"
+                        },
+                        "make:component": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "make:component"
+                            ],
+                            "description": "Generate a PAM Native component"
+                        },
+                        "runtime:update": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:update"
+                            ],
+                            "description": "Update the selected native runtime"
+                        },
+                        "ios:diagnostics": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:diagnostics"
+                            ],
+                            "description": "Capture PAM Native iOS diagnostics"
+                        },
+                        "native:optimize": {
+                            "script": "bin/pam-native-optimize",
+                            "description": "Optimize a PAM Native application"
+                        },
+                        "runtime:install": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:install"
+                            ],
+                            "description": "Install the selected native runtime"
+                        },
+                        "make:native-view": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "make:native-view"
+                            ],
+                            "description": "Generate a PAM Native platform view"
+                        },
+                        "android:diagnostics": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "android:diagnostics"
+                            ],
+                            "description": "Capture Android diagnostics"
+                        },
+                        "native:language-server": {
+                            "script": "bin/pam-native-language-server",
+                            "description": "Start the PAM Native language server"
+                        }
+                    }
+                },
                 "pam-native": {
                     "protocol": 1,
                     "plugin-schema": "resources/pam-native.plugin.schema.json",
@@ -43,7 +351,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BUSL-1.1"
+                "Apache-2.0"
             ],
             "description": "Build fast native Android and iOS applications with PHP and PAM.",
             "homepage": "https://github.com/push-in/pam-native",
@@ -58,7 +366,7 @@
                 "issues": "https://github.com/push-in/pam-native/issues",
                 "source": "https://github.com/push-in/pam-native"
             },
-            "time": "2026-08-06T12:09:27+00:00"
+            "time": "2026-08-22T01:05:32+00:00"
         },
         {
             "name": "pushinbr/pam-native-auth",
@@ -432,16 +740,16 @@
         },
         {
             "name": "pushinbr/pam-native-media",
-            "version": "v0.1.0",
+            "version": "v0.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/push-in/pam-native-media.git",
-                "reference": "b91a52ef7f297c5f3480f111c05831f88c989116"
+                "reference": "8e08f77e90f9b6f91c04697546bf233011c1bf85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/push-in/pam-native-media/zipball/b91a52ef7f297c5f3480f111c05831f88c989116",
-                "reference": "b91a52ef7f297c5f3480f111c05831f88c989116",
+                "url": "https://api.github.com/repos/push-in/pam-native-media/zipball/8e08f77e90f9b6f91c04697546bf233011c1bf85",
+                "reference": "8e08f77e90f9b6f91c04697546bf233011c1bf85",
                 "shasum": ""
             },
             "require": {
@@ -464,14 +772,14 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BUSL-1.1"
+                "Apache-2.0"
             ],
-            "description": "Native media inspection and thumbnail generation for PAM Native.",
+            "description": "Native media inspection, thumbnails and embedded camera capture for PAM Native.",
             "support": {
                 "issues": "https://github.com/push-in/pam-native-media/issues",
-                "source": "https://github.com/push-in/pam-native-media/tree/v0.1.0"
+                "source": "https://github.com/push-in/pam-native-media/tree/v0.2.3"
             },
-            "time": "2026-08-01T04:42:21+00:00"
+            "time": "2026-08-07T11:53:19+00:00"
         },
         {
             "name": "pushinbr/pam-native-nfc",
@@ -804,7 +1112,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4"
+        "php": "^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/certification/android-ecosystem/pam-native.json
+++ b/certification/android-ecosystem/pam-native.json
@@ -5,7 +5,7 @@
     "name": "PAM Native Ecosystem Certification",
     "entry": "index.php",
     "runtime": {
-        "php": "8.4",
+        "php": "8.5",
         "channel": "stable"
     },
     "android": {

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -6721,7 +6721,7 @@ fn write_atomic(path: &Path, contents: &[u8]) -> Result<(), String> {
 
 fn print_usage() {
     eprintln!(
-        "PAM Native commands: init, dev, build, run, doctor, package, devices, logs, codegen, and ios:*"
+        "PAM Native commands:\n  doctor, audit, dev, build, run, package, sign\n  devices, logs, screenshot, devtools, diagnostics\n  prepare, codegen, benchmark, profile\n  plugin:list, plugin:doctor\n  runtime:list, runtime:info, runtime:use, runtime:install, runtime:update\n  make:screen, make:component, make:native-view\n  ios:prepare, ios:doctor, ios:dev, ios:build, ios:run, ios:package, ios:sign, ios:devices, ios:logs, ios:screenshot, ios:devtools, ios:diagnostics"
     );
 }
 

--- a/docs/ecosystem-architecture.md
+++ b/docs/ecosystem-architecture.md
@@ -39,7 +39,7 @@ matrix, changelog, CI, and signed release evidence.
 
 Every repository must pass the following gates before its first stable tag:
 
-1. Strict Composer metadata, PHP 8.4+, PHPStan level 9, formatting and unit tests.
+1. Strict Composer metadata, PHP 8.5+, PHPStan level 9, formatting and unit tests.
 2. Generated binary-wire contracts with sequential integer enums for every
    status, type, state, kind, category or discriminator.
 3. Android lint, unit tests, instrumentation tests and release assembly on the

--- a/examples/community-plugin/composer.json
+++ b/examples/community-plugin/composer.json
@@ -4,8 +4,8 @@
     "type": "pam-native-plugin",
     "license": "Apache-2.0",
     "require": {
-        "php": "^8.4",
-    "pushinbr/pam-native": "^0.6.1"
+        "php": "^8.5",
+        "pushinbr/pam-native": "^0.6.78"
     },
     "autoload": {
         "psr-4": {

--- a/examples/showcase/composer.json
+++ b/examples/showcase/composer.json
@@ -4,8 +4,8 @@
     "type": "project",
     "license": "Apache-2.0",
     "require": {
-        "php": "^8.4",
-    "pushinbr/pam-native": "^0.6.1",
+        "php": "^8.5",
+        "pushinbr/pam-native": "^0.6.78",
         "pam-community/example-plugin": "^0.1"
     },
     "repositories": [
@@ -15,7 +15,7 @@
             "options": {
                 "symlink": false,
                 "versions": {
-          "pushinbr/pam-native": "0.6.45"
+                    "pushinbr/pam-native": "0.6.78"
                 }
             }
         },

--- a/examples/showcase/composer.lock
+++ b/examples/showcase/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10030698802571b62d9286e7ae7b97df",
+    "content-hash": "dc29c0a7d767ffa501ecc767dfb693d2",
     "packages": [
         {
             "name": "pam-community/example-plugin",
@@ -12,11 +12,11 @@
             "dist": {
                 "type": "path",
                 "url": "../community-plugin",
-                "reference": "433a28baadb065973e814630a93d78543cfc5404"
+                "reference": "9103e15f712efe20c50a25c0b11a36db6f2001b7"
             },
             "require": {
-                "php": "^8.4",
-                "pushinbr/pam-native": "^0.6.1"
+                "php": "^8.5",
+                "pushinbr/pam-native": "^0.6.78"
             },
             "type": "pam-native-plugin",
             "extra": {
@@ -40,21 +40,329 @@
         },
         {
             "name": "pushinbr/pam-native",
-            "version": "0.6.45",
+            "version": "0.6.78",
             "dist": {
                 "type": "path",
                 "url": "../../packages/native",
-                "reference": "65536b0232ba6472544d46d6b8e8d6dd048d6e28"
+                "reference": "dfc304277d158945b2d7dca3a493b075f68b01fa"
             },
             "require": {
-                "php": "^8.4"
+                "php": "^8.5"
             },
             "bin": [
+                "bin/pam-native",
                 "bin/pam-native-format",
-                "bin/pam-native-optimize"
+                "bin/pam-native-language-server",
+                "bin/pam-native-optimize",
+                "bin/pam-native-routes"
             ],
             "type": "library",
             "extra": {
+                "pam": {
+                    "commands": {
+                        "benchmark": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "benchmark"
+                            ],
+                            "description": "Benchmark the PAM Native application"
+                        },
+                        "build": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "build"
+                            ],
+                            "description": "Build the PAM Native application"
+                        },
+                        "dev": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "dev"
+                            ],
+                            "description": "Start PAM Native development"
+                        },
+                        "devices": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "devices"
+                            ],
+                            "description": "List native development targets"
+                        },
+                        "devtools": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "devtools"
+                            ],
+                            "description": "Open PAM Native development tools"
+                        },
+                        "doctor": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "doctor"
+                            ],
+                            "description": "Diagnose the PAM Native project"
+                        },
+                        "audit": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "audit"
+                            ],
+                            "description": "Audit native capabilities and platform authority"
+                        },
+                        "codegen": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "codegen"
+                            ],
+                            "description": "Generate native bindings"
+                        },
+                        "diagnostics": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "diagnostics"
+                            ],
+                            "description": "Capture PAM Native diagnostics"
+                        },
+                        "android:diagnostics": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "android:diagnostics"
+                            ],
+                            "description": "Capture Android diagnostics"
+                        },
+                        "ios:prepare": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:prepare"
+                            ],
+                            "description": "Prepare the PAM Native iOS host"
+                        },
+                        "ios:doctor": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:doctor"
+                            ],
+                            "description": "Diagnose the PAM Native iOS host"
+                        },
+                        "ios:build": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:build"
+                            ],
+                            "description": "Build the PAM Native iOS application"
+                        },
+                        "ios:run": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:run"
+                            ],
+                            "description": "Run the PAM Native iOS application"
+                        },
+                        "ios:dev": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:dev"
+                            ],
+                            "description": "Start PAM Native iOS development"
+                        },
+                        "ios:sign": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:sign"
+                            ],
+                            "description": "Inspect PAM Native iOS signing"
+                        },
+                        "ios:package": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:package"
+                            ],
+                            "description": "Package the PAM Native iOS application"
+                        },
+                        "ios:logs": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:logs"
+                            ],
+                            "description": "Stream PAM Native iOS logs"
+                        },
+                        "ios:devices": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:devices"
+                            ],
+                            "description": "List iOS development targets"
+                        },
+                        "ios:screenshot": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:screenshot"
+                            ],
+                            "description": "Capture an iOS screenshot"
+                        },
+                        "ios:devtools": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:devtools"
+                            ],
+                            "description": "Open PAM Native iOS development tools"
+                        },
+                        "ios:diagnostics": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "ios:diagnostics"
+                            ],
+                            "description": "Capture PAM Native iOS diagnostics"
+                        },
+                        "format": {
+                            "script": "bin/pam-native-format",
+                            "description": "Format PAM Native components"
+                        },
+                        "logs": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "logs"
+                            ],
+                            "description": "Inspect PAM Native application logs"
+                        },
+                        "mobile": {
+                            "bin": "bin/pam-native",
+                            "description": "Legacy alias for PAM Native tooling"
+                        },
+                        "native": {
+                            "bin": "bin/pam-native",
+                            "description": "Build, run and diagnose PAM Native applications"
+                        },
+                        "native:format": {
+                            "script": "bin/pam-native-format",
+                            "description": "Format PAM Native components"
+                        },
+                        "native:language-server": {
+                            "script": "bin/pam-native-language-server",
+                            "description": "Start the PAM Native language server"
+                        },
+                        "native:optimize": {
+                            "script": "bin/pam-native-optimize",
+                            "description": "Optimize a PAM Native application"
+                        },
+                        "native:routes": {
+                            "script": "bin/pam-native-routes",
+                            "description": "Inspect PAM Native routes"
+                        },
+                        "make:component": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "make:component"
+                            ],
+                            "description": "Generate a PAM Native component"
+                        },
+                        "make:native-view": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "make:native-view"
+                            ],
+                            "description": "Generate a PAM Native platform view"
+                        },
+                        "make:screen": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "make:screen"
+                            ],
+                            "description": "Generate a PAM Native screen"
+                        },
+                        "package": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "package"
+                            ],
+                            "description": "Package the PAM Native application"
+                        },
+                        "prepare": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "prepare"
+                            ],
+                            "description": "Prepare the PAM Native Android host"
+                        },
+                        "profile": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "profile"
+                            ],
+                            "description": "Profile the PAM Native application"
+                        },
+                        "run": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "run"
+                            ],
+                            "description": "Run the PAM Native application"
+                        },
+                        "sign": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "sign"
+                            ],
+                            "description": "Validate PAM Native release signing"
+                        },
+                        "screenshot": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "screenshot"
+                            ],
+                            "description": "Capture a native device screenshot"
+                        },
+                        "plugin:list": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "plugin:list"
+                            ],
+                            "description": "List installed PAM Native plugins"
+                        },
+                        "plugin:doctor": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "plugin:doctor"
+                            ],
+                            "description": "Diagnose installed PAM Native plugins"
+                        },
+                        "runtime:list": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:list"
+                            ],
+                            "description": "List installed native runtimes"
+                        },
+                        "runtime:info": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:info"
+                            ],
+                            "description": "Inspect the selected native runtime"
+                        },
+                        "runtime:use": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:use"
+                            ],
+                            "description": "Select a native runtime"
+                        },
+                        "runtime:install": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:install"
+                            ],
+                            "description": "Install the selected native runtime"
+                        },
+                        "runtime:update": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "runtime:update"
+                            ],
+                            "description": "Update the selected native runtime"
+                        }
+                    }
+                },
                 "pam-native": {
                     "manifest-schema": "resources/pam-native.schema.json",
                     "plugin-schema": "resources/pam-native.plugin.schema.json",
@@ -96,7 +404,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4"
+        "php": "^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/examples/showcase/resources/native/screens/gallery.pam
+++ b/examples/showcase/resources/native/screens/gallery.pam
@@ -134,7 +134,7 @@
                     </Row>
                 </Pressable>
 
-                <Text height="42" textColor="#FF71859D" textAlign="center" fontSize="12">Android API 26–36 · iOS UIKit · PHP 8.4 · Rust</Text>
+                <Text height="42" textColor="#FF71859D" textAlign="center" fontSize="12">Android API 26–36 · iOS UIKit · PHP 8.5 · Rust</Text>
             </Column>
         </ScrollView>
     </SafeAreaView>

--- a/packages/native/composer.json
+++ b/packages/native/composer.json
@@ -16,7 +16,7 @@
         "source": "https://github.com/push-in/pam-native"
     },
     "require": {
-        "php": "^8.4"
+        "php": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/packages/native/src/Internal/DependencyTracker.php
+++ b/packages/native/src/Internal/DependencyTracker.php
@@ -41,7 +41,8 @@ final class DependencyTracker
 
     public static function read(object $source, string $key): void
     {
-        $component = self::$stack[array_key_last(self::$stack)] ?? null;
+        $last = array_key_last(self::$stack);
+        $component = $last === null ? null : self::$stack[$last];
         if (!$component instanceof Component) {
             return;
         }

--- a/packages/native/src/Internal/ScopedStyleCompiler.php
+++ b/packages/native/src/Internal/ScopedStyleCompiler.php
@@ -903,7 +903,7 @@ final class ScopedStyleCompiler
                     throw new RuntimeException("Invalid CSS value in {$name}.");
                 }
             }
-            if (ctype_space($character) && $depth === 0) {
+            if (self::isAsciiWhitespace($character) && $depth === 0) {
                 if ($start !== null) {
                     $parts[] = substr($value, $start, $index - $start);
                     $start = null;
@@ -920,6 +920,16 @@ final class ScopedStyleCompiler
         }
 
         return $parts;
+    }
+
+    private static function isAsciiWhitespace(string $character): bool
+    {
+        return $character === ' '
+            || $character === "\t"
+            || $character === "\n"
+            || $character === "\r"
+            || $character === "\f"
+            || $character === "\v";
     }
 
     private static function containsTopLevelComma(string $value): bool

--- a/packages/native/src/Internal/TemplateCompiler.php
+++ b/packages/native/src/Internal/TemplateCompiler.php
@@ -378,7 +378,7 @@ final class TemplateCompiler
             }
             if (
                 $nameOffset >= $length
-                || !ctype_alpha($source[$nameOffset])
+                || !self::isAsciiLetter($source[$nameOffset])
             ) {
                 continue;
             }
@@ -424,6 +424,12 @@ final class TemplateCompiler
         }
 
         return $tokens;
+    }
+
+    private static function isAsciiLetter(string $character): bool
+    {
+        return ($character >= 'A' && $character <= 'Z')
+            || ($character >= 'a' && $character <= 'z');
     }
 
     /** @param list<CompiledTemplateNode> $stack */

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.77';
+    public const string SDK_VERSION = '0.6.78';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6215,8 +6215,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.77',
-    'The runtime SDK contract must match the 0.6.77 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.6.78',
+    'The runtime SDK contract must match the 0.6.78 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,

--- a/scripts/prepare-android-runtime.sh
+++ b/scripts/prepare-android-runtime.sh
@@ -11,7 +11,7 @@ if [[ ! ${runtime_tag} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
-for command in cargo curl rustup sha256sum tar; do
+for command in cargo curl python3 rustup sha256sum tar; do
     if ! command -v "${command}" >/dev/null 2>&1; then
         echo "Missing required command: ${command}" >&2
         exit 1
@@ -67,6 +67,29 @@ done < <(tar -tzf "${temporary_directory}/${asset}")
 
 tar -xzf "${temporary_directory}/${asset}" -C "${repository_root}"
 
+catalog="${repository_root}/runtime/catalog.json"
+runtime_id=$(python3 - "${catalog}" <<'PY'
+import json
+import pathlib
+import sys
+
+catalog = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if catalog.get("schemaVersion") != 1:
+    raise SystemExit("Unsupported PAM runtime catalog schema")
+series = catalog.get("default")
+runtime_id = catalog.get("channels", {}).get(series)
+release = catalog.get("releases", {}).get(runtime_id, {})
+if series != "8.5" or not str(release.get("phpVersion", "")).startswith("8.5."):
+    raise SystemExit("The PAM Android runtime default must be PHP 8.5")
+print(runtime_id)
+PY
+)
+runtime_root="${repository_root}/runtime/android/${runtime_id}"
+for abi in arm64-v8a x86_64; do
+    test -f "${runtime_root}/${abi}/lib/libphp.a"
+    cp -a "${runtime_root}/${abi}" "${repository_root}/runtime/android/${abi}"
+done
+
 rustup target add aarch64-linux-android x86_64-linux-android
 
 ndk_bin="${ndk_root}/toolchains/llvm/prebuilt/${ndk_host}/bin"
@@ -91,4 +114,4 @@ test -f "${repository_root}/runtime/android/x86_64/lib/libphp.a"
 test -f "${repository_root}/target/aarch64-linux-android/release/libpam_native_engine.a"
 test -f "${repository_root}/target/x86_64-linux-android/release/libpam_native_engine.a"
 
-echo "Android runtime ${runtime_tag} and native engine are ready."
+echo "Android runtime ${runtime_tag}/${runtime_id} and native engine are ready."

--- a/scripts/prepare-android-runtime.sh
+++ b/scripts/prepare-android-runtime.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-runtime_tag=${PAM_RUNTIME_RELEASE_TAG:-v0.1.32}
+runtime_tag=${PAM_RUNTIME_RELEASE_TAG:-v2.0.7}
 runtime_repository=${PAM_RUNTIME_REPOSITORY:-push-in/pam}
 
 if [[ ! ${runtime_tag} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then


### PR DESCRIPTION
## Outcome

Makes PHP 8.5 and PAM Runtime v2.0.7 the default Native toolchain, aligns public certification and examples, fixes PHP 8.5 runtime compatibility, completes CLI help, and consolidates onboarding.

## Local evidence

- PHP SDK, performance, navigation and 1,000-frame fuzz on PAM Runtime PHP 8.5.9
- 98 Rust tests
- Clippy with warnings denied
- protocol/workflow/evidence/editor tests
- Composer manifests and locks validated
- immutable Composer split verified