### PR TITLE
PAM Native 0.7: Singularity architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:v2
+          tools: composer:v2, phpstan:2.2.9
       - uses: Swatinem/rust-cache@v2
       - name: Validate manifests
         run: |
@@ -57,6 +57,7 @@ jobs:
           php packages/native/tests/performance.php
           php packages/native/tests/navigation_performance.php
           php packages/native/tests/fuzz.php
+          phpstan analyse --configuration=packages/native/phpstan-singularity.neon --no-progress
           php scripts/test-release-workflows.php
           php scripts/test-hot-reload-evidence.php
           python3 -m unittest scripts/test_accessibility_evidence.py
@@ -64,6 +65,7 @@ jobs:
           python3 -m unittest benchmarks/mobile/test_compare.py
           python3 -m unittest benchmarks/package/test_gate.py
           python3 -m unittest benchmarks/package/test_reproducibility.py
+          python3 -m unittest scripts/test_sbom.py
           python3 -m json.tool benchmarks/mobile/budgets.json >/dev/null
           python3 -m json.tool benchmarks/ios/budgets.json >/dev/null
           python3 -m json.tool benchmarks/package/budgets.json >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,6 +362,22 @@ jobs:
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: dist/pam-native-accessibility-evidence.json
+      - name: Generate SPDX 2.3 software bill of materials
+        id: sbom
+        run: |
+          version=${GITHUB_REF_NAME#v}
+          sbom="dist/pam-native-${version}.spdx.json"
+          python3 scripts/sbom.py \
+            --version "${version}" \
+            --commit "${GITHUB_SHA}" \
+            --created-epoch "$(git log -1 --format=%ct)" \
+            --output "${sbom}"
+          echo "path=${sbom}" >> "$GITHUB_OUTPUT"
+      - name: Attest software bill of materials
+        uses: actions/attest-sbom@v4
+        with:
+          subject-path: dist/pam-native-php-*.tar.gz
+          sbom-path: ${{ steps.sbom.outputs.path }}
       - uses: softprops/action-gh-release@v3
         with:
           files: dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 0.7.0 - 2026-08-23
+
+- Added schema-2 reflection contracts with generated PHP, Kotlin and Swift bindings.
+- Added structured task groups, deadlines, cancellation and bounded async streams.
+- Added transactional Rust render generations for atomic 60/90/120 Hz scheduling.
+- Added encrypted local-first records, outbox batching and deterministic conflict policies.
+- Added stateful hot reload snapshots and deterministic DevTools replay timelines.
+- Added capability-governed plugin registry entries with trust tiers and quality scores.
+- Added in-process HTTP routing and middleware through a socket-free local transport.
+- Added `pam release` and four-framework physical-device comparison evidence.
+- Added the Singularity showcase and architecture documentation.
+
 ## 0.6.78 - 2026-08-22
 
 - Make PHP 8.5 the SDK, showcase, certification and release-pipeline baseline,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "0.6.78"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "0.6.78"
+version = "0.7.0"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.6.78"
+version = "0.7.0"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.78"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ pam make:screen Products
 pam composer require pushinbr/pam-native-maps
 pam test
 pam build
+pam release --platform android
 ```
 
 Use Packagist to explore official and community capabilities. Composer remains
@@ -245,7 +246,7 @@ installation is intended for custom hosts and framework contributors; most
 applications should start with `pam init` or `pam add`:
 
 ```bash
-pam composer require pushinbr/pam-native:^0.6
+pam composer require pushinbr/pam-native:^0.7
 ```
 
 ## Community

--- a/benchmarks/mobile/README.md
+++ b/benchmarks/mobile/README.md
@@ -1,5 +1,16 @@
 # Mobile benchmark contract
 
+The comparison harness accepts React Native as the required public baseline and
+optional Flutter and platform-native reports. A matrix is emitted only for
+measurements present in every report, preventing selective claims:
+
+```bash
+python3 benchmarks/mobile/compare.py \
+  --pam evidence/pam --react-native evidence/react-native \
+  --flutter evidence/flutter --native evidence/platform-native \
+  --output evidence/framework-matrix.md
+```
+
 The Android host contains a `:macrobenchmark` module with three identical,
 automation-friendly scenarios:
 

--- a/benchmarks/mobile/compare.py
+++ b/benchmarks/mobile/compare.py
@@ -15,6 +15,8 @@ def arguments() -> argparse.Namespace:
     )
     parser.add_argument("--pam", required=True, type=Path)
     parser.add_argument("--react-native", required=True, type=Path)
+    parser.add_argument("--flutter", type=Path)
+    parser.add_argument("--native", type=Path)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument(
         "--contract",
@@ -138,13 +140,47 @@ def render(
     return "\n".join(lines)
 
 
+def render_matrix(
+    frameworks: dict[str, dict[tuple[str, str, str], float]],
+) -> str:
+    """Render only measurements shared by every certified framework."""
+    if "PAM Native" not in frameworks or len(frameworks) < 2:
+        raise ValueError("A framework matrix requires PAM Native and at least one baseline")
+    shared = set.intersection(*(set(values) for values in frameworks.values()))
+    if not shared:
+        raise ValueError("Framework reports do not share any measurements")
+    names = list(frameworks)
+    lines = [
+        "# PAM Native framework matrix",
+        "",
+        "Lower is better. Every value must come from the same physical-device contract.",
+        "",
+        "| Scenario | Metric | Statistic | " + " | ".join(names) + " |",
+        "| --- | --- | --- | " + " | ".join("---:" for _ in names) + " |",
+    ]
+    for scenario, metric, summary in sorted(shared):
+        values = [frameworks[name][(scenario, metric, summary)] for name in names]
+        lines.append(
+            f"| `{scenario}` | `{metric}` | `{summary}` | "
+            + " | ".join(f"{value:.3f}" for value in values)
+            + " |",
+        )
+    return "\n".join(lines) + "\n"
+
+
 def main() -> None:
     options = arguments()
     pam = metrics(reports(options.pam))
     react = metrics(reports(options.react_native))
     contract = json.loads(options.contract.read_text(encoding="utf-8"))
+    frameworks = {"PAM Native": pam, "React Native": react}
+    for label, path in (("Flutter", options.flutter), ("Platform native", options.native)):
+        if path is not None:
+            values = metrics(reports(path))
+            validate_contract(pam, values, contract)
+            frameworks[label] = values
     validate_contract(pam, react, contract)
-    output = render(pam, react)
+    output = render(pam, react) if len(frameworks) == 2 else render_matrix(frameworks)
     options.output.parent.mkdir(parents=True, exist_ok=True)
     options.output.write_text(output, encoding="utf-8")
     print(options.output)

--- a/benchmarks/mobile/test_compare.py
+++ b/benchmarks/mobile/test_compare.py
@@ -170,6 +170,19 @@ class CompareReportsTest(unittest.TestCase):
         )
         self.assertIn("missing coldStartup.timeToFullDisplayMs.median", failures)
 
+    def test_renders_a_shared_four_framework_matrix(self) -> None:
+        key = ("coldStartup", "timeToFullDisplayMs", "median")
+        report = compare.render_matrix(
+            {
+                "PAM Native": {key: 300.0},
+                "React Native": {key: 600.0},
+                "Flutter": {key: 450.0},
+                "Platform native": {key: 250.0},
+            },
+        )
+        self.assertIn("PAM Native framework matrix", report)
+        self.assertIn("300.000 | 600.000 | 450.000 | 250.000", report)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/package/test_reproducibility.py
+++ b/benchmarks/package/test_reproducibility.py
@@ -93,6 +93,10 @@ class ReproducibilityEvidenceTests(unittest.TestCase):
             publish.index("Reverify downloaded reproducibility evidence"),
             publish.index("softprops/action-gh-release@v3"),
         )
+        self.assertLess(
+            publish.index("actions/attest-sbom@v4"),
+            publish.index("softprops/action-gh-release@v3"),
+        )
 
 
 if __name__ == "__main__":

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -652,6 +652,19 @@ struct NativeDiagnosticsOptions {
     device: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+enum ReleasePlatform {
+    Android = 1,
+    Ios = 2,
+    All = 3,
+}
+
+struct ReleaseOptions {
+    project: PathBuf,
+    platform: ReleasePlatform,
+}
+
 pub fn run(arguments: Vec<OsString>) -> Result<u8, String> {
     let mut arguments = arguments.into_iter();
     let Some(command) = arguments.next() else {
@@ -679,6 +692,7 @@ pub fn run(arguments: Vec<OsString>) -> Result<u8, String> {
         }
         "codegen" => {
             let project = load_project(&parse_project_only(arguments)?)?;
+            generate_typed_contracts(&project)?;
             let native_home = native_home()?;
             let runtime = resolve_runtime(&project, &pam_home()?)?;
             let workspace = sync_android_host(&project, &native_home)?;
@@ -723,6 +737,7 @@ pub fn run(arguments: Vec<OsString>) -> Result<u8, String> {
             options.mode = BuildMode::Release;
             package_android(options)
         }
+        "release" => release(parse_release_options(arguments)?),
         "sign" => signing_status(parse_project_only(arguments)?),
         "run" => {
             let mut options = parse_options(arguments, true)?;
@@ -1097,6 +1112,44 @@ fn parse_options(
         mode,
         abis,
     })
+}
+
+fn parse_release_options(
+    mut arguments: impl Iterator<Item = OsString>,
+) -> Result<ReleaseOptions, String> {
+    let mut project = PathBuf::from(".");
+    let mut positional = false;
+    let mut platform = if cfg!(target_os = "macos") {
+        ReleasePlatform::All
+    } else {
+        ReleasePlatform::Android
+    };
+    while let Some(argument) = arguments.next() {
+        match argument.to_string_lossy().as_ref() {
+            "--platform" => {
+                platform = match arguments
+                    .next()
+                    .ok_or_else(|| "--platform requires android, ios, or all".to_owned())?
+                    .to_string_lossy()
+                    .as_ref()
+                {
+                    "android" => ReleasePlatform::Android,
+                    "ios" => ReleasePlatform::Ios,
+                    "all" => ReleasePlatform::All,
+                    _ => return Err("--platform requires android, ios, or all".to_owned()),
+                };
+            }
+            option if option.starts_with('-') => {
+                return Err(format!("unknown release option {option}"));
+            }
+            _ if !positional => {
+                project = PathBuf::from(argument);
+                positional = true;
+            }
+            _ => return Err("release accepts at most one project directory".to_owned()),
+        }
+    }
+    Ok(ReleaseOptions { project, platform })
 }
 
 fn default_abis() -> Vec<AndroidAbi> {
@@ -5230,6 +5283,30 @@ fn swift_string(value: &str) -> String {
     )
 }
 
+fn generate_typed_contracts(project: &Project) -> Result<(), String> {
+    let configuration = project.root.join("pam-native.contracts.php");
+    if !configuration.is_file() {
+        return Ok(());
+    }
+    let generator = project.root.join("vendor/bin/pam-native-contracts");
+    if !generator.is_file() {
+        return Err(format!(
+            "{} exists but {} is missing; run `pam composer install`",
+            configuration.display(),
+            generator.display()
+        ));
+    }
+    let status = Command::new("php")
+        .arg(&generator)
+        .current_dir(&project.root)
+        .status()
+        .map_err(|error| format!("cannot start typed contract generator: {error}"))?;
+    if !status.success() {
+        return Err(format!("typed contract generator exited with {status}"));
+    }
+    Ok(())
+}
+
 fn generate_modules(project: &Project, workspace: &Path) -> Result<(), String> {
     let target =
         workspace.join("app/src/main/java/dev/pam/nativeapp/modules/GeneratedPamModules.kt");
@@ -5605,6 +5682,36 @@ fn package_android(options: MobileOptions) -> Result<u8, String> {
     println!("Packaged {}", apk_destination.display());
     println!("Metadata {}", metadata_path.display());
     Ok(0)
+}
+
+fn release(options: ReleaseOptions) -> Result<u8, String> {
+    if doctor(options.project.clone())? != 0 {
+        return Err("release stopped because PAM Native doctor failed".to_owned());
+    }
+    if doctor_plugins(options.project.clone())? != 0 {
+        return Err("release stopped because plugin certification failed".to_owned());
+    }
+    match options.platform {
+        ReleasePlatform::Android => package_android(MobileOptions {
+            project: options.project,
+            mode: BuildMode::Release,
+            abis: default_abis(),
+        }),
+        ReleasePlatform::Ios => package_ios(options.project),
+        ReleasePlatform::All => {
+            if !cfg!(target_os = "macos") {
+                return Err(
+                    "--platform all requires macOS because iOS packaging uses Xcode".to_owned(),
+                );
+            }
+            package_android(MobileOptions {
+                project: options.project.clone(),
+                mode: BuildMode::Release,
+                abis: default_abis(),
+            })?;
+            package_ios(options.project)
+        }
+    }
 }
 
 fn write_artifact_checksum(path: &Path) -> Result<(), String> {
@@ -6724,7 +6831,7 @@ fn write_atomic(path: &Path, contents: &[u8]) -> Result<(), String> {
 
 fn print_usage() {
     eprintln!(
-        "PAM Native commands:\n  doctor, audit, dev, build, run, package, sign\n  devices, logs, screenshot, devtools, diagnostics\n  prepare, codegen, benchmark, profile\n  plugin:list, plugin:doctor\n  runtime:list, runtime:info, runtime:use, runtime:install, runtime:update\n  make:screen, make:component, make:native-view\n  ios:prepare, ios:doctor, ios:dev, ios:build, ios:run, ios:package, ios:sign, ios:devices, ios:logs, ios:screenshot, ios:devtools, ios:diagnostics"
+        "PAM Native commands:\n  doctor, audit, dev, build, run, package, release, sign\n  devices, logs, screenshot, devtools, diagnostics\n  prepare, codegen, benchmark, profile\n  plugin:list, plugin:doctor\n  runtime:list, runtime:info, runtime:use, runtime:install, runtime:update\n  make:screen, make:component, make:native-view\n  ios:prepare, ios:doctor, ios:dev, ios:build, ios:run, ios:package, ios:sign, ios:devices, ios:logs, ios:screenshot, ios:devtools, ios:diagnostics"
     );
 }
 
@@ -7585,5 +7692,20 @@ mod tests {
         assert!(source.is_file());
         assert!(neighboring_artifact.is_file());
         fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn release_options_are_explicit_and_platform_safe() {
+        let options = parse_release_options(
+            ["application", "--platform", "android"]
+                .into_iter()
+                .map(OsString::from),
+        )
+        .expect("release options");
+        assert_eq!(options.project, PathBuf::from("application"));
+        assert_eq!(options.platform, ReleasePlatform::Android);
+        assert!(
+            parse_release_options(["--platform", "web"].into_iter().map(OsString::from)).is_err()
+        );
     }
 }

--- a/crates/pam-native-engine/src/lib.rs
+++ b/crates/pam-native-engine/src/lib.rs
@@ -5,6 +5,7 @@ mod layout;
 pub mod performance;
 pub mod reactive;
 pub mod scheduler;
+pub mod transaction;
 pub mod virtualization;
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/pam-native-engine/src/transaction.rs
+++ b/crates/pam-native-engine/src/transaction.rs
@@ -1,0 +1,118 @@
+use std::collections::BTreeMap;
+
+pub type TransactionId = u64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum TransactionPhase {
+    Prepared = 1,
+    Committed = 2,
+    Cancelled = 3,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RenderTransaction {
+    pub id: TransactionId,
+    pub generation: u64,
+    pub phase: TransactionPhase,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Default)]
+pub struct TransactionCoordinator {
+    generation: u64,
+    next_id: TransactionId,
+    pending: BTreeMap<TransactionId, RenderTransaction>,
+}
+
+impl TransactionCoordinator {
+    pub fn prepare(&mut self, payload: Vec<u8>) -> Result<TransactionId, TransactionError> {
+        if payload.is_empty() || payload.len() > 16 * 1024 * 1024 {
+            return Err(TransactionError::InvalidPayload);
+        }
+        self.next_id = self.next_id.saturating_add(1).max(1);
+        let id = self.next_id;
+        self.pending.insert(
+            id,
+            RenderTransaction {
+                id,
+                generation: id,
+                phase: TransactionPhase::Prepared,
+                payload,
+            },
+        );
+        Ok(id)
+    }
+
+    pub fn commit(&mut self, id: TransactionId) -> Result<RenderTransaction, TransactionError> {
+        let mut transaction = self
+            .pending
+            .remove(&id)
+            .ok_or(TransactionError::UnknownTransaction)?;
+        if transaction.generation <= self.generation {
+            return Err(TransactionError::ObsoleteTransaction);
+        }
+        transaction.phase = TransactionPhase::Committed;
+        self.generation = transaction.generation;
+        self.pending
+            .retain(|_, pending| pending.generation > self.generation);
+        Ok(transaction)
+    }
+
+    pub fn cancel(&mut self, id: TransactionId) -> bool {
+        self.pending.remove(&id).is_some()
+    }
+
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    #[must_use]
+    pub fn pending(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TransactionError {
+    InvalidPayload,
+    UnknownTransaction,
+    ObsoleteTransaction,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commits_atomically_and_discards_obsolete_work() {
+        let mut coordinator = TransactionCoordinator::default();
+        let first = coordinator.prepare(vec![1]).expect("first");
+        let second = coordinator.prepare(vec![2]).expect("second");
+        let committed = coordinator.commit(second).expect("commit latest");
+        assert_eq!(committed.payload, vec![2]);
+        assert_eq!(committed.phase, TransactionPhase::Committed);
+        assert_eq!(coordinator.generation(), 2);
+        assert_eq!(coordinator.pending(), 0);
+        assert_eq!(
+            coordinator.commit(first),
+            Err(TransactionError::UnknownTransaction)
+        );
+    }
+
+    #[test]
+    fn bounds_payload_and_supports_cancellation() {
+        let mut coordinator = TransactionCoordinator::default();
+        assert_eq!(
+            coordinator.prepare(Vec::new()),
+            Err(TransactionError::InvalidPayload)
+        );
+        let id = coordinator.prepare(vec![1, 2, 3]).expect("prepare");
+        assert!(coordinator.cancel(id));
+        assert_eq!(
+            coordinator.commit(id),
+            Err(TransactionError::UnknownTransaction)
+        );
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # Pam Native documentation
 
 - [PHP Runtime Manager](runtime-manager.md)
+- [Singularity architecture](singularity.md)
 
 Every public feature added to Pam Native must include a copyable example. Start
 with the focused guide below or use the [capability cookbook](examples.md) for

--- a/docs/navigation-parity.md
+++ b/docs/navigation-parity.md
@@ -38,6 +38,7 @@ tree and is executed by Kotlin/UIKit without a per-frame PHP callback.
 - Accessibility traversal exposes the active route; disabled animations and
   iOS Reduced Motion bypass decorative movement.
 
-The CI contract runs PHP 8.4/8.5, Rust formatting/tests/clippy, protocol tests,
+The CI contract runs PHP 8.5, PHPStan level 9 for new Singularity boundaries,
+Rust formatting/tests/clippy, protocol tests,
 Android unit/lint/build checks, API 26/API 36 instrumented navigation tests,
 UIKit simulator tests, deterministic fuzzing and navigation performance gates.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,5 +1,19 @@
 # Releasing Pam Native
 
+Application releases use one fail-closed entry point:
+
+```bash
+pam release --platform android
+pam release --platform ios
+# macOS only; produces both platform packages:
+pam release --platform all
+```
+
+The command runs Native doctor and plugin certification before validating
+signing and producing checksummed release artifacts. It never creates signing
+credentials or uploads to a store. CI/store adapters consume the resulting
+`dist` metadata and retain rollout authority.
+
 ## Release gate
 
 1. Run PHP SDK tests and lint.

--- a/docs/singularity.md
+++ b/docs/singularity.md
@@ -1,0 +1,78 @@
+# PAM Native Singularity
+
+Singularity is the additive architecture introduced in PAM Native 0.7. It does
+not replace protocol v1 frames or existing plugins. New public boundaries use
+versioned schemas and sequential integer discriminators so future hosts can
+negotiate capabilities without breaking existing applications.
+
+## The twelve production pillars
+
+1. **Compile-time contracts.** Annotated PHP interfaces generate deterministic
+   PHP, Kotlin, and Swift identifiers plus a canonical SHA-256 manifest.
+2. **Transactional rendering.** Rust prepares bounded generations, atomically
+   commits complete work, discards obsolete work, and budgets 60/90/120 Hz.
+3. **Structured concurrency.** Task groups, deferred values, hierarchical
+   cancellation, deadlines, and bounded streams make task ownership explicit.
+4. **Local-first by default.** Optimistic records, outbox batches, deterministic
+   conflict policies, and authenticated AES-256-GCM journals are built in.
+5. **Stateful hot reload.** Bounded state and replay actions carry deterministic
+   fingerprints so hosts can preserve navigation and forms.
+6. **Deterministic DevTools.** Ordered integer-kind timelines can be replayed;
+   native overlays continue to provide redacted frame and capability evidence.
+7. **Governed zero-config plugins.** Composer discovery is joined by immutable
+   versions, digests, trust tiers, capability grants, and quality scores.
+8. **Backend inside the app.** Internal request/response middleware runs through
+   `LocalTransport` without binding TCP or granting network authority.
+9. **Mature declarative UI.** Components, themes, forms, navigation, virtual
+   lists, worklets, accessibility, RTL and Dynamic Type share one renderer.
+10. **One release surface.** Build, sign and release produce reproducible
+    Android/iOS/PHP artifacts, checksums, budgets, SBOM inputs and attestations.
+11. **Public comparative evidence.** PAM, React Native, Flutter, and native are
+    compared only when every report follows the same physical-device contract.
+12. **One Composer domain.** DTOs, validation, transport and domain services can
+    run on PAM Server, HTTP, Native, Desktop, workers, and tests.
+
+## Typed contract example
+
+```php
+#[NativeModule(id: 1, name: 'Camera')]
+interface CameraContract
+{
+    #[NativeMethod(id: 1)]
+    #[NativePermission('camera.capture')]
+    public function capture(string $quality, bool $flash): array;
+}
+
+$artifacts = ContractCompiler::compile([CameraContract::class], 'App.Native');
+```
+
+For application code generation, create `pam-native.contracts.php` returning
+the interface class names. `pam codegen` then writes the manifest, fingerprint,
+PHP, Kotlin and Swift outputs atomically under `.pam-native/contracts`. The same
+operation is available directly as `pam contracts`.
+
+The schema records request/event/stream kind, deadline, nullability, return
+type, and capabilities. IDs are sequential integers and generated output is
+fingerprinted, making platform drift a build failure.
+
+## Internal application API
+
+```php
+$router = (new Router())->route(
+    'POST',
+    '/process',
+    fn (Request $request) => Response::json(['bytes' => strlen($request->body)]),
+);
+$response = (new LocalTransport($router))->send(
+    new Request('POST', '/process', body: 'payload'),
+);
+```
+
+`LocalTransport::opensNetworkSocket()` is always false. Authentication and
+authorization remain required at domain boundaries.
+
+## Claims and evidence
+
+PAM does not claim a universal performance multiple. A release may claim a
+measured advantage only from retained same-device evidence passing thermal,
+build-mode, payload, accessibility, and statistical comparability checks.

--- a/examples/community-plugin/composer.json
+++ b/examples/community-plugin/composer.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^8.5",
-        "pushinbr/pam-native": "^0.6.78"
+        "pushinbr/pam-native": "^0.7.0"
     },
     "autoload": {
         "psr-4": {

--- a/examples/showcase/composer.json
+++ b/examples/showcase/composer.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^8.5",
-        "pushinbr/pam-native": "^0.6.78",
+        "pushinbr/pam-native": "^0.7.0",
         "pam-community/example-plugin": "^0.1"
     },
     "repositories": [
@@ -15,7 +15,7 @@
             "options": {
                 "symlink": false,
                 "versions": {
-                    "pushinbr/pam-native": "0.6.78"
+                    "pushinbr/pam-native": "0.7.0"
                 }
             }
         },

--- a/examples/showcase/composer.lock
+++ b/examples/showcase/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc29c0a7d767ffa501ecc767dfb693d2",
+    "content-hash": "51f5ec5a075fe836ff086ea23a4ac5be",
     "packages": [
         {
             "name": "pam-community/example-plugin",
@@ -12,11 +12,11 @@
             "dist": {
                 "type": "path",
                 "url": "../community-plugin",
-                "reference": "9103e15f712efe20c50a25c0b11a36db6f2001b7"
+                "reference": "621b3fbed576ac726cb1c572bb04a511d0f66dac"
             },
             "require": {
                 "php": "^8.5",
-                "pushinbr/pam-native": "^0.6.78"
+                "pushinbr/pam-native": "^0.7.0"
             },
             "type": "pam-native-plugin",
             "extra": {
@@ -40,17 +40,18 @@
         },
         {
             "name": "pushinbr/pam-native",
-            "version": "0.6.78",
+            "version": "0.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../packages/native",
-                "reference": "dfc304277d158945b2d7dca3a493b075f68b01fa"
+                "reference": "598e85fbd1067fa9e903f49e91fd63983b263776"
             },
             "require": {
                 "php": "^8.5"
             },
             "bin": [
                 "bin/pam-native",
+                "bin/pam-native-contracts",
                 "bin/pam-native-format",
                 "bin/pam-native-language-server",
                 "bin/pam-native-optimize",
@@ -115,6 +116,10 @@
                                 "codegen"
                             ],
                             "description": "Generate native bindings"
+                        },
+                        "contracts": {
+                            "script": "bin/pam-native-contracts",
+                            "description": "Generate typed PHP, Kotlin and Swift contracts"
                         },
                         "diagnostics": {
                             "bin": "bin/pam-native",
@@ -297,6 +302,13 @@
                                 "run"
                             ],
                             "description": "Run the PAM Native application"
+                        },
+                        "release": {
+                            "bin": "bin/pam-native",
+                            "arguments": [
+                                "release"
+                            ],
+                            "description": "Certify, sign and package a PAM Native release"
                         },
                         "sign": {
                             "bin": "bin/pam-native",

--- a/examples/showcase/pam-native.contracts.php
+++ b/examples/showcase/pam-native.contracts.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Native\ShowcaseDeviceContract;
+
+return [ShowcaseDeviceContract::class];

--- a/examples/showcase/src/Native/ShowcaseDeviceContract.php
+++ b/examples/showcase/src/Native/ShowcaseDeviceContract.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Native;
+
+use Pam\Native\Bridge\Attributes\NativeMethod;
+use Pam\Native\Bridge\Attributes\NativeModule;
+use Pam\Native\Bridge\Attributes\NativePermission;
+use Pam\Native\Bridge\NativeCallKind;
+
+#[NativeModule(id: 1, name: 'ShowcaseDevice')]
+interface ShowcaseDeviceContract
+{
+    /** @return array<string, mixed> */
+    #[NativeMethod(id: 1)]
+    #[NativePermission('device.info')]
+    public function information(): array;
+
+    /** @return array<string, mixed> */
+    #[NativeMethod(id: 2, kind: NativeCallKind::Stream, timeoutMs: 60_000)]
+    public function lifecycle(): array;
+}

--- a/examples/showcase/src/Showcase.php
+++ b/examples/showcase/src/Showcase.php
@@ -6,6 +6,11 @@ namespace App;
 
 use Pam\Native\Element;
 use Pam\Native\Http\Http;
+use Pam\Native\InternalHttp\LocalTransport;
+use Pam\Native\InternalHttp\Request as LocalRequest;
+use Pam\Native\InternalHttp\Response as LocalResponse;
+use Pam\Native\InternalHttp\Router as LocalRouter;
+use Pam\Native\LocalFirst\LocalStore;
 use Pam\Native\Routing\Navigation;
 use Pam\Native\StatusBarAppearance;
 use Pam\Native\Storage\Storage;
@@ -27,6 +32,22 @@ final class Showcase
     private string $name = 'PHP';
     private string $networkStatus = 'HTTP has not run yet.';
     private string $storageStatus = 'Storage has not run yet.';
+    private string $singularityStatus = 'Local-first and in-process HTTP are ready.';
+    private readonly LocalStore $localStore;
+    private readonly LocalTransport $localTransport;
+
+    public function __construct()
+    {
+        $this->localStore = new LocalStore();
+        $router = (new LocalRouter())->route(
+            'POST',
+            '/todos',
+            static fn (LocalRequest $request): LocalResponse => LocalResponse::json([
+                'accepted' => strlen($request->body) > 0,
+            ]),
+        );
+        $this->localTransport = new LocalTransport($router);
+    }
 
     public function home(): Element
     {
@@ -176,6 +197,21 @@ final class Showcase
                     Text::make($this->storageStatus)
                         ->key('storage-status')
                         ->style(new Style(height: 28, textColor: 0xFFCBD5E1, fontSize: 13)),
+                    Button::make('Run Singularity local flow')
+                        ->key('singularity')
+                        ->style(new Style(height: 48))
+                        ->onPress(function (): void {
+                            $record = $this->localStore->put('showcase', 'welcome', ['count' => $this->count]);
+                            $response = $this->localTransport->send(new LocalRequest(
+                                'POST',
+                                '/todos',
+                                body: json_encode($record->attributes, JSON_THROW_ON_ERROR),
+                            ));
+                            $this->singularityStatus = "Local v{$record->version}, internal HTTP {$response->status}, sockets: 0";
+                        }),
+                    Text::make($this->singularityStatus)
+                        ->key('singularity-status')
+                        ->style(new Style(height: 36, textColor: 0xFF86EFAC, fontSize: 13)),
                 )->style(new Style(
                     padding: 20,
                     gap: 10,

--- a/packages/native/PROTOCOL.md
+++ b/packages/native/PROTOCOL.md
@@ -5,7 +5,7 @@ PHP, the Rust layout/diff engine and the Android/iOS renderers.
 
 | SDK | Protocol | PHP | Android | iOS |
 | --- | ---: | --- | --- | --- |
-| `pushinbr/pam-native 0.6.x` | `1` | `8.4.x`, `8.5.x` | API 26–36 | current supported Xcode/iOS toolchain |
+| `pushinbr/pam-native 0.7.x` | `1` | `8.5.x` | API 26–36 | current supported Xcode/iOS toolchain |
 
 All peers must support the exact protocol version. Existing sequential integer
 identifiers are never renamed, reused or renumbered. Optional node kinds,

--- a/packages/native/bin/pam-native-contracts
+++ b/packages/native/bin/pam-native-contracts
@@ -1,0 +1,53 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Pam\Native\Bridge\ContractCompiler;
+
+$project = getcwd();
+if (!is_string($project)) {
+    fwrite(STDERR, "pam-native-contracts: cannot resolve the project directory\n");
+    exit(74);
+}
+$autoload = $project.DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'autoload.php';
+$configuration = $project.DIRECTORY_SEPARATOR.'pam-native.contracts.php';
+if (!is_file($autoload) || !is_file($configuration)) {
+    fwrite(STDERR, "pam-native-contracts: vendor/autoload.php and pam-native.contracts.php are required\n");
+    exit(78);
+}
+require $autoload;
+$contracts = require $configuration;
+if (!is_array($contracts) || !array_is_list($contracts)) {
+    fwrite(STDERR, "pam-native-contracts: configuration must return a list of interface class names\n");
+    exit(65);
+}
+$namespace = getenv('PAM_NATIVE_CONTRACT_NAMESPACE');
+$artifacts = ContractCompiler::compile(
+    $contracts,
+    is_string($namespace) && $namespace !== '' ? $namespace : 'Pam.Generated',
+);
+$directory = $project.DIRECTORY_SEPARATOR.'.pam-native'.DIRECTORY_SEPARATOR.'contracts';
+if (!is_dir($directory) && !mkdir($directory, 0700, true) && !is_dir($directory)) {
+    fwrite(STDERR, "pam-native-contracts: cannot create the generated contract directory\n");
+    exit(73);
+}
+$manifest = json_encode($artifacts->manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n";
+foreach ([
+    'manifest.json' => $manifest,
+    'Contracts.php' => $artifacts->php,
+    'Contracts.kt' => $artifacts->kotlin,
+    'Contracts.swift' => $artifacts->swift,
+    'fingerprint.sha256' => $artifacts->fingerprint."\n",
+] as $name => $contents) {
+    $target = $directory.DIRECTORY_SEPARATOR.$name;
+    $temporary = tempnam($directory, '.contract-');
+    if ($temporary === false || file_put_contents($temporary, $contents, LOCK_EX) === false || !rename($temporary, $target)) {
+        if (is_string($temporary)) {
+            @unlink($temporary);
+        }
+        fwrite(STDERR, "pam-native-contracts: cannot atomically write {$target}\n");
+        exit(74);
+    }
+}
+fwrite(STDOUT, "Generated contract {$artifacts->fingerprint}\n");

--- a/packages/native/composer.json
+++ b/packages/native/composer.json
@@ -25,6 +25,7 @@
     },
     "bin": [
         "bin/pam-native",
+        "bin/pam-native-contracts",
         "bin/pam-native-format",
         "bin/pam-native-language-server",
         "bin/pam-native-optimize",
@@ -72,6 +73,10 @@
                     "bin": "bin/pam-native",
                     "arguments": ["codegen"],
                     "description": "Generate native bindings"
+                },
+                "contracts": {
+                    "script": "bin/pam-native-contracts",
+                    "description": "Generate typed PHP, Kotlin and Swift contracts"
                 },
                 "diagnostics": {
                     "bin": "bin/pam-native",
@@ -210,6 +215,11 @@
                     "bin": "bin/pam-native",
                     "arguments": ["run"],
                     "description": "Run the PAM Native application"
+                },
+                "release": {
+                    "bin": "bin/pam-native",
+                    "arguments": ["release"],
+                    "description": "Certify, sign and package a PAM Native release"
                 },
                 "sign": {
                     "bin": "bin/pam-native",

--- a/packages/native/phpstan-singularity.neon
+++ b/packages/native/phpstan-singularity.neon
@@ -1,0 +1,25 @@
+parameters:
+    level: 9
+    paths:
+        - src/Bridge
+        - src/Diagnostics/ReplayTimeline.php
+        - src/HotReload
+        - src/InternalHttp
+        - src/LocalFirst
+        - src/Plugin/PluginRegistry.php
+        - src/Plugin/RegistryEntry.php
+        - src/Plugin/TrustTier.php
+        - src/Scheduling/AsyncStream.php
+        - src/Scheduling/BackpressureException.php
+        - src/Scheduling/DeadlineExceededException.php
+        - src/Scheduling/Deferred.php
+        - src/Scheduling/TaskGroup.php
+    tmpDir: ../../../.pam-native/phpstan-singularity
+    treatPhpDocTypesAsCertain: true
+    reportUnmatchedIgnoredErrors: true
+    scanFiles:
+        - src/State.php
+        - src/Plugin/PluginException.php
+        - src/Scheduling/CancellationToken.php
+        - src/Scheduling/Scheduler.php
+        - src/Scheduling/TaskPriority.php

--- a/packages/native/src/Bridge/Attributes/NativeMethod.php
+++ b/packages/native/src/Bridge/Attributes/NativeMethod.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Bridge\Attributes;
+
+use Attribute;
+use Pam\Native\Bridge\NativeCallKind;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final readonly class NativeMethod
+{
+    public function __construct(
+        public int $id,
+        public NativeCallKind $kind = NativeCallKind::Request,
+        public int $timeoutMs = 30_000,
+    ) {
+        if ($id < 1 || $timeoutMs < 1 || $timeoutMs > 300_000) {
+            throw new \InvalidArgumentException('Native method id or timeout is outside the supported range.');
+        }
+    }
+}

--- a/packages/native/src/Bridge/Attributes/NativeModule.php
+++ b/packages/native/src/Bridge/Attributes/NativeModule.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Bridge\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class NativeModule
+{
+    public function __construct(
+        public int $id,
+        public ?string $name = null,
+        public int $version = 1,
+    ) {
+        if ($id < 1 || $version < 1) {
+            throw new \InvalidArgumentException('Native module id and version must be positive integers.');
+        }
+    }
+}

--- a/packages/native/src/Bridge/Attributes/NativePermission.php
+++ b/packages/native/src/Bridge/Attributes/NativePermission.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Bridge\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final readonly class NativePermission
+{
+    public function __construct(public string $capability)
+    {
+        if (preg_match('/^[a-z][a-z0-9.-]{0,63}$/D', $capability) !== 1) {
+            throw new \InvalidArgumentException('Native capabilities must use portable dotted identifiers.');
+        }
+    }
+}

--- a/packages/native/src/Bridge/ContractArtifacts.php
+++ b/packages/native/src/Bridge/ContractArtifacts.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Bridge;
+
+final readonly class ContractArtifacts
+{
+    /** @param array<string, mixed> $manifest */
+    public function __construct(
+        public array $manifest,
+        public string $php,
+        public string $kotlin,
+        public string $swift,
+        public string $fingerprint,
+    ) {
+    }
+}

--- a/packages/native/src/Bridge/ContractCompiler.php
+++ b/packages/native/src/Bridge/ContractCompiler.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Bridge;
+
+use Pam\Native\Bridge\Attributes\NativeMethod;
+use Pam\Native\Bridge\Attributes\NativeModule;
+use Pam\Native\Bridge\Attributes\NativePermission;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+
+/**
+ * @phpstan-type ParameterShape array{id: int, name: string, type: string, nullable: bool}
+ * @phpstan-type MethodShape array{id: int, name: string, kind: int, timeoutMs: int, parameters: list<ParameterShape>, returns: string, permissions: list<string>}
+ * @phpstan-type ModuleShape array{id: int, name: string, version: int, methods: list<MethodShape>}
+ * @phpstan-type ManifestShape array{schema: int, namespace: string, modules: list<ModuleShape>}
+ */
+final class ContractCompiler
+{
+    /** @param list<class-string> $interfaces */
+    public static function compile(array $interfaces, string $namespace = 'Pam.Generated'): ContractArtifacts
+    {
+        if ($interfaces === [] || count($interfaces) > 256) {
+            throw new \InvalidArgumentException('Contract compilation requires between 1 and 256 interfaces.');
+        }
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/D', $namespace) !== 1) {
+            throw new \InvalidArgumentException('Contract namespace must be a portable dotted identifier.');
+        }
+        $modules = [];
+        foreach ($interfaces as $interface) {
+            $reflection = new ReflectionClass($interface);
+            if (!$reflection->isInterface()) {
+                throw new \InvalidArgumentException("Native contract {$interface} must be an interface.");
+            }
+            $attribute = $reflection->getAttributes(NativeModule::class)[0] ?? null;
+            if ($attribute === null) {
+                throw new \InvalidArgumentException("Native contract {$interface} requires #[NativeModule].");
+            }
+            /** @var NativeModule $module */
+            $module = $attribute->newInstance();
+            $moduleName = $module->name ?? $reflection->getShortName();
+            if (preg_match('/^[A-Za-z_][A-Za-z0-9_]{0,63}$/D', $moduleName) !== 1) {
+                throw new \InvalidArgumentException("Native module {$moduleName} is not a portable identifier.");
+            }
+            /** @var list<MethodShape> $methods */
+            $methods = [];
+            foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                $methods[] = self::method($method);
+            }
+            usort($methods, static fn (array $left, array $right): int => $left['id'] <=> $right['id']);
+            self::sequential(array_column($methods, 'id'), "methods in {$interface}");
+            $modules[] = [
+                'id' => $module->id,
+                'name' => $moduleName,
+                'version' => $module->version,
+                'methods' => $methods,
+            ];
+        }
+        usort($modules, static fn (array $left, array $right): int => $left['id'] <=> $right['id']);
+        self::sequential(array_column($modules, 'id'), 'modules');
+        $manifest = ['schema' => 2, 'namespace' => $namespace, 'modules' => $modules];
+        $canonical = json_encode($manifest, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+
+        return new ContractArtifacts(
+            $manifest,
+            self::php($manifest),
+            self::kotlin($manifest),
+            self::swift($manifest),
+            hash('sha256', $canonical),
+        );
+    }
+
+    /** @return MethodShape */
+    private static function method(ReflectionMethod $method): array
+    {
+        $attribute = $method->getAttributes(NativeMethod::class)[0] ?? null;
+        if ($attribute === null) {
+            throw new \InvalidArgumentException("Native method {$method->getName()} requires #[NativeMethod].");
+        }
+        /** @var NativeMethod $native */
+        $native = $attribute->newInstance();
+        $parameters = [];
+        foreach ($method->getParameters() as $index => $parameter) {
+            $parameters[] = [
+                'id' => $index + 1,
+                'name' => $parameter->getName(),
+                'type' => self::type($parameter->getType()),
+                'nullable' => $parameter->allowsNull(),
+            ];
+        }
+        $permissions = array_map(
+            static fn ($item): string => $item->newInstance()->capability,
+            $method->getAttributes(NativePermission::class),
+        );
+        sort($permissions, SORT_STRING);
+
+        return [
+            'id' => $native->id,
+            'name' => $method->getName(),
+            'kind' => $native->kind->value,
+            'timeoutMs' => $native->timeoutMs,
+            'parameters' => $parameters,
+            'returns' => self::type($method->getReturnType()),
+            'permissions' => $permissions,
+        ];
+    }
+
+    private static function type(?\ReflectionType $type): string
+    {
+        if (!$type instanceof ReflectionNamedType) {
+            throw new \InvalidArgumentException('Native contracts require named parameter and return types.');
+        }
+        $name = $type->getName();
+        if (in_array($name, ['string', 'int', 'float', 'bool', 'array', 'void'], true)) {
+            return $name;
+        }
+        if (enum_exists($name) || class_exists($name) || interface_exists($name)) {
+            return ltrim($name, '\\');
+        }
+        throw new \InvalidArgumentException("Unsupported native contract type {$name}.");
+    }
+
+    /** @param list<int> $ids */
+    private static function sequential(array $ids, string $label): void
+    {
+        if ($ids !== range(1, count($ids))) {
+            throw new \InvalidArgumentException("Native contract {$label} must use sequential ids starting at 1.");
+        }
+    }
+
+    /** @param ManifestShape $manifest */
+    private static function php(array $manifest): string
+    {
+        return "<?php\n\ndeclare(strict_types=1);\n\nnamespace ".str_replace('.', '\\', $manifest['namespace']).";\n\n".self::constants($manifest, 'php');
+    }
+
+    /** @param ManifestShape $manifest */
+    private static function kotlin(array $manifest): string
+    {
+        return "package {$manifest['namespace']}\n\n".self::constants($manifest, 'kotlin');
+    }
+
+    /** @param ManifestShape $manifest */
+    private static function swift(array $manifest): string
+    {
+        return "import Foundation\n\n".self::constants($manifest, 'swift');
+    }
+
+    /** @param ManifestShape $manifest */
+    private static function constants(array $manifest, string $language): string
+    {
+        $output = '';
+        foreach ($manifest['modules'] as $module) {
+            $name = preg_replace('/[^A-Za-z0-9]/', '', $module['name']).'Contract';
+            $output .= match ($language) {
+                'php' => "final class {$name}\n{\n    public const int ID = {$module['id']};\n",
+                'kotlin' => "object {$name} {\n    const val ID: Int = {$module['id']}\n",
+                default => "enum {$name} {\n    static let id: Int = {$module['id']}\n",
+            };
+            foreach ($module['methods'] as $method) {
+                $identifier = $language === 'swift' ? $method['name'] : strtoupper($method['name']);
+                $output .= match ($language) {
+                    'php' => "    public const int {$identifier} = {$method['id']};\n",
+                    'kotlin' => "    const val {$identifier}: Int = {$method['id']}\n",
+                    default => "    static let {$identifier}: Int = {$method['id']}\n",
+                };
+            }
+            $output .= "}\n\n";
+        }
+        return $output;
+    }
+}

--- a/packages/native/src/Bridge/NativeCallKind.php
+++ b/packages/native/src/Bridge/NativeCallKind.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Bridge;
+
+enum NativeCallKind: int
+{
+    case Request = 1;
+    case Event = 2;
+    case Stream = 3;
+}

--- a/packages/native/src/Diagnostics/ReplayTimeline.php
+++ b/packages/native/src/Diagnostics/ReplayTimeline.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Diagnostics;
+
+final class ReplayTimeline
+{
+    /** @var list<array{sequence: int, kind: int, payload: array<string, mixed>}> */
+    private array $events = [];
+
+    /** @param array<string, mixed> $payload */
+    public function record(int $kind, array $payload): void
+    {
+        if ($kind < 1 || count($this->events) >= 10_000) {
+            throw new \OverflowException('Replay timeline kind is invalid or the bounded log is full.');
+        }
+        $this->events[] = ['sequence' => count($this->events) + 1, 'kind' => $kind, 'payload' => $payload];
+    }
+
+    /** @param \Closure(int, array<string, mixed>): void $consumer */
+    public function replay(\Closure $consumer): void
+    {
+        foreach ($this->events as $event) {
+            $consumer($event['kind'], $event['payload']);
+        }
+    }
+
+    public function fingerprint(): string
+    {
+        return hash('sha256', json_encode($this->events, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/packages/native/src/HotReload/HotReloadCoordinator.php
+++ b/packages/native/src/HotReload/HotReloadCoordinator.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\HotReload;
+
+use Pam\Native\State;
+
+final class HotReloadCoordinator
+{
+    private const string STATE_KEY = 'runtime.hotReloadSnapshot';
+    /** @var array<string, \Closure(): array<string, mixed>> */
+    private array $capture = [];
+    /** @var array<string, \Closure(array<string, mixed>): void> */
+    private array $restore = [];
+
+    /** @param \Closure(): array<string, mixed> $capture @param \Closure(array<string, mixed>): void $restore */
+    public function register(string $scope, \Closure $capture, \Closure $restore): void
+    {
+        if (preg_match('/^[a-z][a-z0-9_.-]{0,63}$/D', $scope) !== 1) {
+            throw new \InvalidArgumentException('Hot reload scopes must use portable identifiers.');
+        }
+        $this->capture[$scope] = $capture;
+        $this->restore[$scope] = $restore;
+    }
+
+    /** @param list<array<string, mixed>> $actions */
+    public function checkpoint(array $actions = []): StateSnapshot
+    {
+        $state = [];
+        foreach ($this->capture as $scope => $capture) {
+            $state[$scope] = $capture();
+        }
+        $snapshot = StateSnapshot::capture($state, $actions);
+        State::set(self::STATE_KEY, [
+            'schema' => $snapshot->schema,
+            'state' => $snapshot->state,
+            'actions' => $snapshot->actions,
+            'fingerprint' => $snapshot->fingerprint,
+        ]);
+        return $snapshot;
+    }
+
+    public function restore(): bool
+    {
+        $persisted = State::get(self::STATE_KEY);
+        if (!is_array($persisted) || ($persisted['schema'] ?? null) !== 1) {
+            return false;
+        }
+        $state = self::stringMap($persisted['state'] ?? null);
+        $actions = self::actionList($persisted['actions'] ?? null);
+        $fingerprint = $persisted['fingerprint'] ?? null;
+        if ($state === null || $actions === null || !is_string($fingerprint)) {
+            return false;
+        }
+        $snapshot = StateSnapshot::capture($state, $actions);
+        if (!hash_equals($snapshot->fingerprint, $fingerprint)) {
+            throw new \RuntimeException('Persisted hot reload snapshot failed integrity verification.');
+        }
+        foreach ($snapshot->state as $scope => $state) {
+            $restore = $this->restore[$scope] ?? null;
+            $restoredState = self::stringMap($state);
+            if ($restore !== null && $restoredState !== null) {
+                $restore($restoredState);
+            }
+        }
+        return true;
+    }
+
+    public function clear(): void
+    {
+        State::forget(self::STATE_KEY);
+    }
+
+    /** @return array<string, mixed>|null */
+    private static function stringMap(mixed $value): ?array
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+        $normalized = [];
+        foreach ($value as $key => $item) {
+            if (!is_string($key)) {
+                return null;
+            }
+            $normalized[$key] = $item;
+        }
+        return $normalized;
+    }
+
+    /** @return list<array<string, mixed>>|null */
+    private static function actionList(mixed $value): ?array
+    {
+        if (!is_array($value) || !array_is_list($value)) {
+            return null;
+        }
+        $actions = [];
+        foreach ($value as $action) {
+            $normalized = self::stringMap($action);
+            if ($normalized === null) {
+                return null;
+            }
+            $actions[] = $normalized;
+        }
+        return $actions;
+    }
+}

--- a/packages/native/src/HotReload/StateSnapshot.php
+++ b/packages/native/src/HotReload/StateSnapshot.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\HotReload;
+
+final readonly class StateSnapshot
+{
+    /**
+     * @param array<string, mixed> $state
+     * @param list<array<string, mixed>> $actions
+     */
+    public function __construct(
+        public int $schema,
+        public array $state,
+        public array $actions,
+        public string $fingerprint,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $state
+     * @param list<array<string, mixed>> $actions
+     */
+    public static function capture(array $state, array $actions = []): self
+    {
+        $canonical = json_encode(['schema' => 1, 'state' => $state, 'actions' => $actions], JSON_THROW_ON_ERROR);
+        if (strlen($canonical) > 8_388_608) {
+            throw new \OverflowException('Hot reload snapshot exceeds 8 MiB.');
+        }
+        return new self(1, $state, $actions, hash('sha256', $canonical));
+    }
+
+    /** @return array<string, mixed> */
+    public function restore(): array
+    {
+        return $this->state;
+    }
+}

--- a/packages/native/src/InternalHttp/LocalTransport.php
+++ b/packages/native/src/InternalHttp/LocalTransport.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\InternalHttp;
+
+final readonly class LocalTransport
+{
+    public function __construct(private Router $router)
+    {
+    }
+
+    public function send(Request $request): Response
+    {
+        return $this->router->dispatch($request);
+    }
+
+    public function opensNetworkSocket(): bool
+    {
+        return false;
+    }
+}

--- a/packages/native/src/InternalHttp/Request.php
+++ b/packages/native/src/InternalHttp/Request.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\InternalHttp;
+
+final readonly class Request
+{
+    /** @param array<string, string> $headers */
+    public function __construct(
+        public string $method,
+        public string $path,
+        public array $headers = [],
+        public string $body = '',
+    ) {
+        if (preg_match('/^[A-Z]{3,12}$/D', $method) !== 1 || !str_starts_with($path, '/') || strlen($body) > 16_777_216) {
+            throw new \InvalidArgumentException('Internal request is invalid or exceeds 16 MiB.');
+        }
+    }
+}

--- a/packages/native/src/InternalHttp/Response.php
+++ b/packages/native/src/InternalHttp/Response.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\InternalHttp;
+
+final readonly class Response
+{
+    /** @param array<string, string> $headers */
+    public function __construct(public int $status, public string $body = '', public array $headers = [])
+    {
+        if ($status < 100 || $status > 599) {
+            throw new \InvalidArgumentException('Internal response status is invalid.');
+        }
+    }
+
+    /** @param array<string, mixed> $payload */
+    public static function json(array $payload, int $status = 200): self
+    {
+        return new self($status, json_encode($payload, JSON_THROW_ON_ERROR), ['content-type' => 'application/json']);
+    }
+}

--- a/packages/native/src/InternalHttp/Router.php
+++ b/packages/native/src/InternalHttp/Router.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\InternalHttp;
+
+final class Router
+{
+    /** @var array<string, \Closure(Request): Response> */
+    private array $routes = [];
+    /** @var list<\Closure(Request, \Closure(Request): Response): Response> */
+    private array $middleware = [];
+
+    /** @param \Closure(Request): Response $handler */
+    public function route(string $method, string $path, \Closure $handler): self
+    {
+        $request = new Request(strtoupper($method), $path);
+        $this->routes["{$request->method} {$request->path}"] = $handler;
+        return $this;
+    }
+
+    /** @param \Closure(Request, \Closure(Request): Response): Response $middleware */
+    public function middleware(\Closure $middleware): self
+    {
+        $this->middleware[] = $middleware;
+        return $this;
+    }
+
+    public function dispatch(Request $request): Response
+    {
+        $handler = $this->routes["{$request->method} {$request->path}"] ?? null;
+        if ($handler === null) {
+            return Response::json(['error' => 'not_found'], 404);
+        }
+        $next = $handler;
+        foreach (array_reverse($this->middleware) as $middleware) {
+            $downstream = $next;
+            $next = static fn (Request $current): Response => $middleware($current, $downstream);
+        }
+        return $next($request);
+    }
+}

--- a/packages/native/src/LocalFirst/ConflictPolicy.php
+++ b/packages/native/src/LocalFirst/ConflictPolicy.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\LocalFirst;
+
+enum ConflictPolicy: int
+{
+    case ClientWins = 1;
+    case ServerWins = 2;
+    case LatestWriteWins = 3;
+    case Merge = 4;
+}

--- a/packages/native/src/LocalFirst/EncryptedJournal.php
+++ b/packages/native/src/LocalFirst/EncryptedJournal.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\LocalFirst;
+
+final class EncryptedJournal
+{
+    private const int MAX_BYTES = 16_777_216;
+
+    public function __construct(private readonly string $key)
+    {
+        if (strlen($key) !== 32) {
+            throw new \InvalidArgumentException('Local-first encryption requires a 256-bit key.');
+        }
+    }
+
+    /** @param list<array<string, mixed>> $entries */
+    public function seal(array $entries): string
+    {
+        $plaintext = json_encode($entries, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        if (strlen($plaintext) > self::MAX_BYTES) {
+            throw new \OverflowException('Local-first journal exceeds 16 MiB.');
+        }
+        $nonce = random_bytes(12);
+        $tag = '';
+        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $this->key, OPENSSL_RAW_DATA, $nonce, $tag, 'PAM-NATIVE-LF1');
+        if (!is_string($ciphertext) || strlen($tag) !== 16) {
+            throw new \RuntimeException('Local-first journal encryption failed.');
+        }
+        return 'PNL1'.$nonce.$tag.$ciphertext;
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function open(string $payload): array
+    {
+        if (!str_starts_with($payload, 'PNL1') || strlen($payload) < 32 || strlen($payload) > self::MAX_BYTES + 32) {
+            throw new \InvalidArgumentException('Local-first journal envelope is invalid.');
+        }
+        $plaintext = openssl_decrypt(
+            substr($payload, 32),
+            'aes-256-gcm',
+            $this->key,
+            OPENSSL_RAW_DATA,
+            substr($payload, 4, 12),
+            substr($payload, 16, 16),
+            'PAM-NATIVE-LF1',
+        );
+        if (!is_string($plaintext)) {
+            throw new \RuntimeException('Local-first journal authentication failed.');
+        }
+        $decoded = json_decode($plaintext, true, 64, JSON_THROW_ON_ERROR);
+        if (!is_array($decoded) || !array_is_list($decoded)) {
+            throw new \RuntimeException('Local-first journal content is invalid.');
+        }
+        $entries = [];
+        foreach ($decoded as $entry) {
+            if (!is_array($entry)) {
+                throw new \RuntimeException('Local-first journal entries must be objects.');
+            }
+            $normalized = [];
+            foreach ($entry as $key => $value) {
+                if (!is_string($key)) {
+                    throw new \RuntimeException('Local-first journal entry keys must be strings.');
+                }
+                $normalized[$key] = $value;
+            }
+            $entries[] = $normalized;
+        }
+        return $entries;
+    }
+}

--- a/packages/native/src/LocalFirst/LocalRecord.php
+++ b/packages/native/src/LocalFirst/LocalRecord.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\LocalFirst;
+
+final readonly class LocalRecord
+{
+    /** @param array<string, mixed> $attributes */
+    public function __construct(
+        public string $collection,
+        public string $id,
+        public array $attributes,
+        public int $version,
+        public int $updatedAtMs,
+        public bool $deleted = false,
+    ) {
+        if (preg_match('/^[a-z][a-z0-9_.-]{0,63}$/D', $collection) !== 1 || $id === '' || $version < 1) {
+            throw new \InvalidArgumentException('Local-first record identity or version is invalid.');
+        }
+    }
+}

--- a/packages/native/src/LocalFirst/LocalStore.php
+++ b/packages/native/src/LocalFirst/LocalStore.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\LocalFirst;
+
+final class LocalStore
+{
+    /** @var array<string, LocalRecord> */
+    private array $records = [];
+    /** @var list<array<string, mixed>> */
+    private array $outbox = [];
+
+    /** @param array<string, mixed> $attributes */
+    public function put(string $collection, string $id, array $attributes, ?int $updatedAtMs = null): LocalRecord
+    {
+        $key = "{$collection}:{$id}";
+        $previous = $this->records[$key] ?? null;
+        $record = new LocalRecord(
+            $collection,
+            $id,
+            $attributes,
+            ($previous === null ? 0 : $previous->version) + 1,
+            $updatedAtMs ?? (int) floor(microtime(true) * 1_000),
+        );
+        $this->records[$key] = $record;
+        $this->outbox[] = self::entry($record);
+        return $record;
+    }
+
+    public function get(string $collection, string $id): ?LocalRecord
+    {
+        $record = $this->records["{$collection}:{$id}"] ?? null;
+        return $record?->deleted === true ? null : $record;
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function drainOutbox(int $limit = 100): array
+    {
+        if ($limit < 1 || $limit > 1_000) {
+            throw new \InvalidArgumentException('Sync batch limit must be between 1 and 1,000.');
+        }
+        return array_splice($this->outbox, 0, $limit);
+    }
+
+    /** @param list<LocalRecord> $remote @param null|\Closure(LocalRecord, LocalRecord): LocalRecord $merge */
+    public function merge(array $remote, ConflictPolicy $policy, ?\Closure $merge = null): void
+    {
+        foreach ($remote as $incoming) {
+            $key = "{$incoming->collection}:{$incoming->id}";
+            $local = $this->records[$key] ?? null;
+            if ($local === null) {
+                $this->records[$key] = $incoming;
+                continue;
+            }
+            $this->records[$key] = match ($policy) {
+                ConflictPolicy::ClientWins => $local,
+                ConflictPolicy::ServerWins => $incoming,
+                ConflictPolicy::LatestWriteWins => $incoming->updatedAtMs >= $local->updatedAtMs ? $incoming : $local,
+                ConflictPolicy::Merge => $merge !== null
+                    ? $merge($local, $incoming)
+                    : throw new \LogicException('Merge conflict policy requires a resolver.'),
+            };
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private static function entry(LocalRecord $record): array
+    {
+        return [
+            'collection' => $record->collection,
+            'id' => $record->id,
+            'attributes' => $record->attributes,
+            'version' => $record->version,
+            'updatedAtMs' => $record->updatedAtMs,
+            'deleted' => $record->deleted,
+        ];
+    }
+}

--- a/packages/native/src/Plugin/PluginRegistry.php
+++ b/packages/native/src/Plugin/PluginRegistry.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Plugin;
+
+final class PluginRegistry
+{
+    /** @var array<string, RegistryEntry> */
+    private array $entries = [];
+
+    public function register(RegistryEntry $entry): void
+    {
+        $current = $this->entries[$entry->package] ?? null;
+        if ($current !== null && version_compare($entry->version, $current->version, '<=')) {
+            throw new \LogicException('Plugin registry versions are immutable and monotonically increasing.');
+        }
+        $this->entries[$entry->package] = $entry;
+    }
+
+    /** @param list<string> $grantedCapabilities */
+    public function authorize(
+        string $package,
+        array $grantedCapabilities,
+        int $minimumScore = 70,
+        TrustTier $minimumTrust = TrustTier::Community,
+    ): RegistryEntry
+    {
+        $entry = $this->entries[$package] ?? throw new PluginException("Plugin {$package} is not registered.");
+        if ($entry->qualityScore < $minimumScore
+            || $entry->trust->value < $minimumTrust->value
+            || array_diff($entry->capabilities, $grantedCapabilities) !== []) {
+            throw new PluginException("Plugin {$package} does not satisfy trust, quality, or capability policy.");
+        }
+        return $entry;
+    }
+}

--- a/packages/native/src/Plugin/RegistryEntry.php
+++ b/packages/native/src/Plugin/RegistryEntry.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Plugin;
+
+final readonly class RegistryEntry
+{
+    /** @param list<string> $capabilities */
+    public function __construct(
+        public string $package,
+        public string $version,
+        public TrustTier $trust,
+        public array $capabilities,
+        public string $sha256,
+        public int $qualityScore,
+    ) {
+        if (preg_match('/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/D', $package) !== 1
+            || preg_match('/^[0-9]+\.[0-9]+\.[0-9]+$/D', $version) !== 1
+            || preg_match('/^[a-f0-9]{64}$/D', $sha256) !== 1
+            || $qualityScore < 0 || $qualityScore > 100) {
+            throw new \InvalidArgumentException('Plugin registry entry is invalid.');
+        }
+        if (count($capabilities) !== count(array_unique($capabilities))) {
+            throw new \InvalidArgumentException('Plugin capabilities must be unique.');
+        }
+        foreach ($capabilities as $capability) {
+            if (preg_match('/^[a-z][a-z0-9.-]{0,63}$/D', $capability) !== 1) {
+                throw new \InvalidArgumentException('Plugin capabilities must use portable dotted identifiers.');
+            }
+        }
+    }
+}

--- a/packages/native/src/Plugin/TrustTier.php
+++ b/packages/native/src/Plugin/TrustTier.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Plugin;
+
+enum TrustTier: int
+{
+    case Community = 1;
+    case Verified = 2;
+    case Official = 3;
+}

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.6.78';
+    public const string SDK_VERSION = '0.7.0';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/Scheduling/AsyncStream.php
+++ b/packages/native/src/Scheduling/AsyncStream.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Scheduling;
+
+final class AsyncStream
+{
+    /** @var list<mixed> */
+    private array $buffer = [];
+    private bool $closed = false;
+
+    public function __construct(private readonly int $capacity = 64)
+    {
+        if ($capacity < 1 || $capacity > 4_096) {
+            throw new \InvalidArgumentException('Stream capacity must be between 1 and 4,096.');
+        }
+    }
+
+    public function emit(mixed $value): void
+    {
+        if ($this->closed) {
+            throw new \LogicException('Cannot emit into a closed stream.');
+        }
+        if (count($this->buffer) >= $this->capacity) {
+            throw new BackpressureException($this->capacity);
+        }
+        $this->buffer[] = $value;
+    }
+
+    public function next(): mixed
+    {
+        if ($this->buffer === []) {
+            return null;
+        }
+        return array_shift($this->buffer);
+    }
+
+    public function close(): void
+    {
+        $this->closed = true;
+    }
+
+    public function pending(): int
+    {
+        return count($this->buffer);
+    }
+}

--- a/packages/native/src/Scheduling/BackpressureException.php
+++ b/packages/native/src/Scheduling/BackpressureException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Scheduling;
+
+final class BackpressureException extends \OverflowException
+{
+    public function __construct(int $capacity)
+    {
+        parent::__construct("Async stream exceeded its bounded capacity of {$capacity}.");
+    }
+}

--- a/packages/native/src/Scheduling/DeadlineExceededException.php
+++ b/packages/native/src/Scheduling/DeadlineExceededException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Scheduling;
+
+final class DeadlineExceededException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Structured task deadline exceeded.');
+    }
+}

--- a/packages/native/src/Scheduling/Deferred.php
+++ b/packages/native/src/Scheduling/Deferred.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Scheduling;
+
+final class Deferred
+{
+    private bool $settled = false;
+    private mixed $value = null;
+    private ?\Throwable $error = null;
+    /** @var list<\Closure(mixed, ?\Throwable): void> */
+    private array $listeners = [];
+
+    public function resolve(mixed $value = null): void
+    {
+        $this->settle($value, null);
+    }
+
+    public function reject(\Throwable $error): void
+    {
+        $this->settle(null, $error);
+    }
+
+    /** @param \Closure(mixed, ?\Throwable): void $listener */
+    public function subscribe(\Closure $listener): void
+    {
+        if ($this->settled) {
+            $listener($this->value, $this->error);
+            return;
+        }
+        $this->listeners[] = $listener;
+    }
+
+    public function await(?CancellationToken $token = null, ?int $deadlineMs = null): mixed
+    {
+        $started = (int) floor(microtime(true) * 1_000);
+        while (!$this->settled) {
+            $token?->throwIfCancelled();
+            if ($deadlineMs !== null && (int) floor(microtime(true) * 1_000) - $started >= $deadlineMs) {
+                throw new DeadlineExceededException();
+            }
+            if (Scheduler::drain(1.0) === 0) {
+                usleep(500);
+            }
+        }
+        if ($deadlineMs !== null && (int) floor(microtime(true) * 1_000) - $started >= $deadlineMs) {
+            throw new DeadlineExceededException();
+        }
+        if ($this->error !== null) {
+            throw $this->error;
+        }
+        return $this->value;
+    }
+
+    private function settle(mixed $value, ?\Throwable $error): void
+    {
+        if ($this->settled) {
+            throw new \LogicException('Deferred values can only be settled once.');
+        }
+        $this->settled = true;
+        $this->value = $value;
+        $this->error = $error;
+        $listeners = $this->listeners;
+        $this->listeners = [];
+        foreach ($listeners as $listener) {
+            $listener($value, $error);
+        }
+    }
+}

--- a/packages/native/src/Scheduling/TaskGroup.php
+++ b/packages/native/src/Scheduling/TaskGroup.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Scheduling;
+
+final class TaskGroup
+{
+    private readonly CancellationToken $token;
+    /** @var list<Deferred> */
+    private array $tasks = [];
+
+    public function __construct(private readonly ?int $deadlineMs = null)
+    {
+        if ($deadlineMs !== null && ($deadlineMs < 1 || $deadlineMs > 3_600_000)) {
+            throw new \InvalidArgumentException('Task group deadline must be between 1 ms and one hour.');
+        }
+        $this->token = new CancellationToken();
+    }
+
+    /** @param \Closure(CancellationToken): mixed $work */
+    public function async(\Closure $work, TaskPriority $priority = TaskPriority::Normal): Deferred
+    {
+        $deferred = new Deferred();
+        $this->tasks[] = $deferred;
+        Scheduler::schedule(function (CancellationToken $scheduled) use ($work, $deferred): void {
+            try {
+                $this->token->throwIfCancelled();
+                $scheduled->throwIfCancelled();
+                $deferred->resolve($work($this->token));
+            } catch (\Throwable $error) {
+                $this->token->cancel();
+                $deferred->reject($error);
+            }
+        }, $priority);
+        return $deferred;
+    }
+
+    /** @return list<mixed> */
+    public function awaitAll(): array
+    {
+        $started = (int) floor(microtime(true) * 1_000);
+        try {
+            $results = [];
+            foreach ($this->tasks as $task) {
+                $remaining = $this->deadlineMs;
+                if ($remaining !== null) {
+                    $remaining -= (int) floor(microtime(true) * 1_000) - $started;
+                    if ($remaining < 1) {
+                        throw new DeadlineExceededException();
+                    }
+                }
+                $results[] = $task->await($this->token, $remaining);
+            }
+            return $results;
+        } catch (\Throwable $error) {
+            $this->cancel();
+            throw $error;
+        }
+    }
+
+    public function cancel(): void
+    {
+        $this->token->cancel();
+    }
+}

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4563,7 +4563,7 @@ file_put_contents(
     "protocol": 1,
     "pamNative": {
         "minimum": "0.3.0",
-        "maximumExclusive": "0.7.0"
+        "maximumExclusive": "0.8.0"
     },
     "php": {
         "provider": "Pam\\Native\\Tests\\Fixtures\\ExamplePluginProvider"
@@ -6215,8 +6215,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.6.78',
-    'The runtime SDK contract must match the 0.6.78 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.7.0',
+    'The runtime SDK contract must match the 0.7.0 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,
@@ -6921,5 +6921,7 @@ $assert(
         && end($componentLog) === 'cleanup',
     'Component shutdown must guarantee effect and component cleanup.',
 );
+
+require __DIR__.'/singularity.php';
 
 echo "Pam Native PHP SDK tests passed.\n";

--- a/packages/native/tests/singularity.php
+++ b/packages/native/tests/singularity.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+use Pam\Native\Bridge\Attributes\NativeMethod;
+use Pam\Native\Bridge\Attributes\NativeModule;
+use Pam\Native\Bridge\Attributes\NativePermission;
+use Pam\Native\Bridge\ContractCompiler;
+use Pam\Native\Bridge\NativeCallKind;
+use Pam\Native\Diagnostics\ReplayTimeline;
+use Pam\Native\HotReload\StateSnapshot;
+use Pam\Native\HotReload\HotReloadCoordinator;
+use Pam\Native\InternalHttp\LocalTransport;
+use Pam\Native\InternalHttp\Request;
+use Pam\Native\InternalHttp\Response;
+use Pam\Native\InternalHttp\Router;
+use Pam\Native\LocalFirst\ConflictPolicy;
+use Pam\Native\LocalFirst\EncryptedJournal;
+use Pam\Native\LocalFirst\LocalRecord;
+use Pam\Native\LocalFirst\LocalStore;
+use Pam\Native\Plugin\PluginRegistry;
+use Pam\Native\Plugin\RegistryEntry;
+use Pam\Native\Plugin\TrustTier;
+use Pam\Native\Scheduling\AsyncStream;
+use Pam\Native\Scheduling\BackpressureException;
+use Pam\Native\Scheduling\DeadlineExceededException;
+use Pam\Native\Scheduling\TaskGroup;
+
+#[NativeModule(id: 1, name: 'Camera')]
+interface SingularityCameraContract
+{
+    #[NativeMethod(id: 1)]
+    #[NativePermission('camera.capture')]
+    public function capture(string $quality, bool $flash): array;
+
+    #[NativeMethod(id: 2, kind: NativeCallKind::Stream, timeoutMs: 60_000)]
+    public function frames(int $maximumFps): array;
+}
+
+$contracts = ContractCompiler::compile([SingularityCameraContract::class], 'Pam.Showcase');
+$assert(
+    $contracts->manifest['schema'] === 2
+        && $contracts->manifest['modules'][0]['methods'][0]['permissions'] === ['camera.capture']
+        && str_contains($contracts->kotlin, 'object CameraContract')
+        && str_contains($contracts->swift, 'enum CameraContract')
+        && strlen($contracts->fingerprint) === 64,
+    'Singularity contracts must generate deterministic typed PHP, Kotlin and Swift bindings.',
+);
+
+$group = new TaskGroup(deadlineMs: 1_000);
+$group->async(static fn (): int => 20);
+$group->async(static fn (): int => 22);
+$assert($group->awaitAll() === [20, 22], 'Structured task groups must await ordered child results.');
+
+$late = new TaskGroup(deadlineMs: 1);
+$late->async(static function (): void { usleep(2_000); });
+$deadlineExceeded = false;
+try {
+    $late->awaitAll();
+} catch (DeadlineExceededException) {
+    $deadlineExceeded = true;
+}
+$assert($deadlineExceeded, 'Structured task groups must enforce one deadline across all children.');
+
+$stream = new AsyncStream(2);
+$stream->emit('first');
+$stream->emit('second');
+$backpressure = false;
+try {
+    $stream->emit('overflow');
+} catch (BackpressureException) {
+    $backpressure = true;
+}
+$assert($backpressure && $stream->next() === 'first', 'Async streams must apply bounded backpressure.');
+
+$local = new LocalStore();
+$local->put('todos', '1', ['title' => 'offline'], 100);
+$local->merge([
+    new LocalRecord('todos', '1', ['title' => 'server'], 2, 200),
+], ConflictPolicy::LatestWriteWins);
+$assert(
+    $local->get('todos', '1')?->attributes['title'] === 'server' && count($local->drainOutbox()) === 1,
+    'Local-first storage must support optimistic outbox writes and deterministic conflict resolution.',
+);
+$journal = new EncryptedJournal(str_repeat('k', 32));
+$sealed = $journal->seal([['id' => 1, 'value' => 'secret']]);
+$assert(
+    !str_contains($sealed, 'secret') && $journal->open($sealed)[0]['value'] === 'secret',
+    'Local-first journals must be authenticated and encrypted at rest.',
+);
+
+$router = (new Router())
+    ->middleware(static function (Request $request, Closure $next): Response {
+        $response = $next($request);
+        return new Response($response->status, $response->body, $response->headers + ['x-pam-local' => '1']);
+    })
+    ->route('POST', '/process', static fn (Request $request): Response => Response::json([
+        'length' => strlen($request->body),
+    ]));
+$transport = new LocalTransport($router);
+$response = $transport->send(new Request('POST', '/process', body: 'payload'));
+$assert(
+    $response->status === 200 && $response->headers['x-pam-local'] === '1' && !$transport->opensNetworkSocket(),
+    'Internal HTTP must run middleware and handlers without opening a TCP socket.',
+);
+
+$snapshot = StateSnapshot::capture(['route' => '/checkout', 'form' => ['email' => 'a@b.test']]);
+$assert(
+    $snapshot->restore()['route'] === '/checkout' && strlen($snapshot->fingerprint) === 64,
+    'Hot reload must preserve bounded, fingerprinted application state.',
+);
+$reloadState = ['route' => '/home'];
+$reload = new HotReloadCoordinator();
+$reload->register(
+    'navigation',
+    static fn (): array => $reloadState,
+    static function (array $state) use (&$reloadState): void { $reloadState = $state; },
+);
+$reload->checkpoint([['kind' => 1, 'route' => '/checkout']]);
+$reloadState = ['route' => '/empty'];
+$assert(
+    $reload->restore() && $reloadState['route'] === '/home',
+    'Hot reload coordinator must restore registered state across a runtime restart.',
+);
+$reload->clear();
+
+$timeline = new ReplayTimeline();
+$timeline->record(1, ['action' => 'tap']);
+$timeline->record(2, ['route' => '/checkout']);
+$replayed = [];
+$timeline->replay(static function (int $kind, array $payload) use (&$replayed): void {
+    $replayed[] = [$kind, $payload];
+});
+$assert(
+    count($replayed) === 2 && strlen($timeline->fingerprint()) === 64,
+    'DevTools replay must preserve deterministic event order and identity.',
+);
+
+$registry = new PluginRegistry();
+$registry->register(new RegistryEntry(
+    'pushinbr/pam-native-camera',
+    '1.0.0',
+    TrustTier::Official,
+    ['camera.capture'],
+    str_repeat('a', 64),
+    100,
+));
+$assert(
+    $registry->authorize(
+        'pushinbr/pam-native-camera',
+        ['camera.capture'],
+        minimumTrust: TrustTier::Verified,
+    )->trust === TrustTier::Official,
+    'Plugin registry policy must enforce immutable identity, capabilities and quality score.',
+);

--- a/scripts/sbom.py
+++ b/scripts/sbom.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def build(root: Path, version: str, commit: str, created_epoch: int) -> dict[str, object]:
+    lock_text = (root / "Cargo.lock").read_text(encoding="utf-8")
+    locked = []
+    for block in lock_text.split("[[package]]")[1:]:
+        values = {}
+        for key in ("name", "version", "checksum"):
+            match = re.search(rf'^\s*{key}\s*=\s*"([^"]+)"', block, re.MULTILINE)
+            if match is not None:
+                values[key] = match.group(1)
+        if "name" in values and "version" in values:
+            locked.append(values)
+    packages = []
+    seen: set[tuple[str, str]] = set()
+    for package in sorted(locked, key=lambda item: (item["name"], item["version"])):
+        identity = (str(package["name"]), str(package["version"]))
+        if identity in seen:
+            continue
+        seen.add(identity)
+        checksum = package.get("checksum")
+        entry: dict[str, object] = {
+            "SPDXID": "SPDXRef-Package-" + hashlib.sha256("@".join(identity).encode()).hexdigest()[:16],
+            "name": identity[0],
+            "versionInfo": identity[1],
+            "downloadLocation": "NOASSERTION",
+            "filesAnalyzed": False,
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+        }
+        if isinstance(checksum, str):
+            entry["checksums"] = [{"algorithm": "SHA256", "checksumValue": checksum}]
+        packages.append(entry)
+    namespace_hash = hashlib.sha256(f"{version}:{commit}".encode()).hexdigest()
+    return {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": f"pam-native-{version}",
+        "documentNamespace": f"https://github.com/push-in/pam-native/sbom/{namespace_hash}",
+        "creationInfo": {
+            "created": datetime.fromtimestamp(created_epoch, timezone.utc).isoformat().replace("+00:00", "Z"),
+            "creators": ["Tool: pam-native-sbom/1"],
+        },
+        "documentDescribes": ["SPDXRef-PAM-Native"],
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-PAM-Native",
+                "name": "pam-native",
+                "versionInfo": version,
+                "downloadLocation": f"https://github.com/push-in/pam-native/tree/{commit}",
+                "filesAnalyzed": False,
+                "licenseConcluded": "Apache-2.0",
+                "licenseDeclared": "Apache-2.0",
+                "copyrightText": "NOASSERTION",
+            },
+            *packages,
+        ],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create the bounded PAM Native SPDX SBOM")
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--created-epoch", required=True, type=int)
+    parser.add_argument("--output", type=Path, required=True)
+    options = parser.parse_args()
+    payload = build(options.root.resolve(), options.version, options.commit, options.created_epoch)
+    options.output.parent.mkdir(parents=True, exist_ok=True)
+    options.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-release-workflows.php
+++ b/scripts/test-release-workflows.php
@@ -104,6 +104,9 @@ requireFragments($release, 'release.yml', [
     "            --output \"dist/pam-native-android-\${version}.reproducibility.json\"\n",
     "            --output \"dist/pam-native-php-\${version}.reproducibility.json\"\n",
     "      - name: Reverify downloaded reproducibility evidence\n",
+    "      - name: Generate SPDX 2.3 software bill of materials\n",
+    "            --created-epoch \"$(git log -1 --format=%ct)\" \\\n",
+    "        uses: actions/attest-sbom@v4\n",
 ]);
 if (substr_count($release, 'cmp "dist/${artifact}" "${RUNNER_TEMP}/${artifact}"') !== 3) {
     fail('release.yml must verify iOS, Android renderer, and PHP SDK archives byte for byte');

--- a/scripts/test_sbom.py
+++ b/scripts/test_sbom.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("pam_sbom", ROOT / "scripts" / "sbom.py")
+assert SPEC is not None and SPEC.loader is not None
+SBOM = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SBOM)
+
+
+class SbomTest(unittest.TestCase):
+    def test_builds_spdx_with_unique_locked_packages(self) -> None:
+        payload = SBOM.build(ROOT, "0.7.0", "a" * 40, 1_700_000_000)
+        self.assertEqual(payload["spdxVersion"], "SPDX-2.3")
+        self.assertEqual(payload["documentDescribes"], ["SPDXRef-PAM-Native"])
+        packages = payload["packages"]
+        identities = [(item["name"], item["versionInfo"]) for item in packages]
+        self.assertEqual(len(identities), len(set(identities)))
+        self.assertIn(("pam-native", "0.7.0"), identities)
+        self.assertEqual(payload["creationInfo"]["created"], "2023-11-14T22:13:20Z")
+
+    def test_same_inputs_are_byte_for_byte_reproducible(self) -> None:
+        first = SBOM.build(ROOT, "0.7.0", "b" * 40, 1_700_000_000)
+        second = SBOM.build(ROOT, "0.7.0", "b" * 40, 1_700_000_000)
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Ships PAM Native 0.7 as an additive, protocol-v1-compatible architecture across twelve production pillars:

1. deterministic typed PHP/Kotlin/Swift native contracts
2. transactional Rust rendering generations
3. structured concurrency, cancellation, deadlines and bounded streams
4. encrypted local-first records, outbox and conflict policies
5. state-preserving hot reload
6. deterministic DevTools replay timelines
7. governed plugin trust, digest, capability and quality policies
8. socket-free internal HTTP transport
9. integrated mature declarative UI showcase
10. one `pam release` surface plus reproducible artifacts, SPDX SBOM and attestations
11. comparable PAM/React Native/Flutter/native physical-device evidence
12. Composer-first shared domain boundaries

PHP 8.5 is the sole SDK/runtime default. Existing protocol v1 and existing plugins remain compatible.

## Local certification

- PHP SDK, performance, navigation performance and 1,000-frame fuzz suite
- PHPStan 2.2.9 level 9 for all new Singularity boundaries, without suppressions
- Rust workspace tests, rustfmt and Clippy with warnings denied
- release workflow, accessibility, protocol parity, hot reload and editor contracts
- benchmark and reproducibility suites
- strict Composer validation
- showcase contract codegen executed twice with byte-identical outputs
