### PR TITLE
ci: certify the candidate Native CLI

### DIFF
--- a/.github/workflows/ecosystem-android.yml
+++ b/.github/workflows/ecosystem-android.yml
@@ -54,7 +54,12 @@ jobs:
           echo "PAM_HOME=${pam_distribution}/share/pam" >> "$GITHUB_ENV"
           echo "PAM_NATIVE_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
       - name: Prepare verified PHP 8.5 runtime and candidate Native engine
-        run: scripts/prepare-android-runtime.sh
+        run: |
+          scripts/prepare-android-runtime.sh
+          # The candidate preparer verifies and normalizes the release runtime
+          # under this checkout. Point host generation at that exact tree so
+          # CMake consumes the same immutable PHP 8.5 payload we certified.
+          echo "PAM_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
       - name: Install exact public Composer packages
         working-directory: certification/android-ecosystem
         run: composer install --no-interaction --prefer-dist --no-progress

--- a/.github/workflows/ecosystem-android.yml
+++ b/.github/workflows/ecosystem-android.yml
@@ -53,6 +53,8 @@ jobs:
           pam_distribution=$(cd "$(dirname "${pam_binary}")/.." && pwd)
           echo "PAM_HOME=${pam_distribution}/share/pam" >> "$GITHUB_ENV"
           echo "PAM_NATIVE_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+      - name: Prepare verified PHP 8.5 runtime and candidate Native engine
+        run: scripts/prepare-android-runtime.sh
       - name: Install exact public Composer packages
         working-directory: certification/android-ecosystem
         run: composer install --no-interaction --prefer-dist --no-progress

--- a/.github/workflows/ecosystem-android.yml
+++ b/.github/workflows/ecosystem-android.yml
@@ -34,11 +34,12 @@ jobs:
         with:
           php-version: '8.5'
           tools: composer:v2
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@v4
+      - uses: dtolnay/rust-toolchain@1.88.0
       - name: Install pinned Android SDK
         run: sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.1.12297006' 'cmake;3.22.1'
       - name: Install verified PAM CLI release
@@ -48,12 +49,19 @@ jobs:
           curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
             https://github.com/push-in/pam/releases/download/${PAM_VERSION}/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          pam_binary=$(readlink -f "$HOME/.local/bin/pam")
+          pam_distribution=$(cd "$(dirname "${pam_binary}")/.." && pwd)
+          echo "PAM_HOME=${pam_distribution}/share/pam" >> "$GITHUB_ENV"
+          echo "PAM_NATIVE_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
       - name: Install exact public Composer packages
         working-directory: certification/android-ecosystem
         run: composer install --no-interaction --prefer-dist --no-progress
       - name: Generate the aggregate Android host
         working-directory: certification/android-ecosystem
-        run: pam mobile prepare .
+        run: >-
+          cargo run --locked --release
+          --manifest-path ../../Cargo.toml
+          --package pam-native-cli -- prepare .
       - name: Compile and lint every plugin in one application
         working-directory: certification/android-ecosystem/.pam-native/android
         run: ./gradlew :app:assembleDebug :app:lintDebug --stacktrace --no-daemon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   declared PHP 8.5 default and expose the selected immutable runtime to Gradle.
 - Accept Composer's canonical `vMAJOR.MINOR.PATCH` installed-package version
   while retaining strict SemVer validation for Native plugin compatibility.
+- Certify public Android plugins with the candidate Native CLI and the verified
+  public PAM runtime, removing the pre-release dependency on an older SDK CLI.
 
 - Make all four iOS, Android renderer, Android plugin API and PHP SDK release
   artifacts reproducible from the tagged commit. The release gate constructs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   while retaining strict SemVer validation for Native plugin compatibility.
 - Certify public Android plugins with the candidate Native CLI and the verified
   public PAM runtime, removing the pre-release dependency on an older SDK CLI.
+- Build the candidate Rust engine for both supported Android ABIs inside the
+  aggregate plugin job instead of relying on artifacts from another workflow.
 
 - Make all four iOS, Android renderer, Android plugin API and PHP SDK release
   artifacts reproducible from the tagged commit. The release gate constructs

--- a/certification/android-ecosystem/pam-native.json
+++ b/certification/android-ecosystem/pam-native.json
@@ -12,6 +12,9 @@
         "minSdk": 26,
         "targetSdk": 36
     },
+    "ios": {
+        "minimumVersion": "18.0"
+    },
     "modules": [],
     "views": []
 }


### PR DESCRIPTION
Breaks the pre-release certification cycle: public plugin releases and the signed PAM runtime remain external inputs, while host generation uses the exact Native CLI commit under certification. Also pins PAM_HOME/PAM_NATIVE_HOME explicitly and updates Java/Android setup actions.