### PR TITLE
fix: accept Composer release version prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   outside an active component render.
 - Resolve PAM 2 runtime catalogs during Android source builds, require their
   declared PHP 8.5 default and expose the selected immutable runtime to Gradle.
+- Accept Composer's canonical `vMAJOR.MINOR.PATCH` installed-package version
+  while retaining strict SemVer validation for Native plugin compatibility.
 
 - Make all four iOS, Android renderer, Android plugin API and PHP SDK release
   artifacts reproducible from the tagged commit. The release gate constructs

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -1333,7 +1333,10 @@ fn discover_plugins(root: &Path, app: &NativeManifest) -> Result<Vec<NativePlugi
         .find(|package| package.name == "pushinbr/pam-native")
         .map(|package| package.version.clone())
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_owned());
-    let current_version = parse_release_version(&current_version_text)?;
+    let composer_release = current_version_text
+        .strip_prefix('v')
+        .unwrap_or(&current_version_text);
+    let current_version = parse_release_version(composer_release)?;
     let mut plugins = Vec::new();
 
     for package in packages {
@@ -7264,7 +7267,7 @@ mod tests {
             r#"{
                 "packages": [{
                     "name": "pushinbr/pam-native",
-                    "version": "0.6.0"
+                    "version": "v0.6.0"
                 }, {
                     "name": "community/example",
                     "version": "1.2.3",


### PR DESCRIPTION
Fixes clean-host ecosystem certification when Packagist exposes the installed SDK as `vMAJOR.MINOR.PATCH`. The prefix is normalized only at the Composer boundary; plugin compatibility versions remain strict.

Regression test updates the installed.json fixture to the exact public form.