### PR TITLE
Keep CI prerequisites out of public releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,10 @@ jobs:
           cargo build --locked --release --package pam-native-cli --target '${{ matrix.target }}'
           mkdir -p dist
           cp "target/${{ matrix.target }}/release/pam-native${{ matrix.extension }}" "dist/${artifact}"
-          sha256sum "dist/${artifact}" > "dist/${artifact}.sha256"
+          (
+            cd dist
+            sha256sum "${artifact}" > "${artifact}.sha256"
+          )
       - uses: actions/attest-build-provenance@v4
         with:
           subject-path: dist/pam-native-cli-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,6 +332,8 @@ jobs:
           pattern: pam-native-*
           path: dist
           merge-multiple: true
+      - name: Remove CI-only prerequisite payloads
+        run: rm -f dist/Info.plist dist/pam-native-android-prerequisites.tar.gz
       - name: Reverify downloaded package budget evidence
         run: |
           version=${GITHUB_REF_NAME#v}

--- a/scripts/test-release-workflows.php
+++ b/scripts/test-release-workflows.php
@@ -106,6 +106,7 @@ requireFragments($release, 'release.yml', [
     "      - name: Reverify downloaded reproducibility evidence\n",
     "      - name: Generate SPDX 2.3 software bill of materials\n",
     "        run: rm -f dist/Info.plist dist/pam-native-android-prerequisites.tar.gz\n",
+    "            sha256sum \"\${artifact}\" > \"\${artifact}.sha256\"\n",
     "            --created-epoch \"$(git log -1 --format=%ct)\" \\\n",
     "        uses: actions/attest-sbom@v4\n",
 ]);

--- a/scripts/test-release-workflows.php
+++ b/scripts/test-release-workflows.php
@@ -105,6 +105,7 @@ requireFragments($release, 'release.yml', [
     "            --output \"dist/pam-native-php-\${version}.reproducibility.json\"\n",
     "      - name: Reverify downloaded reproducibility evidence\n",
     "      - name: Generate SPDX 2.3 software bill of materials\n",
+    "        run: rm -f dist/Info.plist dist/pam-native-android-prerequisites.tar.gz\n",
     "            --created-epoch \"$(git log -1 --format=%ct)\" \\\n",
     "        uses: actions/attest-sbom@v4\n",
 ]);


### PR DESCRIPTION
Removes the Android prerequisite bundle and transient Info.plist after artifact download, before the release asset glob. The v0.7.0 release was cleaned manually; this makes the rule permanent for future releases. Release workflow contract tests pass.