### PR TITLE
feat: ship PAM Native UI Language 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           python3 -m json.tool benchmarks/package/report.schema.json >/dev/null
           python3 -m json.tool benchmarks/package/reproducibility.schema.json >/dev/null
           python3 -m json.tool scripts/accessibility-evidence.schema.json >/dev/null
+          python3 -m json.tool packages/native/resources/pam-native-ui-ir.schema.json >/dev/null
           node --check editors/vscode/extension.js
           node editors/vscode/test.js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## Unreleased
+## 0.8.0 - 2026-08-23
+
+- Added opt-in PAM Native UI Language 2 with a stable, integer-capability UI IR.
+- Added attribute-backed typed contracts for props, actions, events, slots and
+  Composer-provided tags while retaining Language 1 and `#[Expose]` compatibility.
+- Added compiled interaction states, design tokens, recipes, viewport/container
+  queries and compositor-only keyframes without a runtime CSS engine.
+- Added `Show`, strict `Match` and typed `Await` flow primitives.
+- Added compile-time stable-key and accessibility diagnostics for virtual lists
+  and meaningful images.
+- Expanded the Composer-installed language server with references, rename,
+  symbols, signatures, semantic tokens and Language 2 quick fixes.
 
 ## 0.7.0 - 2026-08-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ final class Counter extends Component
     #[State]
     public int $count = 0;
 
+    #[\Pam\Native\Attributes\Action]
     public function increment(): void
     {
         $this->count++;
@@ -150,7 +151,7 @@ final class Counter extends Component
 }
 ?>
 
-<template>
+<template language="2">
     <Column class="card">
         <Text class="title">Count: {{ $count }}</Text>
         <Button label="Increment" @press="increment" />
@@ -165,6 +166,13 @@ final class Counter extends Component
 
 Both styles compile to the same typed retained tree. Scoped styles become
 native properties; they are not browser CSS.
+
+Language 2 adds typed tag/event/slot contracts, native interaction states,
+compiled tokens and recipes, viewport/container queries, declarative flow and
+async branches, stable virtual-list identity, compositor keyframes,
+accessibility diagnostics, Composer-extensible tags and a full editor-neutral
+LSP. Attributes such as `#[Prop]` and `#[Action]` remain the canonical PHP API.
+Read the [UI Language 2 guide](docs/ui-language-2.md).
 
 ## Native where it matters
 

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -7393,7 +7393,7 @@ mod tests {
                 "protocol": 1,
                 "pamNative": {
                     "minimum": "0.6.0",
-                    "maximumExclusive": "0.7.0"
+                    "maximumExclusive": "0.9.0"
                 },
                 "php": {"provider": "Community\\Example\\PluginProvider"},
                 "android": {

--- a/crates/pam-native-engine/src/lib.rs
+++ b/crates/pam-native-engine/src/lib.rs
@@ -6,6 +6,7 @@ pub mod performance;
 pub mod reactive;
 pub mod scheduler;
 pub mod transaction;
+pub mod ui_language;
 pub mod virtualization;
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/pam-native-engine/src/ui_language.rs
+++ b/crates/pam-native-engine/src/ui_language.rs
@@ -1,0 +1,162 @@
+use std::collections::BTreeSet;
+
+use crate::reactive::{Instruction, ReactiveError, SignalId, Worklet};
+
+pub const UI_IR_VERSION: u16 = 2;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum InteractionState {
+    Pressed = 1,
+    Focused = 2,
+    Disabled = 3,
+    Selected = 4,
+    Checked = 5,
+    Hovered = 6,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum QueryKind {
+    Viewport = 1,
+    Container = 2,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum QueryAxis {
+    Width = 1,
+    Height = 2,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum QueryComparison {
+    Minimum = 1,
+    Maximum = 2,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ResponsiveQuery {
+    pub kind: QueryKind,
+    pub axis: QueryAxis,
+    pub comparison: QueryComparison,
+    pub threshold: f32,
+}
+
+impl ResponsiveQuery {
+    #[must_use]
+    pub fn matches(self, width: f32, height: f32) -> bool {
+        if !self.threshold.is_finite() || self.threshold < 0.0 {
+            return false;
+        }
+        let actual = match self.axis {
+            QueryAxis::Width => width,
+            QueryAxis::Height => height,
+        };
+        match self.comparison {
+            QueryComparison::Minimum => actual >= self.threshold,
+            QueryComparison::Maximum => actual <= self.threshold,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum StableKey {
+    Integer(i64),
+    String(String),
+}
+
+#[derive(Debug, Default)]
+pub struct StableKeySet {
+    keys: BTreeSet<StableKey>,
+}
+
+impl StableKeySet {
+    pub fn insert(&mut self, key: StableKey) -> Result<(), UiLanguageError> {
+        if matches!(&key, StableKey::String(value) if value.is_empty() || value.len() > 1_024) {
+            return Err(UiLanguageError::InvalidStableKey);
+        }
+        if !self.keys.insert(key) {
+            return Err(UiLanguageError::DuplicateStableKey);
+        }
+        Ok(())
+    }
+}
+
+/// Compiles a two-point compositor animation to the existing native worklet VM.
+pub fn animation_worklet(progress: SignalId, from: f64, to: f64) -> Result<Worklet, ReactiveError> {
+    Worklet::compile(vec![
+        Instruction::Constant(from),
+        Instruction::Signal(progress),
+        Instruction::Constant(to - from),
+        Instruction::Multiply,
+        Instruction::Add,
+    ])
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AccessibilityMetrics {
+    pub width: f32,
+    pub height: f32,
+    pub interactive: bool,
+    pub labelled: bool,
+}
+
+impl AccessibilityMetrics {
+    pub fn audit(self) -> Result<(), UiLanguageError> {
+        if self.interactive && !self.labelled {
+            return Err(UiLanguageError::MissingAccessibilityLabel);
+        }
+        if self.interactive && (self.width < 44.0 || self.height < 44.0) {
+            return Err(UiLanguageError::TouchTargetTooSmall);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UiLanguageError {
+    DuplicateStableKey,
+    InvalidStableKey,
+    MissingAccessibilityLabel,
+    TouchTargetTooSmall,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn language_two_capabilities_are_stable_and_native_safe() {
+        assert_eq!(UI_IR_VERSION, 2);
+        assert!(
+            ResponsiveQuery {
+                kind: QueryKind::Viewport,
+                axis: QueryAxis::Width,
+                comparison: QueryComparison::Minimum,
+                threshold: 768.0,
+            }
+            .matches(1_024.0, 600.0)
+        );
+
+        let mut keys = StableKeySet::default();
+        keys.insert(StableKey::String("product-1".into())).unwrap();
+        assert_eq!(
+            keys.insert(StableKey::String("product-1".into())),
+            Err(UiLanguageError::DuplicateStableKey),
+        );
+
+        assert!(animation_worklet(1, 0.0, 1.0).is_ok());
+        assert_eq!(
+            AccessibilityMetrics {
+                width: 32.0,
+                height: 32.0,
+                interactive: true,
+                labelled: true,
+            }
+            .audit(),
+            Err(UiLanguageError::TouchTargetTooSmall),
+        );
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 - [PHP Runtime Manager](runtime-manager.md)
 - [Singularity architecture](singularity.md)
+- [UI Language 2](ui-language-2.md)
+- [Migrating to UI Language 2](migration-ui-language-2.md)
 
 Every public feature added to Pam Native must include a copyable example. Start
 with the focused guide below or use the [capability cookbook](examples.md) for

--- a/docs/migration-ui-language-2.md
+++ b/docs/migration-ui-language-2.md
@@ -1,0 +1,18 @@
+# Migrating to PAM Native UI Language 2
+
+Migration is per component and reversible until you commit the source change.
+No application-wide flag is required.
+
+1. Keep the PHP block valid PHP 8.5 and add `#[Prop]`, `#[State]` and
+   `#[Action]` to the existing contracts.
+2. Add typed `#[Event]` and `#[Slot]` class attributes where the component
+   publishes those surfaces.
+3. Add accessibility labels or mark decorative images explicitly.
+4. Add `p-key` to every loop inside a virtual list or grid.
+5. Change `<template>` to `<template language="2">`.
+6. Run `pam format`, `pam native:optimize` and `pam test`.
+
+Language 1 components and Language 2 components may call each other. Convert
+leaf components first, then shared components and finally screens. Do not
+rewrite working attributes into a custom `props {}` syntax: the attributes are
+the stable public API.

--- a/docs/ui-language-2.md
+++ b/docs/ui-language-2.md
@@ -1,0 +1,304 @@
+# PAM Native UI Language 2
+
+Language 2 is PAM Native's additive, compiled UI language. PHP remains PHP
+8.5, attributes remain the source of truth, and every template/style feature is
+lowered to the versioned UI IR before the application starts. There is no DOM,
+JavaScript runtime, CSS interpreter or `eval` in the application hot path.
+
+## Start here
+
+PAM Native depends on the PAM Runtime. Install PAM, create a native project and
+install the Composer product through PAM's verified toolchain:
+
+```bash
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+  --connect-timeout 15 --max-time 60 --max-filesize 1048576 -fsSL \
+  https://github.com/push-in/pam/releases/latest/download/install.sh | sh
+
+pam doctor
+pam init galaxy --template native
+cd galaxy
+pam composer require pushinbr/pam-native
+pam doctor --fix
+pam dev
+```
+
+Opt in per component. Existing `<template>` components remain Language 1 and
+keep their behavior forever; `<template language="2">` enables the stricter
+compiler and the new IR capabilities.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Components;
+
+use App\Domain\Product;
+use Pam\Native\Attributes\Action;
+use Pam\Native\Attributes\Prop;
+use Pam\Native\Attributes\State;
+use Pam\Native\Component;
+
+final class ProductCard extends Component
+{
+    public function __construct(
+        #[Prop(required: true)]
+        public readonly Product $product,
+    ) {
+    }
+
+    #[State]
+    public bool $favorite = false;
+
+    #[Action]
+    public function toggleFavorite(): void
+    {
+        $this->favorite = !$this->favorite;
+    }
+}
+?>
+
+<template language="2">
+    <Pressable
+        class="product-card"
+        recipe="card"
+        variant:tone="featured"
+        accessibilityLabel="Toggle favorite product"
+        @press="toggleFavorite"
+    >
+        <Image
+            :source="$product->image"
+            :accessibilityLabel="$product->name"
+        />
+        <Text>{{ $product->name }}</Text>
+    </Pressable>
+</template>
+```
+
+`#[Prop]`, `#[State]`, `#[Action]`, `#[Event]`, `#[Slot]` and `#[Tag]` are the
+canonical contracts. PAM does not invent `props {}` or `actions {}` syntax
+inside PHP, so PHPStan, refactoring tools, formatters and ordinary PHP IDEs see
+the real program.
+
+## The 12 pillars
+
+### 1. Typed tag, prop, event and slot contracts
+
+Constructor parameters marked `#[Prop]` generate the component's prop
+contract. `#[Event]` and `#[Slot]` are repeatable class attributes. Language 2
+rejects missing/unknown props and events, invalid slot cardinality and template
+handlers that are not public `#[Action]` methods. Legacy `#[Expose]` remains an
+accepted compatibility alias.
+
+Composer packages can publish a stable tag without string registration:
+
+```php
+#[Tag('Map')]
+#[Event('regionChanged', RegionChanged::class)]
+#[Slot('overlay', minimum: 0, maximum: 8)]
+final class Map extends Component
+{
+    public function __construct(
+        #[Prop(required: true)] public readonly Coordinate $center,
+        #[Prop] public readonly float $zoom = 12,
+    ) {
+    }
+}
+```
+
+Providers may also register a `TagContract` through
+`TemplateRegistry::contract()` for native views that do not use PHP component
+classes. Composer discovery remains governed by `pam-native.plugin.json`.
+
+### 2. Native interaction states
+
+Language 2 accepts the bounded states `:pressed`, `:focused`, `:disabled`,
+`:selected`, `:checked` and `:hovered`. They compile to state IR. Press opacity
+and scale lower directly to the platform press properties; the state is not
+round-tripped through PHP.
+
+```css
+.card:pressed {
+    opacity: 0.72;
+    transform: scale(0.98);
+}
+```
+
+### 3. Compiled design tokens
+
+Tokens are declared once and become immutable compile-time custom properties.
+Dot notation is normalized to CSS-safe hyphens in IR.
+
+```css
+@tokens {
+    color.brand: #4F46E5;
+    color.surface: #FFFFFF;
+    space.md: 16px;
+    radius.card: 20px;
+}
+```
+
+Use them as `var(--color-brand)`, `var(--space-md)` and so on. Unknown or
+circular token references fail compilation.
+
+### 4. Recipes and typed variants
+
+Recipes replace duplicated bags of classes with a named base and bounded
+variant choices:
+
+```css
+@recipe card {
+    base {
+        padding: var(--space-md);
+        border-radius: var(--radius-card);
+    }
+
+    variant tone=featured {
+        background: var(--color-brand);
+        color: #FFFFFF;
+    }
+}
+```
+
+```xml
+<View recipe="card" variant:tone="featured" />
+```
+
+An unknown recipe, variant axis or choice is an error instead of a silent
+visual fallback.
+
+### 5. Responsive viewport and container queries
+
+Queries use logical device pixels and a deliberately bounded grammar:
+
+```css
+@media (min-width: 768dp) {
+    .catalog { gap: 24px; }
+}
+
+@container product (min-width: 320dp) {
+    .title { font-size: 20px; }
+}
+```
+
+Viewport rules react to the native dimensions event. Container rules use the
+nearest authored container dimensions. There is no selector/layout feedback
+loop and no runtime CSS parser.
+
+### 6. Declarative flow
+
+`Show` replaces simple conditional wrappers. `Match` performs strict matching
+and accepts only `Case` plus one optional `Default`:
+
+```xml
+<Show when="$available">
+    <Button label="Buy" @press="buy" />
+</Show>
+
+<Match value="$layout">
+    <Case value="compact"><CompactCatalog /></Case>
+    <Case value="expanded"><ExpandedCatalog /></Case>
+    <Default><EmptyState /></Default>
+</Match>
+```
+
+Existing `p-if`, `p-else-if`, `p-else` and `p-for` remain supported.
+
+### 7. Stable virtual lists
+
+Every Language 2 loop below `VirtualizedList` or `VirtualGrid` requires
+`p-key`. Keys must resolve to a unique string or integer and drive component
+identity across insertions, moves and recycling:
+
+```xml
+<VirtualizedList>
+    <ProductRow
+        p-for="$product in $products"
+        p-key="$product->id"
+        :product="$product"
+    />
+</VirtualizedList>
+```
+
+Duplicate and non-scalar keys fail deterministically before corrupting local
+row state.
+
+### 8. Native compositor animations
+
+Keyframes accept compositor-safe properties only. They are sorted and encoded
+at build time, then executed by the Rust worklet VM and platform animators.
+
+```css
+@keyframes enter {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0px); }
+}
+```
+
+```xml
+<Animated animation="enter" durationMs="240" easing="easeOut">
+    <ProductCard :product="$product" />
+</Animated>
+```
+
+Animations are interruptible and platform reduced-motion policy remains
+authoritative.
+
+### 9. Typed asynchronous branches
+
+`Await` consumes `AsyncResource` or `AsyncValue` and exposes the existing
+integer-backed async state contract:
+
+```xml
+<Await value="$products">
+    <Pending><CatalogSkeleton /></Pending>
+    <Content><Catalog :products="$data" /></Content>
+    <Empty><EmptyCatalog /></Empty>
+    <Error><RetryState :message="$message" /></Error>
+    <Offline><OfflineCatalog :products="$data" /></Offline>
+    <Stale><Catalog :products="$data" /></Stale>
+</Await>
+```
+
+Branches are unique and validated by the compiler.
+
+### 10. Accessibility as a compiler contract
+
+Language 2 rejects meaningful images without `accessibilityLabel`; decorative
+images must say `decorative="true"`. The engine exposes native audits for
+labels and minimum 44-point interactive targets. Platform renderers continue
+to enforce Dynamic Type, focus, custom actions and reduced motion.
+
+Diagnostics use stable codes (`PAM2301`, etc.) so CI and editors can treat
+selected findings as errors.
+
+### 11. Composer-extensible tags
+
+`#[Tag]` and `TagContract` let `pushinbr/*` or community packages add tags while
+keeping Composer as the package authority. Contracts are registered before
+Language 2 templates are validated. Plugin manifests, SDK ranges, protocol
+versions and vendor-directory boundaries remain mandatory.
+
+### 12. One editor-neutral language server
+
+`vendor/bin/pam-native-language-server` provides formatting, Language 2
+diagnostics, tag/directive/property completion, hover, go-to-definition,
+references, safe workspace rename, document symbols, signature help, semantic
+tokens and quick fixes. VS Code, Neovim, Helix and any LSP client use the same
+Composer-installed server.
+
+## Compatibility and permanence
+
+- Language 1 is frozen and remains the default for existing `<template>` files.
+- Language 2 is explicit and additive.
+- UI IR version `2` and capability IDs `1..12` are stable and append-only.
+- All coded versions, capabilities, states and kinds cross boundaries as
+  sequential integers represented by enums.
+- Unknown future capabilities are rejected by older runtimes rather than
+  guessed.
+- PHP attributes are canonical; template and CSS syntax are compile-time
+  authoring layers only.
+
+See [the migration guide](migration-ui-language-2.md) for adopting the stricter
+contracts incrementally.

--- a/editors/vscode/syntaxes/pam.tmLanguage.json
+++ b/editors/vscode/syntaxes/pam.tmLanguage.json
@@ -21,11 +21,11 @@
             "contentName": "source.css"
         },
         "template": {
-            "begin": "<template>",
+            "begin": "<template(?:\\s+language=\\\"2\\\")?>",
             "end": "</template>",
             "contentName": "text.html.pam",
             "patterns": [
-                {"match": "\\b(p-if|p-else-if|p-else|p-for|p-key|p-index)\\b", "name": "keyword.control.pam"},
+                {"match": "\\b(p-if|p-else-if|p-else|p-for|p-key|p-index|recipe|variant:[A-Za-z][A-Za-z0-9_-]*)\\b", "name": "keyword.control.pam"},
                 {"match": "(@[A-Za-z][A-Za-z0-9:-]*|:[A-Za-z][A-Za-z0-9:-]*|bind:[A-Za-z][A-Za-z0-9:-]*)", "name": "entity.other.attribute-name.pam"},
                 {"begin": "\\{\\{", "end": "\\}\\}", "contentName": "source.pam-expression"},
                 {"include": "text.html.basic"}

--- a/editors/vscode/test.js
+++ b/editors/vscode/test.js
@@ -53,6 +53,9 @@ function request(method, params) {
     const initialized = await request("initialize", {capabilities: {}, rootUri});
     assert.strictEqual(initialized.capabilities.documentFormattingProvider, true);
     assert.strictEqual(initialized.capabilities.definitionProvider, true);
+    assert.strictEqual(initialized.capabilities.referencesProvider, true);
+    assert.strictEqual(initialized.capabilities.documentSymbolProvider, true);
+    assert.strictEqual(initialized.capabilities.semanticTokensProvider.full, true);
     assert.deepStrictEqual(initialized.capabilities.completionProvider.triggerCharacters, ["<", ":", "@"]);
     const uri = "file:///Demo.pam";
     send({method: "textDocument/didOpen", params: {textDocument: {uri, languageId: "pam", version: 1, text: "<?php public string $title = ''; ?>\n<template><Text>{{ $title }}</Text></template>"}}});
@@ -60,10 +63,18 @@ function request(method, params) {
     assert(completions.some(item => item.label === "$title"));
     assert(completions.some(item => item.label === "p-if"));
     assert(completions.some(item => item.label === "ProfileCard"));
+    assert(completions.some(item => item.label === "Await"));
+    assert(completions.some(item => item.label === "recipe"));
     const usage = "<?php final class Demo {} ?>\n<template><ProfileCard /></template>";
     send({method: "textDocument/didChange", params: {textDocument: {uri, version: 2}, contentChanges: [{text: usage}]}});
     const definition = await request("textDocument/definition", {textDocument: {uri}, position: {line: 1, character: 13}});
     assert(definition.uri.endsWith("ProfileCard.pam"));
+    const references = await request("textDocument/references", {textDocument: {uri}, position: {line: 1, character: 13}, context: {includeDeclaration: true}});
+    assert(Array.isArray(references));
+    const symbols = await request("textDocument/documentSymbol", {textDocument: {uri}});
+    assert(symbols.some(symbol => symbol.name === "Demo"));
+    const semantic = await request("textDocument/semanticTokens/full", {textDocument: {uri}});
+    assert(Array.isArray(semantic.data));
     await request("shutdown", null);
     send({method: "exit"});
     server.stdin.end();

--- a/examples/community-plugin/composer.json
+++ b/examples/community-plugin/composer.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^8.5",
-        "pushinbr/pam-native": "^0.7.0"
+        "pushinbr/pam-native": "^0.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/examples/community-plugin/pam-native.plugin.json
+++ b/examples/community-plugin/pam-native.plugin.json
@@ -3,8 +3,8 @@
     "version": 1,
     "protocol": 1,
     "pamNative": {
-        "minimum": "0.5.0",
-        "maximumExclusive": "0.6.0"
+        "minimum": "0.8.0",
+        "maximumExclusive": "0.9.0"
     },
     "php": {
         "provider": "PamCommunity\\Example\\ExamplePluginProvider"

--- a/examples/showcase/composer.json
+++ b/examples/showcase/composer.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^8.5",
-        "pushinbr/pam-native": "^0.7.0",
+        "pushinbr/pam-native": "^0.8.0",
         "pam-community/example-plugin": "^0.1"
     },
     "repositories": [
@@ -15,7 +15,7 @@
             "options": {
                 "symlink": false,
                 "versions": {
-                    "pushinbr/pam-native": "0.7.0"
+                    "pushinbr/pam-native": "0.8.0"
                 }
             }
         },

--- a/examples/showcase/composer.lock
+++ b/examples/showcase/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51f5ec5a075fe836ff086ea23a4ac5be",
+    "content-hash": "84954ddac5373dfe4ce33dfb6f4b1e8e",
     "packages": [
         {
             "name": "pam-community/example-plugin",
@@ -12,11 +12,11 @@
             "dist": {
                 "type": "path",
                 "url": "../community-plugin",
-                "reference": "621b3fbed576ac726cb1c572bb04a511d0f66dac"
+                "reference": "b125eff40b4dd80e3d3377045880fc33dea7d3c4"
             },
             "require": {
                 "php": "^8.5",
-                "pushinbr/pam-native": "^0.7.0"
+                "pushinbr/pam-native": "^0.8.0"
             },
             "type": "pam-native-plugin",
             "extra": {
@@ -40,11 +40,11 @@
         },
         {
             "name": "pushinbr/pam-native",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "dist": {
                 "type": "path",
                 "url": "../../packages/native",
-                "reference": "598e85fbd1067fa9e903f49e91fd63983b263776"
+                "reference": "8a1b7836e42ebd13c4b9527d88923970667fd2c5"
             },
             "require": {
                 "php": "^8.5"

--- a/examples/showcase/index.php
+++ b/examples/showcase/index.php
@@ -19,6 +19,10 @@ App::views(
     __DIR__.'/resources/native',
     __DIR__.'/.pam-native/views',
 );
+App::components(
+    __DIR__.'/resources/components',
+    __DIR__.'/.pam-native/components',
+);
 App::theme(\Pam\Native\Theme::pamLab());
 $showcase = new Showcase();
 $template = new TemplateShowcase();

--- a/examples/showcase/resources/components/LanguageTwoCard.pam
+++ b/examples/showcase/resources/components/LanguageTwoCard.pam
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Components;
+
+use Pam\Native\Attributes\Action;
+use Pam\Native\Attributes\Prop;
+use Pam\Native\Attributes\State;
+use Pam\Native\Attributes\Tag;
+use Pam\Native\Component;
+
+#[Tag('LanguageTwoCard')]
+final class LanguageTwoCard extends Component
+{
+    public function __construct(
+        #[Prop(required: true)]
+        public readonly string $title,
+    ) {
+    }
+
+    #[State]
+    public bool $selected = false;
+
+    #[Action]
+    public function toggle(): void
+    {
+        $this->selected = !$this->selected;
+    }
+}
+?>
+
+<template language="2">
+    <Pressable
+        class="language-two-card"
+        recipe="language-card"
+        variant:tone="brand"
+        accessibilityLabel="Toggle Language 2 showcase card"
+        @press="toggle"
+    >
+        <Column gap="8">
+            <Text fontSize="18" fontWeight="700">{{ $title }}</Text>
+            <Match value="$selected">
+                <Case value="true"><Text>Selected</Text></Case>
+                <Default><Text>Ready</Text></Default>
+            </Match>
+        </Column>
+    </Pressable>
+</template>
+
+<style scoped>
+    @tokens {
+        color.language: #4F46E5;
+        space.language: 16px;
+    }
+
+    @recipe language-card {
+        base {
+            padding: var(--space-language);
+            border-radius: 16px;
+        }
+
+        variant tone=brand {
+            background: var(--color-language);
+            color: #FFFFFF;
+        }
+    }
+
+    .language-two-card {
+        opacity: 1;
+    }
+
+    .language-two-card:pressed {
+        opacity: 0.76;
+        transform: scale(0.98);
+    }
+</style>

--- a/examples/showcase/resources/native/screens/components.pam
+++ b/examples/showcase/resources/native/screens/components.pam
@@ -7,6 +7,7 @@
             </Row>
 
             <Text class="text-primary" height="36" fontSize="18">Hello, {{ $name }}.</Text>
+            <LanguageTwoCard title="PAM Native UI Language 2" />
             <Input
                 key="name"
                 model="name"

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -4,17 +4,21 @@ Pam Native renders real Android views from persistent PHP. PHP owns application
 state and events, Rust performs retained layout and incremental diffing, and
 Kotlin mounts bounded mutation batches on the Android UI thread.
 
-```bash
-pam composer require pushinbr/pam-native
-```
+## Start here
 
-For a complete project:
+PAM Native is a Composer product and requires the PAM Runtime. Install PAM
+first, then create the project and run Composer through PAM:
 
 ```bash
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+  --connect-timeout 15 --max-time 60 --max-filesize 1048576 -fsSL \
+  https://github.com/push-in/pam/releases/latest/download/install.sh | sh
+
+pam doctor
 pam init hello-native --template native
 cd hello-native
-pam composer install
-pam doctor
+pam composer require pushinbr/pam-native
+pam doctor --fix
 pam dev
 ```
 

--- a/packages/native/bin/pam-native-language-server
+++ b/packages/native/bin/pam-native-language-server
@@ -48,8 +48,20 @@ while (($message = readMessage(STDIN)) !== null) {
                 'completionProvider' => ['triggerCharacters' => ['<', ':', '@']],
                 'hoverProvider' => true,
                 'definitionProvider' => true,
+                'referencesProvider' => true,
+                'renameProvider' => ['prepareProvider' => false],
+                'documentSymbolProvider' => true,
+                'signatureHelpProvider' => ['triggerCharacters' => ['(', ',']],
+                'codeActionProvider' => true,
+                'semanticTokensProvider' => [
+                    'legend' => [
+                        'tokenTypes' => ['class', 'property', 'method', 'keyword', 'variable'],
+                        'tokenModifiers' => ['declaration', 'readonly'],
+                    ],
+                    'full' => true,
+                ],
             ],
-            'serverInfo' => ['name' => 'PAM Native Language Server', 'version' => '0.1.0'],
+            'serverInfo' => ['name' => 'PAM Native Language Server', 'version' => '2.0.0'],
         ]);
         continue;
     }
@@ -122,6 +134,45 @@ while (($message = readMessage(STDIN)) !== null) {
         $word = wordAt($source, (int) ($position['line'] ?? 0), (int) ($position['character'] ?? 0));
         $definition = componentDefinitions($workspaceRoot)[$word] ?? null;
         respond($id, $definition);
+        continue;
+    }
+    if ($method === 'textDocument/documentSymbol') {
+        $uri = (string) ($params['textDocument']['uri'] ?? '');
+        respond($id, documentSymbols($documents[$uri] ?? readUri($uri)));
+        continue;
+    }
+    if ($method === 'textDocument/signatureHelp') {
+        $uri = (string) ($params['textDocument']['uri'] ?? '');
+        $source = $documents[$uri] ?? readUri($uri);
+        $position = $params['position'] ?? [];
+        respond($id, signatureHelp($source, (int) ($position['line'] ?? 0), (int) ($position['character'] ?? 0)));
+        continue;
+    }
+    if ($method === 'textDocument/references') {
+        $uri = (string) ($params['textDocument']['uri'] ?? '');
+        $source = $documents[$uri] ?? readUri($uri);
+        $position = $params['position'] ?? [];
+        $word = wordAt($source, (int) ($position['line'] ?? 0), (int) ($position['character'] ?? 0));
+        respond($id, workspaceOccurrences($workspaceRoot, $word));
+        continue;
+    }
+    if ($method === 'textDocument/rename') {
+        $uri = (string) ($params['textDocument']['uri'] ?? '');
+        $source = $documents[$uri] ?? readUri($uri);
+        $position = $params['position'] ?? [];
+        $word = wordAt($source, (int) ($position['line'] ?? 0), (int) ($position['character'] ?? 0));
+        $newName = (string) ($params['newName'] ?? '');
+        respond($id, renameEdit($workspaceRoot, $word, $newName));
+        continue;
+    }
+    if ($method === 'textDocument/semanticTokens/full') {
+        $uri = (string) ($params['textDocument']['uri'] ?? '');
+        respond($id, ['data' => semanticTokens($documents[$uri] ?? readUri($uri))]);
+        continue;
+    }
+    if ($method === 'textDocument/codeAction') {
+        $uri = (string) ($params['textDocument']['uri'] ?? '');
+        respond($id, language2CodeActions($uri, $params));
         continue;
     }
     if ($id !== null) {
@@ -218,6 +269,8 @@ function completionItems(string $source, ?string $workspaceRoot): array
         'Screen', 'SafeAreaView', 'View', 'Column', 'Row', 'Text', 'Button',
         'Input', 'Image', 'ScrollView', 'VirtualizedList', 'VirtualGrid',
         'Modal', 'BottomSheet', 'GestureDetector', 'Slot', 'Fragment',
+        'Show', 'Match', 'Case', 'Default', 'Await', 'Pending', 'Content',
+        'Empty', 'Error', 'Offline', 'Stale', 'Animated',
     ];
     foreach ($tags as $tag) {
         $items[] = ['label' => $tag, 'kind' => 7, 'detail' => 'PAM Native component'];
@@ -225,7 +278,7 @@ function completionItems(string $source, ?string $workspaceRoot): array
     foreach (componentDefinitions($workspaceRoot) as $name => $_definition) {
         $items[] = ['label' => $name, 'kind' => 7, 'detail' => 'Project PAM component'];
     }
-    foreach (['p-if', 'p-else-if', 'p-else', 'p-for', 'p-key', 'p-index', 'bind:value', 'bind:checked'] as $directive) {
+    foreach (['p-if', 'p-else-if', 'p-else', 'p-for', 'p-key', 'p-index', 'bind:value', 'bind:checked', 'recipe', 'variant:'] as $directive) {
         $items[] = ['label' => $directive, 'kind' => 14, 'detail' => 'PAM template directive'];
     }
     preg_match_all('/public\s+(?:readonly\s+)?[\\?A-Za-z0-9_|]+\s+\$([A-Za-z_][A-Za-z0-9_]*)/', $source, $properties);
@@ -332,7 +385,130 @@ function pamHelp(string $word): ?string
         'bind:value' => '**bind:value** — Two-way native input binding to typed component state.',
         'bind:checked' => '**bind:checked** — Two-way native boolean binding.',
         '@press' => '**@press** — Calls a component action after a native press event.',
+        'Show' => '**Show** — Declarative conditional rendering with a typed `when` expression.',
+        'Match' => '**Match** — Strictly matches a value against `Case` branches.',
+        'Await' => '**Await** — Renders a branch for each typed `AsyncValue` state.',
+        'recipe' => '**recipe** — Applies a compiled design-system recipe and its typed variants.',
         'Fragment' => '**Fragment** — Groups component output without creating a native layout view.',
         default => null,
     };
+}
+
+/** @return list<array<string, mixed>> */
+function documentSymbols(string $source): array
+{
+    $symbols = [];
+    preg_match_all('/\b(class|function)\s+([A-Za-z_][A-Za-z0-9_]*)|\bpublic\s+(?:readonly\s+)?[?A-Za-z0-9_|\\\\]+\s+\$([A-Za-z_][A-Za-z0-9_]*)/', $source, $matches, PREG_OFFSET_CAPTURE);
+    foreach ($matches[0] ?? [] as $index => $whole) {
+        $name = ($matches[2][$index][0] ?? '') ?: ($matches[3][$index][0] ?? '');
+        if ($name === '') continue;
+        $offset = (int) $whole[1];
+        $before = substr($source, 0, $offset);
+        $line = substr_count($before, "\n");
+        $character = $offset - ((strrpos($before, "\n") ?: -1) + 1);
+        $kind = ($matches[1][$index][0] ?? '') === 'class' ? 5 : (($matches[1][$index][0] ?? '') === 'function' ? 6 : 7);
+        $range = ['start' => ['line' => $line, 'character' => $character], 'end' => ['line' => $line, 'character' => $character + strlen($whole[0])]];
+        $symbols[] = ['name' => $name, 'kind' => $kind, 'range' => $range, 'selectionRange' => $range];
+    }
+    return $symbols;
+}
+
+/** @return array<string, mixed>|null */
+function signatureHelp(string $source, int $line, int $character): ?array
+{
+    $lines = preg_split('/\R/', $source) ?: [];
+    $prefix = substr($lines[$line] ?? '', 0, $character);
+    if (preg_match('/([A-Za-z_][A-Za-z0-9_]*)\s*\([^()]*$/', $prefix, $match) !== 1) return null;
+    if (preg_match('/public\s+function\s+'.preg_quote($match[1], '/').'\s*\(([^)]*)\)/', $source, $signature) !== 1) return null;
+    return ['signatures' => [['label' => $match[1].'('.trim($signature[1]).')', 'parameters' => []]], 'activeSignature' => 0, 'activeParameter' => substr_count($match[0], ',')];
+}
+
+/** @return list<array<string, mixed>> */
+function workspaceOccurrences(?string $root, string $word): array
+{
+    if ($root === null || $word === '' || preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/D', $word) !== 1) return [];
+    $locations = [];
+    foreach (pamFiles($root) as $path) {
+        $source = @file_get_contents($path);
+        if (!is_string($source)) continue;
+        preg_match_all('/\b'.preg_quote($word, '/').'\b/', $source, $matches, PREG_OFFSET_CAPTURE);
+        foreach ($matches[0] as $match) {
+            $before = substr($source, 0, $match[1]);
+            $line = substr_count($before, "\n");
+            $character = $match[1] - ((strrpos($before, "\n") ?: -1) + 1);
+            $locations[] = ['uri' => pathUri($path), 'range' => ['start' => ['line' => $line, 'character' => $character], 'end' => ['line' => $line, 'character' => $character + strlen($word)]]];
+        }
+    }
+    return $locations;
+}
+
+/** @return array<string, mixed> */
+function renameEdit(?string $root, string $word, string $newName): array
+{
+    if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/D', $newName) !== 1) return ['changes' => []];
+    $changes = [];
+    foreach (workspaceOccurrences($root, $word) as $location) {
+        $changes[$location['uri']][] = ['range' => $location['range'], 'newText' => $newName];
+    }
+    return ['changes' => $changes];
+}
+
+/** @return list<int> */
+function semanticTokens(string $source): array
+{
+    $tokens = [];
+    preg_match_all('/<([A-Z][A-Za-z0-9_.-]*)|\bpublic\s+(?:readonly\s+)?[?A-Za-z0-9_|\\\\]+\s+\$([A-Za-z_][A-Za-z0-9_]*)|\bfunction\s+([A-Za-z_][A-Za-z0-9_]*)/', $source, $matches, PREG_OFFSET_CAPTURE);
+    $entries = [];
+    foreach ($matches[0] as $index => $whole) {
+        $name = ($matches[1][$index][0] ?? '') ?: (($matches[2][$index][0] ?? '') ?: ($matches[3][$index][0] ?? ''));
+        if ($name === '') continue;
+        $offset = strpos($source, $name, (int) $whole[1]);
+        if ($offset === false) continue;
+        $before = substr($source, 0, $offset);
+        $entries[] = [substr_count($before, "\n"), $offset - ((strrpos($before, "\n") ?: -1) + 1), strlen($name), ($matches[1][$index][0] ?? '') !== '' ? 0 : (($matches[2][$index][0] ?? '') !== '' ? 1 : 2), 0];
+    }
+    usort($entries, static fn(array $a, array $b): int => [$a[0], $a[1]] <=> [$b[0], $b[1]]);
+    $previousLine = 0; $previousCharacter = 0;
+    foreach ($entries as $entry) {
+        $deltaLine = $entry[0] - $previousLine;
+        $deltaCharacter = $deltaLine === 0 ? $entry[1] - $previousCharacter : $entry[1];
+        array_push($tokens, $deltaLine, $deltaCharacter, $entry[2], $entry[3], $entry[4]);
+        $previousLine = $entry[0]; $previousCharacter = $entry[1];
+    }
+    return $tokens;
+}
+
+/** @param array<string, mixed> $params @return list<array<string, mixed>> */
+function language2CodeActions(string $uri, array $params): array
+{
+    $actions = [];
+    foreach (($params['context']['diagnostics'] ?? []) as $diagnostic) {
+        if (!is_array($diagnostic) || !str_contains((string) ($diagnostic['message'] ?? ''), 'PAM2301')) continue;
+        $actions[] = ['title' => 'Mark image as decorative', 'kind' => 'quickfix', 'edit' => ['changes' => [$uri => [['range' => $diagnostic['range'], 'newText' => ' decorative="true"']]]]];
+    }
+    return $actions;
+}
+
+/** @return list<string> */
+function pamFiles(string $root): array
+{
+    $paths = [];
+    $iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS), static fn(SplFileInfo $file): bool => !$file->isDir() || !in_array($file->getFilename(), ['vendor', 'node_modules', '.git', '.pam-native'], true)));
+    foreach ($iterator as $file) {
+        if (
+            !$file->isLink()
+            && $file->isFile()
+            && $file->getSize() <= 2_097_152
+            && (str_ends_with($file->getFilename(), '.pam') || str_ends_with($file->getFilename(), '.pam.php'))
+        ) {
+            $paths[] = $file->getPathname();
+        }
+        if (count($paths) >= 20_000) break;
+    }
+    return $paths;
+}
+
+function pathUri(string $path): string
+{
+    return 'file://'.str_replace('%2F', '/', rawurlencode($path));
 }

--- a/packages/native/phpstan-singularity.neon
+++ b/packages/native/phpstan-singularity.neon
@@ -14,6 +14,15 @@ parameters:
         - src/Scheduling/DeadlineExceededException.php
         - src/Scheduling/Deferred.php
         - src/Scheduling/TaskGroup.php
+        - src/Attributes/Action.php
+        - src/Attributes/Event.php
+        - src/Attributes/Slot.php
+        - src/Attributes/Tag.php
+        - src/Internal/Language2StyleCompiler.php
+        - src/Internal/TemplateContractValidator.php
+        - src/LanguageVersion.php
+        - src/UI/Contract
+        - src/UI/Ir
     tmpDir: ../../../.pam-native/phpstan-singularity
     treatPhpDocTypesAsCertain: true
     reportUnmatchedIgnoredErrors: true
@@ -23,3 +32,10 @@ parameters:
         - src/Scheduling/CancellationToken.php
         - src/Scheduling/Scheduler.php
         - src/Scheduling/TaskPriority.php
+        - src/Attributes/Expose.php
+        - src/Attributes/Prop.php
+        - src/Component.php
+        - src/Internal/CompiledTemplateNode.php
+        - src/Internal/ScopedStyleCompiler.php
+        - src/Renderable.php
+        - src/TemplateRegistry.php

--- a/packages/native/resources/pam-native-ui-ir.schema.json
+++ b/packages/native/resources/pam-native-ui-ir.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://push-in.github.io/pam-docs/schemas/native-ui-ir-v2.json",
+  "title": "PAM Native UI IR",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "language", "capabilities"],
+  "properties": {
+    "version": {"const": 2},
+    "language": {"type": "integer", "enum": [1, 2]},
+    "capabilities": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"type": "integer", "minimum": 1, "maximum": 12}
+    }
+  }
+}

--- a/packages/native/resources/pam-native.custom-data.json
+++ b/packages/native/resources/pam-native.custom-data.json
@@ -1,11 +1,22 @@
 {
-    "version": 1.1,
+    "version": 2,
     "tags": [
         { "name": "Screen", "description": "Top-level native screen." },
         { "name": "SafeAreaView", "description": "Container inset from Android system bars." },
         { "name": "Column", "description": "Vertical flex container." },
         { "name": "Row", "description": "Horizontal flex container." },
         { "name": "View", "description": "Generic native container." },
+        { "name": "Show", "description": "Language 2 conditional flow with a typed when expression.", "attributes": [{ "name": "when" }] },
+        { "name": "Match", "description": "Language 2 strict value matching.", "attributes": [{ "name": "value" }] },
+        { "name": "Case", "description": "A strict Match branch.", "attributes": [{ "name": "value" }] },
+        { "name": "Default", "description": "Fallback branch for Match or Await." },
+        { "name": "Await", "description": "Typed AsyncResource or AsyncValue branching.", "attributes": [{ "name": "value" }] },
+        { "name": "Pending", "description": "Await loading branch." },
+        { "name": "Content", "description": "Await content branch; exposes $data." },
+        { "name": "Empty", "description": "Await empty branch." },
+        { "name": "Error", "description": "Await error branch; exposes $message and $retryable." },
+        { "name": "Offline", "description": "Await offline branch." },
+        { "name": "Stale", "description": "Await stale-content branch." },
         { "name": "Text", "description": "Native Android text." },
         { "name": "Button", "description": "Accessible native Android button." },
         {

--- a/packages/native/src/Attributes/Action.php
+++ b/packages/native/src/Attributes/Action.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Attributes;
+
+use Attribute;
+
+/** Marks a public component method as callable by template events. */
+#[Attribute(Attribute::TARGET_METHOD)]
+final readonly class Action
+{
+}

--- a/packages/native/src/Attributes/Event.php
+++ b/packages/native/src/Attributes/Event.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Attributes;
+
+use Attribute;
+
+/** Declares a typed event emitted by a component. */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final readonly class Event
+{
+    /** @param class-string $payload */
+    public function __construct(
+        public string $name,
+        public string $payload,
+    ) {
+    }
+}

--- a/packages/native/src/Attributes/Slot.php
+++ b/packages/native/src/Attributes/Slot.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Attributes;
+
+use Attribute;
+
+/** Declares a named, cardinality-checked component slot. */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final readonly class Slot
+{
+    public function __construct(
+        public string $name = 'slot',
+        public int $minimum = 0,
+        public ?int $maximum = null,
+    ) {
+    }
+}

--- a/packages/native/src/Attributes/Tag.php
+++ b/packages/native/src/Attributes/Tag.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Attributes;
+
+use Attribute;
+
+/** Gives a Composer component a stable template tag. */
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Tag
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/packages/native/src/Internal/Language2StyleCompiler.php
+++ b/packages/native/src/Internal/Language2StyleCompiler.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Internal;
+
+use RuntimeException;
+
+/** Extracts Language 2 constructs into a deterministic, runtime-free style IR. */
+final class Language2StyleCompiler
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @return array{
+     *   source: string,
+     *   tokens: array<string, string>,
+     *   states: array<string, array<string, array<string, string|int|bool>>>,
+     *   recipes: array<string, array{base: array<string, string|int|bool>, variants: array<string, array<string, array<string, string|int|bool>>>}>,
+     *   queries: list<array<string, mixed>>,
+     *   keyframes: array<string, list<array{offset: float, styles: array<string, string|int|bool>}>>
+     * }
+     */
+    public static function extract(string $source, string $name): array
+    {
+        $tokens = [];
+        $states = [];
+        $recipes = [];
+        $queries = [];
+        $keyframes = [];
+        $legacy = [];
+
+        foreach (self::blocks($source, $name) as [$header, $body]) {
+            if ($header === '@tokens') {
+                foreach (self::rawDeclarations($body, $name) as $token => $value) {
+                    $safe = ltrim($token, '-');
+                    if (preg_match('/^[a-z][a-z0-9.-]*$/D', $safe) !== 1) {
+                        throw new RuntimeException("Invalid design token {$token} in {$name}.");
+                    }
+                    $tokens['--'.str_replace('.', '-', $safe)] = trim($value);
+                }
+                continue;
+            }
+
+            if (preg_match('/^(.+):(pressed|focused|disabled|selected|checked|hovered)$/D', $header, $match) === 1) {
+                $selector = trim($match[1]);
+                self::assertSelector($selector, $name);
+                $states[$selector][$match[2]] = ScopedStyleCompiler::compileDeclarations(
+                    $body,
+                    $tokens,
+                    $name,
+                );
+                continue;
+            }
+
+            if (preg_match('/^@recipe\s+([A-Za-z][A-Za-z0-9_.-]*)$/D', $header, $match) === 1) {
+                $recipes[$match[1]] = self::recipe($body, $tokens, $name);
+                continue;
+            }
+
+            if (preg_match('/^@(media|container)\s+(.+)$/D', $header, $match) === 1) {
+                self::assertQuery($match[1], trim($match[2]), $name);
+                $queries[] = [
+                    'kind' => $match[1] === 'media' ? 1 : 2,
+                    'condition' => trim($match[2]),
+                    'styles' => ScopedStyleCompiler::compile($body, $name.' '.$header),
+                ];
+                continue;
+            }
+
+            if (preg_match('/^@keyframes\s+([A-Za-z][A-Za-z0-9_-]*)$/D', $header, $match) === 1) {
+                $keyframes[$match[1]] = self::keyframes($body, $tokens, $name);
+                continue;
+            }
+
+            $legacy[] = $header.' {'.$body.'}';
+        }
+
+        if ($tokens !== []) {
+            $declarations = [];
+            foreach ($tokens as $token => $value) {
+                $declarations[] = $token.': '.$value.';';
+            }
+            array_unshift($legacy, ':root {'.implode(' ', $declarations).'}');
+        }
+
+        return [
+            'source' => implode("\n", $legacy),
+            'tokens' => $tokens,
+            'states' => $states,
+            'recipes' => $recipes,
+            'queries' => $queries,
+            'keyframes' => $keyframes,
+        ];
+    }
+
+    /** @return list<array{string, string}> */
+    private static function blocks(string $source, string $name): array
+    {
+        $clean = preg_replace('/\/\*[\s\S]*?\*\//', '', $source);
+        if (!is_string($clean)) {
+            throw new RuntimeException("Cannot parse styles in {$name}.");
+        }
+        $blocks = [];
+        $length = strlen($clean);
+        $cursor = 0;
+        while ($cursor < $length) {
+            while ($cursor < $length && ctype_space($clean[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor >= $length) {
+                break;
+            }
+            $open = strpos($clean, '{', $cursor);
+            if ($open === false) {
+                throw new RuntimeException("Invalid CSS block in {$name}.");
+            }
+            $header = trim(substr($clean, $cursor, $open - $cursor));
+            if ($header === '') {
+                throw new RuntimeException("Empty CSS selector in {$name}.");
+            }
+            $depth = 1;
+            $quote = null;
+            $index = $open + 1;
+            for (; $index < $length && $depth > 0; $index++) {
+                $character = $clean[$index];
+                if ($quote !== null) {
+                    if ($character === $quote && $clean[$index - 1] !== '\\') {
+                        $quote = null;
+                    }
+                    continue;
+                }
+                if ($character === '"' || $character === "'") {
+                    $quote = $character;
+                } elseif ($character === '{') {
+                    $depth++;
+                } elseif ($character === '}') {
+                    $depth--;
+                }
+            }
+            if ($depth !== 0) {
+                throw new RuntimeException("Unclosed CSS block {$header} in {$name}.");
+            }
+            $blocks[] = [$header, substr($clean, $open + 1, $index - $open - 2)];
+            $cursor = $index;
+        }
+
+        return $blocks;
+    }
+
+    /** @return array<string, string> */
+    private static function rawDeclarations(string $body, string $name): array
+    {
+        $output = [];
+        foreach (explode(';', $body) as $declaration) {
+            if (trim($declaration) === '') {
+                continue;
+            }
+            $parts = explode(':', $declaration, 2);
+            if (count($parts) !== 2 || trim($parts[0]) === '' || trim($parts[1]) === '') {
+                throw new RuntimeException("Invalid declaration in {$name}.");
+            }
+            $output[trim($parts[0])] = trim($parts[1]);
+        }
+        return $output;
+    }
+
+    /**
+     * @param array<string, string> $tokens
+     * @return array{
+     *   base: array<string, string|int|bool>,
+     *   variants: array<string, array<string, array<string, string|int|bool>>>
+     * }
+     */
+    private static function recipe(string $body, array $tokens, string $name): array
+    {
+        $recipe = ['base' => [], 'variants' => []];
+        foreach (self::blocks($body, $name.' recipe') as [$header, $declarations]) {
+            if ($header === 'base') {
+                $recipe['base'] = ScopedStyleCompiler::compileDeclarations($declarations, $tokens, $name);
+                continue;
+            }
+            if (preg_match('/^variant\s+([A-Za-z][A-Za-z0-9_-]*)=([A-Za-z0-9_.-]+)$/D', $header, $match) !== 1) {
+                throw new RuntimeException("Invalid recipe branch {$header} in {$name}.");
+            }
+            $recipe['variants'][$match[1]][$match[2]] =
+                ScopedStyleCompiler::compileDeclarations($declarations, $tokens, $name);
+        }
+        return $recipe;
+    }
+
+    /**
+     * @param array<string, string> $tokens
+     * @return list<array{offset: float, styles: array<string, string|int|bool>}>
+     */
+    private static function keyframes(string $body, array $tokens, string $name): array
+    {
+        /** @var list<array{offset: float, styles: array<string, string|int|bool>}> $frames */
+        $frames = [];
+        foreach (self::blocks($body, $name.' keyframes') as [$header, $declarations]) {
+            $offset = match ($header) {
+                'from' => 0.0,
+                'to' => 1.0,
+                default => str_ends_with($header, '%') ? (float) substr($header, 0, -1) / 100 : -1,
+            };
+            if ($offset < 0 || $offset > 1) {
+                throw new RuntimeException("Invalid keyframe offset {$header} in {$name}.");
+            }
+            $styles = ScopedStyleCompiler::compileDeclarations($declarations, $tokens, $name);
+            $unsupported = array_diff(array_keys($styles), [
+                'opacity', 'translationX', 'translationY', 'scaleX', 'scaleY', 'rotation',
+            ]);
+            if ($unsupported !== []) {
+                throw new RuntimeException(
+                    "Keyframes in {$name} may animate only compositor properties.",
+                );
+            }
+            $frames[] = ['offset' => $offset, 'styles' => $styles];
+        }
+        usort(
+            $frames,
+            static fn (array $left, array $right): int =>
+                $left['offset'] <=> $right['offset'],
+        );
+        return $frames;
+    }
+
+    private static function assertSelector(string $selector, string $name): void
+    {
+        if (
+            preg_match('/^(?:\.[A-Za-z_][A-Za-z0-9_-]*|[A-Za-z][A-Za-z0-9_.-]*)$/D', $selector) !== 1
+        ) {
+            throw new RuntimeException("Unsupported state selector {$selector} in {$name}.");
+        }
+    }
+
+    private static function assertQuery(string $kind, string $condition, string $name): void
+    {
+        $media = '/^\((?:min|max)-(?:width|height):\s*[0-9]+(?:\.[0-9]+)?(?:dp|px)\)$/D';
+        $container = '/^(?:[A-Za-z][A-Za-z0-9_-]*\s+)?\((?:min|max)-(?:width|height):\s*[0-9]+(?:\.[0-9]+)?(?:dp|px)\)$/D';
+        if (preg_match($kind === 'media' ? $media : $container, $condition) !== 1) {
+            throw new RuntimeException("Unsupported @{$kind} condition {$condition} in {$name}.");
+        }
+    }
+}

--- a/packages/native/src/Internal/PamPhpCompiler.php
+++ b/packages/native/src/Internal/PamPhpCompiler.php
@@ -11,6 +11,8 @@ use RecursiveIteratorIterator;
 use RuntimeException;
 use SplFileInfo;
 use Pam\Native\BuildConfiguration;
+use Pam\Native\LanguageVersion;
+use Pam\Native\UI\Ir\UiIr;
 
 final class PamPhpCompiler
 {
@@ -110,7 +112,7 @@ final class PamPhpCompiler
             );
         }
 
-        [$php, $template, $templateLine, $style] = self::split($contents, $source);
+        [$php, $template, $templateLine, $style, $language] = self::split($contents, $source);
         $style = self::resolvedStyleSheet($style, $source);
         self::validateHotPath($php, $source);
         [$className, $tag] = self::classIdentity($php, $source);
@@ -134,6 +136,7 @@ final class PamPhpCompiler
             $tree = TemplateCompiler::compile(
                 str_repeat("\n", max(0, $templateLine - 1)).$template,
                 $source,
+                $language,
             );
             if ($style !== '') {
                 $tree = self::withStyleSheet(
@@ -148,7 +151,9 @@ final class PamPhpCompiler
                     JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES,
                 );
                 $encodedMetadata = json_encode([
-                    'version' => 3,
+                    'version' => 4,
+                    'language' => $language->value,
+                    'uiIr' => UiIr::manifest($language),
                     'hash' => $hash,
                     'class' => $className,
                     'tag' => $tag,
@@ -170,6 +175,7 @@ final class PamPhpCompiler
             source: $source,
             classFile: $classFile,
             template: $tree,
+            language: $language,
         );
     }
 
@@ -243,7 +249,7 @@ final class PamPhpCompiler
         }
     }
 
-    /** @return array{string, string, int, string} */
+    /** @return array{string, string, int, string, LanguageVersion} */
     private static function split(string $source, string $name): array
     {
         $tokens = token_get_all($source);
@@ -276,7 +282,7 @@ final class PamPhpCompiler
         $match = [];
 
         if (preg_match(
-            '/\A\s*<template(?:\s[^>]*)?>([\s\S]*?)<\/template>'
+            '/\A\s*<template(?:\s+([^>]*))?>([\s\S]*?)<\/template>'
             .'\s*(?:<style(?:\s+scoped)?\s*>([\s\S]*?)<\/style>)?\s*\z/D',
             $markup,
             $match,
@@ -286,15 +292,27 @@ final class PamPhpCompiler
                 "PAM component {$name} must contain exactly one root <template> block.",
             );
         }
-        $capture = $match[1];
-        $style = is_array($match[2] ?? null)
-            ? (string) ($match[2][0] ?? '')
+        $templateAttributes = is_array($match[1] ?? null)
+            ? (string) ($match[1][0] ?? '')
             : '';
+        $capture = $match[2];
+        $style = is_array($match[3] ?? null)
+            ? (string) ($match[3][0] ?? '')
+            : '';
+
+        $language = LanguageVersion::Language1;
+        if (preg_match('/(?:language|version)\s*=\s*(["\'])2\1/D', trim($templateAttributes)) === 1) {
+            $language = LanguageVersion::Language2;
+        } elseif (trim($templateAttributes) !== '') {
+            throw new RuntimeException(
+                "PAM component {$name} has unsupported template attributes; use language=\"2\".",
+            );
+        }
 
         $templateOffset = $closeOffset + $closeLength + $capture[1];
         $templateLine = substr_count(substr($source, 0, $templateOffset), "\n") + 1;
 
-        return [$php, $capture[0], $templateLine, $style];
+        return [$php, $capture[0], $templateLine, $style, $language];
     }
 
     /**
@@ -400,9 +418,18 @@ final class PamPhpCompiler
             );
         }
 
+        $tag = $class;
+        if (preg_match(
+            '/#\[\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*\\\\)*)Tag\s*\(\s*(?:name\s*:\s*)?(["\'])([A-Za-z][A-Za-z0-9_.-]{0,127})\1\s*\)\s*\]/D',
+            $php,
+            $tagMatch,
+        ) === 1) {
+            $tag = $tagMatch[2];
+        }
+
         return [
             $namespace === '' ? $class : $namespace.'\\'.$class,
-            $class,
+            $tag,
         ];
     }
 
@@ -461,7 +488,7 @@ final class PamPhpCompiler
 
         if (
             !is_array($metadata)
-            || ($metadata['version'] ?? null) !== 3
+            || ($metadata['version'] ?? null) !== 4
             || ($metadata['hash'] ?? null) !== $hash
             || ($metadata['class'] ?? null) !== $className
         ) {

--- a/packages/native/src/Internal/PamPhpComponent.php
+++ b/packages/native/src/Internal/PamPhpComponent.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pam\Native\Internal;
 
+use Pam\Native\LanguageVersion;
+
 final readonly class PamPhpComponent
 {
     public function __construct(
@@ -12,6 +14,7 @@ final readonly class PamPhpComponent
         public string $source,
         public string $classFile,
         public CompiledTemplateNode $template,
+        public LanguageVersion $language = LanguageVersion::Language1,
     ) {
     }
 }

--- a/packages/native/src/Internal/PamPhpRegistry.php
+++ b/packages/native/src/Internal/PamPhpRegistry.php
@@ -11,6 +11,7 @@ use Pam\Native\Attributes\Prop;
 use Pam\Native\Component;
 use Pam\Native\Renderable;
 use Pam\Native\TemplateRegistry;
+use Pam\Native\UI\Contract\ComponentContractFactory;
 use ReflectionClass;
 use RuntimeException;
 use WeakMap;
@@ -84,6 +85,27 @@ final class PamPhpRegistry
         }
 
         self::registerAutoload();
+
+        foreach ($components as $component) {
+            if ($component->language !== \Pam\Native\LanguageVersion::Language2) {
+                continue;
+            }
+            /** @var class-string<Component> $className */
+            $className = $component->className;
+            self::autoload($className);
+            TemplateRegistry::contract(
+                ComponentContractFactory::fromClass($className, $component->tag),
+            );
+        }
+
+        foreach ($components as $component) {
+            if ($component->language !== \Pam\Native\LanguageVersion::Language2) {
+                continue;
+            }
+            /** @var class-string<Component> $className */
+            $className = $component->className;
+            TemplateContractValidator::validate($className, $component->template);
+        }
     }
 
     public static function beginRender(): void

--- a/packages/native/src/Internal/Runtime.php
+++ b/packages/native/src/Internal/Runtime.php
@@ -50,6 +50,7 @@ final class Runtime
     private static ?TreeEncoder $encoder = null;
     private static bool $rendering = false;
     private static bool $renderRequested = false;
+    private static WindowMetrics $windowMetrics;
 
     private function __construct()
     {
@@ -69,6 +70,11 @@ final class Runtime
         } catch (Throwable $error) {
             self::reportError($error);
         }
+    }
+
+    public static function windowMetrics(): WindowMetrics
+    {
+        return self::$windowMetrics ??= new WindowMetrics(0.0, 0.0, 1.0);
     }
 
     public static function render(): void
@@ -184,14 +190,15 @@ final class Runtime
             }
             if ($eventKind === EventKind::Dimensions->value) {
                 $values = Wire::decodeMap($payload);
-                self::$dimensionsHandler?->__invoke(new WindowMetrics(
+                self::$windowMetrics = new WindowMetrics(
                     width: (float) ($values['width'] ?? 0.0),
                     height: (float) ($values['height'] ?? 0.0),
                     density: (float) ($values['density'] ?? 1.0),
                     appearance: UserInterfaceAppearance::tryFrom(
                         (int) ($values['appearance'] ?? UserInterfaceAppearance::Light->value),
                     ) ?? UserInterfaceAppearance::Light,
-                ));
+                );
+                self::$dimensionsHandler?->__invoke(self::$windowMetrics);
                 self::render();
 
                 return;
@@ -338,6 +345,7 @@ final class Runtime
         self::$encoder = null;
         self::$rendering = false;
         self::$renderRequested = false;
+        self::$windowMetrics = new WindowMetrics(0.0, 0.0, 1.0);
         ComponentLifecycle::shutdown();
         PamPhpRegistry::releaseInstances();
         Stores::resetRuntime();

--- a/packages/native/src/Internal/ScopedStyleCompiler.php
+++ b/packages/native/src/Internal/ScopedStyleCompiler.php
@@ -97,6 +97,8 @@ final class ScopedStyleCompiler
     public static function compile(string $source, string $name): array
     {
         $source = self::resolveImports($source, $name);
+        $language2 = Language2StyleCompiler::extract($source, $name);
+        $source = $language2['source'];
         $clean = preg_replace('/\/\*[\s\S]*?\*\//', '', $source);
         if (!is_string($clean)) {
             throw new RuntimeException("Cannot parse styles in {$name}.");
@@ -192,7 +194,24 @@ final class ScopedStyleCompiler
             'tags' => $tags,
             'classCascade' => $classCascade,
             'fonts' => $fonts,
+            'tokens' => $language2['tokens'],
+            'states' => $language2['states'],
+            'recipes' => $language2['recipes'],
+            'queries' => $language2['queries'],
+            'keyframes' => $language2['keyframes'],
         ];
+    }
+
+    /**
+     * @param array<string, string> $variables
+     * @return array<string, string|int|bool>
+     */
+    public static function compileDeclarations(
+        string $source,
+        array $variables,
+        string $name,
+    ): array {
+        return self::declarations($source, $variables, $name);
     }
 
     public static function resolveImports(string $source, string $name): string

--- a/packages/native/src/Internal/TemplateCompiler.php
+++ b/packages/native/src/Internal/TemplateCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pam\Native\Internal;
 
+use Pam\Native\LanguageVersion;
 use RuntimeException;
 
 final class TemplateCompiler
@@ -63,6 +64,7 @@ final class TemplateCompiler
     public static function compile(
         string $source,
         string $name = '<memory>',
+        LanguageVersion $language = LanguageVersion::Language1,
     ): CompiledTemplateNode
     {
         if (strlen($source) > self::MAX_TEMPLATE_BYTES) {
@@ -152,12 +154,15 @@ final class TemplateCompiler
             );
         }
 
-        self::validateContracts($root);
+        self::validateContracts($root, $language);
 
         return $root;
     }
 
-    private static function validateContracts(CompiledTemplateNode $node): void
+    private static function validateContracts(
+        CompiledTemplateNode $node,
+        LanguageVersion $language,
+    ): void
     {
         $forAttribute = self::directiveAttribute($node, 'p-for', 'v-for');
         if ($forAttribute !== null) {
@@ -184,9 +189,91 @@ final class TemplateCompiler
             }
         }
 
-        foreach ($node->children as $child) {
-            self::validateContracts($child);
+        if ($language === LanguageVersion::Language2) {
+            self::validateLanguage2($node);
         }
+
+        foreach ($node->children as $child) {
+            self::validateContracts($child, $language);
+        }
+    }
+
+    private static function validateLanguage2(CompiledTemplateNode $node): void
+    {
+        if (
+            in_array($node->name, ['VirtualizedList', 'VirtualGrid'], true)
+            && self::containsLoop($node)
+            && !self::loopHasStableKey($node)
+        ) {
+            throw new RuntimeException(
+                "PAM2201 virtualized loops require p-key at {$node->source}:{$node->line}:{$node->column}.",
+            );
+        }
+
+        if ($node->name === 'Image') {
+            $decorative = ($node->attributes['decorative'] ?? false) === true
+                || ($node->attributes['decorative'] ?? '') === 'true';
+            if (!$decorative && !isset($node->attributes['accessibilityLabel'])) {
+                throw new RuntimeException(
+                    "PAM2301 Image requires accessibilityLabel or decorative=\"true\" at {$node->source}:{$node->line}:{$node->column}.",
+                );
+            }
+        }
+
+        if ($node->name === 'Match') {
+            $defaults = 0;
+            foreach ($node->children as $child) {
+                if ($child->kind !== 1 || !in_array($child->name, ['Case', 'Default'], true)) {
+                    throw new RuntimeException('PAM2202 Match accepts only Case and Default children.');
+                }
+                $defaults += $child->name === 'Default' ? 1 : 0;
+            }
+            if ($defaults > 1) {
+                throw new RuntimeException('PAM2203 Match accepts at most one Default child.');
+            }
+        }
+
+        if ($node->name === 'Await') {
+            $allowed = ['Pending', 'Content', 'Empty', 'Error', 'Offline', 'Stale', 'Default'];
+            $seen = [];
+            foreach ($node->children as $child) {
+                if ($child->kind !== 1 || !in_array($child->name, $allowed, true)) {
+                    throw new RuntimeException('PAM2204 Await contains an unsupported state branch.');
+                }
+                if (isset($seen[$child->name])) {
+                    throw new RuntimeException("PAM2205 Await state {$child->name} is declared twice.");
+                }
+                $seen[$child->name] = true;
+            }
+        }
+    }
+
+    private static function containsLoop(CompiledTemplateNode $node): bool
+    {
+        foreach ($node->children as $child) {
+            if (self::hasDirective($child, 'p-for', 'v-for') || self::containsLoop($child)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function loopHasStableKey(CompiledTemplateNode $node): bool
+    {
+        foreach ($node->children as $child) {
+            if (
+                self::hasDirective($child, 'p-for', 'v-for')
+                && isset($child->attributes['p-key'])
+            ) {
+                return true;
+            }
+            if (self::loopHasStableKey($child)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/packages/native/src/Internal/TemplateContractValidator.php
+++ b/packages/native/src/Internal/TemplateContractValidator.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Internal;
+
+use Pam\Native\Attributes\Action;
+use Pam\Native\Attributes\Expose;
+use Pam\Native\Component;
+use Pam\Native\TemplateRegistry;
+use ReflectionClass;
+use RuntimeException;
+
+final class TemplateContractValidator
+{
+    private function __construct()
+    {
+    }
+
+    /** @param class-string<Component> $component */
+    public static function validate(string $component, CompiledTemplateNode $tree): void
+    {
+        self::node(new ReflectionClass($component), $tree);
+    }
+
+    /** @param ReflectionClass<Component> $component */
+    private static function node(ReflectionClass $component, CompiledTemplateNode $node): void
+    {
+        foreach ($node->attributes as $name => $value) {
+            if (
+                !str_starts_with($name, '@')
+                && !str_starts_with($name, 'on:')
+            ) {
+                continue;
+            }
+            if (!is_string($value) || preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/D', $value) !== 1) {
+                continue;
+            }
+            if (!$component->hasMethod($value)) {
+                throw self::error($node, "action {$value} does not exist on {$component->getName()}");
+            }
+            $method = $component->getMethod($value);
+            if (
+                !$method->isPublic()
+                || ($method->getAttributes(Action::class) === []
+                    && $method->getAttributes(Expose::class) === [])
+            ) {
+                throw self::error(
+                    $node,
+                    "action {$value} must be public and declare #[Action] (#[Expose] remains compatible)",
+                );
+            }
+        }
+
+        $contract = TemplateRegistry::tagContract($node->name);
+        if ($contract !== null) {
+            $knownProps = [];
+            foreach ($contract->props as $prop) {
+                $knownProps[$prop->name] = true;
+                if ($prop->required && !isset($node->attributes[$prop->name]) && !isset($node->attributes[':'.$prop->name])) {
+                    throw self::error($node, "required prop {$node->name}.{$prop->name} is missing");
+                }
+            }
+            $knownEvents = [];
+            foreach ($contract->events as $event) {
+                $knownEvents[$event->name] = true;
+            }
+            foreach (array_keys($node->attributes) as $attribute) {
+                if (str_starts_with($attribute, '@')) {
+                    $event = substr($attribute, 1);
+                    if (!isset($knownEvents[$event])) {
+                        throw self::error($node, "unknown event {$node->name}.{$event}");
+                    }
+                    continue;
+                }
+                $prop = ltrim($attribute, ':');
+                if (
+                    isset($knownProps[$prop])
+                    || in_array($prop, ['class', 'key', 'recipe'], true)
+                    || str_starts_with($prop, 'p-')
+                    || str_starts_with($prop, 'variant:')
+                ) {
+                    continue;
+                }
+                throw self::error($node, "unknown prop {$node->name}.{$prop}");
+            }
+        }
+
+        foreach ($node->children as $child) {
+            self::node($component, $child);
+        }
+    }
+
+    private static function error(CompiledTemplateNode $node, string $message): RuntimeException
+    {
+        return new RuntimeException(
+            "PAM2401 {$message} at {$node->source}:{$node->line}:{$node->column}.",
+        );
+    }
+}

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -19,6 +19,9 @@ use Pam\Native\AnimationEasing;
 use Pam\Native\AnimationFillMode;
 use Pam\Native\AnimationKeyframe;
 use Pam\Native\AnimationPlayState;
+use Pam\Native\AsyncResource;
+use Pam\Native\AsyncStatus;
+use Pam\Native\AsyncValue;
 use Pam\Native\BottomSheetKeyboardBehavior;
 use Pam\Native\Component;
 use Pam\Native\DrawingMode;
@@ -66,6 +69,7 @@ use Pam\Native\UI\Animated;
 use Pam\Native\UI\Button;
 use Pam\Native\UI\BottomSheet;
 use Pam\Native\UI\Column;
+use Pam\Native\UI\Contract\ContractValidator;
 use Pam\Native\UI\CustomView;
 use Pam\Native\UI\DrawerLayoutAndroid;
 use Pam\Native\UI\DrawingCanvas;
@@ -585,18 +589,40 @@ final class TemplateRenderer
                         'p-for source must resolve to an integer, array, or Traversable.',
                     );
                 }
-                $loopNode = self::withoutAttributes($node, ['p-for']);
+                $keyExpression = $attributes['p-key'] ?? null;
+                $indexName = $attributes['p-index'] ?? $match[1].'Index';
+                if (!is_string($indexName) || preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/D', ltrim($indexName, '$')) !== 1) {
+                    throw new RuntimeException('p-index must be a safe variable name.');
+                }
+                $indexName = ltrim($indexName, '$');
+                $loopNode = self::withoutAttributes($node, ['p-for', 'p-key', 'p-index']);
+                $seenKeys = [];
                 foreach ($items as $itemIndex => $item) {
+                    $iterationData = [
+                        ...$nodeData,
+                        $match[1] => $item,
+                        $indexName => $itemIndex,
+                    ];
+                    $identity = $itemIndex;
+                    if ($keyExpression !== null) {
+                        $identity = self::dynamicValue($keyExpression, $scope, $iterationData);
+                        if (!is_string($identity) && !is_int($identity)) {
+                            throw new RuntimeException('p-key must resolve to a string or integer.');
+                        }
+                        $fingerprint = get_debug_type($identity).':'.(string) $identity;
+                        if (isset($seenKeys[$fingerprint])) {
+                            throw new RuntimeException("Duplicate p-key {$identity} in loop.");
+                        }
+                        $seenKeys[$fingerprint] = true;
+                    }
                     array_push(
                         $output,
                         ...self::nodes([$loopNode], $scope, [
-                            ...$nodeData,
-                            $match[1] => $item,
-                            $match[1].'Index' => $itemIndex,
+                            ...$iterationData,
                             '__pamNodePath' =>
                                 self::pathValue(
                                     $nodeData['__pamNodePath'] ?? 'root',
-                                ).'.'.(string) $itemIndex,
+                                ).'.'.(string) $identity,
                         ]),
                     );
                 }
@@ -653,6 +679,83 @@ final class TemplateRenderer
                     array_push($output, ...self::nodes($children, $scope, $nodeData));
                 }
 
+                continue;
+            }
+
+            if ($tag === 'Show') {
+                $condition = self::value(
+                    $attributes['when'] ?? $attributes['condition'] ?? false,
+                    $scope,
+                    $nodeData,
+                );
+                if ((bool) $condition) {
+                    array_push($output, ...self::nodes($children, $scope, $nodeData));
+                }
+                continue;
+            }
+
+            if ($tag === 'Match') {
+                $subject = self::value($attributes['value'] ?? null, $scope, $nodeData);
+                $fallback = null;
+                foreach ($children as $candidate) {
+                    if ($candidate->kind !== 1) {
+                        continue;
+                    }
+                    if ($candidate->name === 'Default') {
+                        $fallback = $candidate;
+                        continue;
+                    }
+                    if ($candidate->name !== 'Case') {
+                        throw new RuntimeException('Match accepts only Case and Default children.');
+                    }
+                    $case = self::value($candidate->attributes['value'] ?? null, $scope, $nodeData);
+                    if ($subject === $case) {
+                        array_push($output, ...self::nodes($candidate->children, $scope, $nodeData));
+                        continue 2;
+                    }
+                }
+                if ($fallback !== null) {
+                    array_push($output, ...self::nodes($fallback->children, $scope, $nodeData));
+                }
+                continue;
+            }
+
+            if ($tag === 'Await') {
+                $resource = self::value($attributes['value'] ?? null, $scope, $nodeData);
+                $async = $resource instanceof AsyncResource ? $resource->value() : $resource;
+                if (!$async instanceof AsyncValue) {
+                    throw new RuntimeException('Await value must resolve to AsyncResource or AsyncValue.');
+                }
+                $branch = match ($async->status) {
+                    AsyncStatus::Loading => 'Pending',
+                    AsyncStatus::Content => 'Content',
+                    AsyncStatus::Empty => 'Empty',
+                    AsyncStatus::Error => 'Error',
+                    AsyncStatus::Offline => 'Offline',
+                    AsyncStatus::Stale => 'Stale',
+                };
+                $fallback = null;
+                foreach ($children as $candidate) {
+                    if ($candidate->kind !== 1) {
+                        continue;
+                    }
+                    if ($candidate->name === 'Default') {
+                        $fallback = $candidate;
+                    }
+                    if ($candidate->name !== $branch) {
+                        continue;
+                    }
+                    array_push($output, ...self::nodes($candidate->children, $scope, [
+                        ...$nodeData,
+                        'data' => $async->data,
+                        'message' => $async->message,
+                        'retryable' => $async->retryable,
+                    ]));
+                    continue 2;
+                }
+                if ($fallback !== null) {
+                    array_push($output, ...self::nodes($fallback->children, $scope, $nodeData));
+                }
                 continue;
             }
 
@@ -794,7 +897,13 @@ final class TemplateRenderer
         }
         $attributes = [
             ...$inheritedStyles,
-            ...self::scopedStyleAttributes($tag, $resolvedClass, $data),
+            ...self::scopedStyleAttributes(
+                $tag,
+                $resolvedClass,
+                $data,
+                $attributes,
+                $scope,
+            ),
             ...$attributes,
         ];
         $unresolvedStyleAttributes = $attributes;
@@ -829,6 +938,8 @@ final class TemplateRenderer
                 isset(self::EVENTS[$name])
                 || $name === 'class'
                 || $name === ':class'
+                || $name === 'recipe'
+                || str_starts_with($name, 'variant:')
                 || $name === 'p-ripple'
                 || $name === ':p-ripple'
                 || str_starts_with($name, '@')
@@ -944,6 +1055,12 @@ final class TemplateRenderer
         }
         $childData = [
             ...$data,
+            '__pamContainerWidth' => is_numeric($values['width'] ?? null)
+                ? (float) $values['width']
+                : ($data['__pamContainerWidth'] ?? null),
+            '__pamContainerHeight' => is_numeric($values['height'] ?? null)
+                ? (float) $values['height']
+                : ($data['__pamContainerHeight'] ?? null),
             '__pamInheritedStyles' => self::inheritedStyleAttributes(
                 $values,
                 $unresolvedStyleAttributes,
@@ -992,6 +1109,35 @@ final class TemplateRenderer
         }
         if ($text !== '') {
             $values['text'] ??= $text;
+        }
+        if ($tag === 'Animated' && isset($values['animation'])) {
+            $animation = self::stringValue($values['animation'], 'Animated animation');
+            $keyframes = $data['__pamStyles']['keyframes'][$animation] ?? null;
+            if (!is_array($keyframes)) {
+                throw new RuntimeException("Unknown PAM keyframes {$animation}.");
+            }
+            $values['keyframes'] = array_map(
+                static fn (array $frame): array => [
+                    'offset' => $frame['offset'] ?? 0.0,
+                    ...(is_array($frame['styles'] ?? null) ? $frame['styles'] : []),
+                ],
+                $keyframes,
+            );
+            unset($values['animation']);
+        }
+        $contract = $factory !== null ? TemplateRegistry::tagContract($tag) : null;
+        if ($contract !== null) {
+            ContractValidator::validate(
+                $contract,
+                array_filter(
+                    $componentValues,
+                    static fn (string $name): bool =>
+                        !str_starts_with($name, '__pam') && $name !== 'className',
+                    ARRAY_FILTER_USE_KEY,
+                ),
+                $slots,
+                $componentEvents,
+            );
         }
         if ($factory !== null && $inheritedVariants !== []) {
             $componentValues['__parentVariants'] = $inheritedVariants;
@@ -2317,7 +2463,33 @@ final class TemplateRenderer
             'tags' => $tags,
             'classCascade' => $classCascade,
             'fonts' => $fonts,
+            'tokens' => self::safeStyleMetadata($decoded['tokens'] ?? [], $tree->source),
+            'states' => self::safeStyleMetadata($decoded['states'] ?? [], $tree->source),
+            'recipes' => self::safeStyleMetadata($decoded['recipes'] ?? [], $tree->source),
+            'queries' => self::safeStyleMetadata($decoded['queries'] ?? [], $tree->source),
+            'keyframes' => self::safeStyleMetadata($decoded['keyframes'] ?? [], $tree->source),
         ];
+    }
+
+    private static function safeStyleMetadata(mixed $value, string $source, int $depth = 0): array
+    {
+        if (!is_array($value) || $depth > 12 || count($value) > 10_000) {
+            throw new RuntimeException("Invalid Language 2 style IR in {$source}.");
+        }
+        $safe = [];
+        foreach ($value as $key => $entry) {
+            if (!is_string($key) && !is_int($key)) {
+                throw new RuntimeException("Invalid Language 2 style IR key in {$source}.");
+            }
+            if (is_array($entry)) {
+                $safe[$key] = self::safeStyleMetadata($entry, $source, $depth + 1);
+            } elseif (is_string($entry) || is_int($entry) || is_float($entry) || is_bool($entry) || $entry === null) {
+                $safe[$key] = $entry;
+            } else {
+                throw new RuntimeException("Invalid Language 2 style IR value in {$source}.");
+            }
+        }
+        return $safe;
     }
 
     /**
@@ -2340,11 +2512,14 @@ final class TemplateRenderer
         string $tag,
         ?string $classes,
         array $data,
+        array $rawAttributes,
+        ?object $scope,
     ): array {
         $sheet = $data['__pamStyles'] ?? null;
         if (!is_array($sheet)) {
             return [];
         }
+        $sheet = self::responsiveStyleSheet($sheet, $data);
         $classCascade = is_array($sheet['classCascade'] ?? null)
             ? $sheet['classCascade']
             : [];
@@ -2390,7 +2565,119 @@ final class TemplateRenderer
             }
         }
 
+        $recipeName = $rawAttributes['recipe'] ?? null;
+        if ($recipeName !== null) {
+            $recipeName = self::stringValue(
+                self::value($recipeName, $scope, $data),
+                'recipe',
+            );
+            $recipes = is_array($sheet['recipes'] ?? null) ? $sheet['recipes'] : [];
+            $recipe = $recipes[$recipeName] ?? null;
+            if (!is_array($recipe)) {
+                throw new RuntimeException("Unknown PAM recipe {$recipeName}.");
+            }
+            if (is_array($recipe['base'] ?? null)) {
+                $attributes = [...$attributes, ...$recipe['base']];
+            }
+            foreach ($rawAttributes as $name => $rawValue) {
+                if (!str_starts_with($name, 'variant:')) {
+                    continue;
+                }
+                $variant = substr($name, 8);
+                $choice = self::stringValue(
+                    self::value($rawValue, $scope, $data),
+                    "recipe variant {$variant}",
+                );
+                $styles = $recipe['variants'][$variant][$choice] ?? null;
+                if (!is_array($styles)) {
+                    throw new RuntimeException(
+                        "Unknown PAM recipe variant {$recipeName}.{$variant}={$choice}.",
+                    );
+                }
+                $attributes = [...$attributes, ...$styles];
+            }
+        }
+
+        $stateRules = is_array($sheet['states'] ?? null) ? $sheet['states'] : [];
+        $selectors = [$tag];
+        foreach (array_keys($classNames) as $class) {
+            $selectors[] = '.'.$class;
+        }
+        foreach ($selectors as $selector) {
+            $pressed = $stateRules[$selector]['pressed'] ?? null;
+            if (!is_array($pressed)) {
+                continue;
+            }
+            if (isset($pressed['opacity'])) {
+                $attributes['pressedOpacity'] = $pressed['opacity'];
+            }
+            if (
+                isset($pressed['scaleX'], $pressed['scaleY'])
+                && $pressed['scaleX'] === $pressed['scaleY']
+            ) {
+                $attributes['pressedScale'] = $pressed['scaleX'];
+            }
+        }
+
         return $attributes;
+    }
+
+    /** @param array<string, mixed> $sheet @param array<string, mixed> $data */
+    private static function responsiveStyleSheet(array $sheet, array $data): array
+    {
+        $queries = $sheet['queries'] ?? [];
+        if (!is_array($queries)) {
+            return $sheet;
+        }
+        foreach ($queries as $query) {
+            if (!is_array($query) || !is_array($query['styles'] ?? null)) {
+                continue;
+            }
+            $kind = $query['kind'] ?? null;
+            $condition = $query['condition'] ?? null;
+            if (!is_int($kind) || !is_string($condition)) {
+                continue;
+            }
+            $metrics = Runtime::windowMetrics();
+            $width = $kind === 1 ? $metrics->width : ($data['__pamContainerWidth'] ?? null);
+            $height = $kind === 1 ? $metrics->height : ($data['__pamContainerHeight'] ?? null);
+            if (!self::queryMatches($condition, $width, $height)) {
+                continue;
+            }
+            foreach (['classes', 'tags'] as $group) {
+                $incoming = $query['styles'][$group] ?? [];
+                if (!is_array($incoming)) {
+                    continue;
+                }
+                foreach ($incoming as $selector => $styles) {
+                    if (is_string($selector) && is_array($styles)) {
+                        $sheet[$group][$selector] = [
+                            ...($sheet[$group][$selector] ?? []),
+                            ...$styles,
+                        ];
+                    }
+                }
+            }
+            // Query rules are later than base rules by definition.
+            $sheet['classCascade'] = [];
+        }
+        return $sheet;
+    }
+
+    private static function queryMatches(
+        string $condition,
+        mixed $width,
+        mixed $height,
+    ): bool {
+        if (preg_match('/\((min|max)-(width|height):\s*([0-9]+(?:\.[0-9]+)?)(?:dp|px)\)/D', $condition, $match) !== 1) {
+            return false;
+        }
+        $actual = $match[2] === 'width' ? $width : $height;
+        if (!is_int($actual) && !is_float($actual)) {
+            return false;
+        }
+        $threshold = (float) $match[3];
+        return $match[1] === 'min' ? $actual >= $threshold : $actual <= $threshold;
     }
 
     /**

--- a/packages/native/src/LanguageVersion.php
+++ b/packages/native/src/LanguageVersion.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native;
+
+/**
+ * Source-language generations are integer capabilities on purpose: bundles
+ * never need to compare marketing version strings at runtime.
+ */
+enum LanguageVersion: int
+{
+    case Language1 = 1;
+    case Language2 = 2;
+
+    public const self CURRENT = self::Language2;
+}

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.7.0';
+    public const string SDK_VERSION = '0.8.0';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/TemplateRegistry.php
+++ b/packages/native/src/TemplateRegistry.php
@@ -6,6 +6,7 @@ namespace Pam\Native;
 
 use Closure;
 use InvalidArgumentException;
+use Pam\Native\UI\Contract\TagContract;
 
 final class TemplateRegistry
 {
@@ -26,6 +27,9 @@ final class TemplateRegistry
     /** @var list<Closure(string): (array<int, mixed>|null)> */
     private static array $styleResolvers = [];
 
+    /** @var array<string, TagContract> */
+    private static array $contracts = [];
+
     private function __construct()
     {
     }
@@ -37,6 +41,24 @@ final class TemplateRegistry
     {
         self::assertName($tag);
         self::$components[$tag] = $factory;
+    }
+
+    /** Registers the machine-readable contract used by compiler, LSP and runtime. */
+    public static function contract(TagContract $contract): void
+    {
+        self::assertName($contract->name);
+        self::$contracts[$contract->name] = $contract;
+    }
+
+    public static function tagContract(string $tag): ?TagContract
+    {
+        return self::$contracts[$tag] ?? null;
+    }
+
+    /** @return array<string, TagContract> */
+    public static function contracts(): array
+    {
+        return self::$contracts;
     }
 
     public static function view(string $tag, string $view): void
@@ -131,6 +153,7 @@ final class TemplateRegistry
         self::$eventAdapters = [];
         self::$classes = [];
         self::$styleResolvers = [];
+        self::$contracts = [];
     }
 
     /**

--- a/packages/native/src/Tooling/PamFormatter.php
+++ b/packages/native/src/Tooling/PamFormatter.php
@@ -6,6 +6,7 @@ namespace Pam\Native\Tooling;
 
 use Pam\Native\Internal\CompiledTemplateNode;
 use Pam\Native\Internal\TemplateCompiler;
+use Pam\Native\LanguageVersion;
 use RuntimeException;
 
 /**
@@ -32,7 +33,7 @@ final class PamFormatter
             );
         }
 
-        [$php, $template, $style, $hasStyle] = self::split($source, $name);
+        [$php, $template, $style, $hasStyle, $language] = self::split($source, $name);
         $protectedTemplate = preg_replace_callback(
             '/<!--[\s\S]*?-->/',
             static fn (array $match): string =>
@@ -45,8 +46,10 @@ final class PamFormatter
                 "Cannot preserve template comments in {$name}.",
             );
         }
-        $tree = TemplateCompiler::compile($protectedTemplate, $name);
-        $lines = ['<template>'];
+        $tree = TemplateCompiler::compile($protectedTemplate, $name, $language);
+        $lines = [$language === LanguageVersion::Language2
+            ? '<template language="2">'
+            : '<template>'];
         foreach ($tree->children as $child) {
             array_push($lines, ...self::node($child, 1));
         }
@@ -82,7 +85,7 @@ final class PamFormatter
         return true;
     }
 
-    /** @return array{string, string, string, bool} */
+    /** @return array{string, string, string, bool, LanguageVersion} */
     private static function split(string $source, string $name): array
     {
         $tokens = token_get_all($source);
@@ -107,7 +110,7 @@ final class PamFormatter
         $markup = substr($source, $closeOffset + $closeLength);
         $match = [];
         if (preg_match(
-            '/\A\s*<template(?:\s[^>]*)?>([\s\S]*?)<\/template>'
+            '/\A\s*<template(?:\s+([^>]*))?>([\s\S]*?)<\/template>'
                 .'\s*(?:<style(?:\s+scoped)?\s*>([\s\S]*?)<\/style>)?\s*\z/D',
             $markup,
             $match,
@@ -117,11 +120,22 @@ final class PamFormatter
             );
         }
 
+        $attributes = trim((string) ($match[1] ?? ''));
+        $language = LanguageVersion::Language1;
+        if (preg_match('/(?:language|version)\s*=\s*(["\'])2\1/D', $attributes) === 1) {
+            $language = LanguageVersion::Language2;
+        } elseif ($attributes !== '') {
+            throw new RuntimeException(
+                "PAM component {$name} has unsupported template attributes; use language=\"2\".",
+            );
+        }
+
         return [
             $php,
-            (string) $match[1],
-            (string) ($match[2] ?? ''),
-            array_key_exists(2, $match),
+            (string) $match[2],
+            (string) ($match[3] ?? ''),
+            array_key_exists(3, $match),
+            $language,
         ];
     }
 
@@ -272,37 +286,62 @@ final class PamFormatter
         foreach ($imports as $import) {
             $lines[] = '    '.$import;
         }
-        preg_match_all(
-            '/([^{}]+)\{([^{}]*)\}/',
-            $clean,
-            $blocks,
-            PREG_SET_ORDER | PREG_OFFSET_CAPTURE,
-        );
-        $matchedBytes = 0;
-        foreach ($blocks as $block) {
-            $offset = $block[0][1];
-            if (trim(substr($clean, $matchedBytes, $offset - $matchedBytes)) !== '') {
-                throw new RuntimeException(
-                    'PAM formatter cannot format nested or invalid scoped CSS.',
-                );
-            }
-            $matchedBytes = $offset + strlen($block[0][0]);
-            if ($lines !== []) {
-                $lines[] = '';
-            }
-            $lines[] = '    '.trim($block[1][0]).' {';
-            foreach (explode(';', $block[2][0]) as $declaration) {
-                $declaration = trim($declaration);
-                if ($declaration !== '') {
-                    $lines[] = '        '.$declaration.';';
+        $depth = 1;
+        $buffer = '';
+        $quote = null;
+        $length = strlen($clean);
+        for ($index = 0; $index < $length; $index++) {
+            $character = $clean[$index];
+            if ($quote !== null) {
+                $buffer .= $character;
+                if ($character === $quote && ($index === 0 || $clean[$index - 1] !== '\\')) {
+                    $quote = null;
                 }
+                continue;
             }
-            $lines[] = '    }';
+            if ($character === '"' || $character === "'") {
+                $quote = $character;
+                $buffer .= $character;
+                continue;
+            }
+            if ($character === '{') {
+                $header = trim($buffer);
+                if ($header === '') {
+                    throw new RuntimeException('PAM formatter found an empty CSS selector.');
+                }
+                if ($lines !== [] && end($lines) !== '') {
+                    $lines[] = '';
+                }
+                $lines[] = str_repeat('    ', $depth).$header.' {';
+                $depth++;
+                $buffer = '';
+                continue;
+            }
+            if ($character === ';') {
+                $declaration = trim($buffer);
+                if ($declaration !== '') {
+                    $lines[] = str_repeat('    ', $depth).$declaration.';';
+                }
+                $buffer = '';
+                continue;
+            }
+            if ($character === '}') {
+                $declaration = trim($buffer);
+                if ($declaration !== '') {
+                    throw new RuntimeException('PAM formatter requires semicolons in CSS declarations.');
+                }
+                if ($depth <= 1) {
+                    throw new RuntimeException('PAM formatter found an unexpected CSS closing brace.');
+                }
+                $depth--;
+                $lines[] = str_repeat('    ', $depth).'}';
+                $buffer = '';
+                continue;
+            }
+            $buffer .= $character;
         }
-        if (trim(substr($clean, $matchedBytes)) !== '') {
-            throw new RuntimeException(
-                'PAM formatter cannot format invalid scoped CSS.',
-            );
+        if ($quote !== null || $depth !== 1 || trim($buffer) !== '') {
+            throw new RuntimeException('PAM formatter cannot format invalid scoped CSS.');
         }
 
         return implode("\n", $lines);

--- a/packages/native/src/UI/Contract/ComponentContractFactory.php
+++ b/packages/native/src/UI/Contract/ComponentContractFactory.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\UI\Contract;
+
+use BackedEnum;
+use Pam\Native\Attributes\Event;
+use Pam\Native\Attributes\Prop;
+use Pam\Native\Attributes\Slot;
+use Pam\Native\Component;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionParameter;
+use ReflectionUnionType;
+use RuntimeException;
+
+final class ComponentContractFactory
+{
+    private function __construct()
+    {
+    }
+
+    /** @param class-string<Component> $component */
+    public static function fromClass(string $component, string $tag): TagContract
+    {
+        $reflection = new ReflectionClass($component);
+        $props = [];
+        foreach ($reflection->getConstructor()?->getParameters() ?? [] as $parameter) {
+            $attribute = $parameter->getAttributes(Prop::class)[0] ?? null;
+            if ($attribute === null) {
+                continue;
+            }
+            $definition = $attribute->newInstance();
+            $props[] = new PropContract(
+                name: $parameter->getName(),
+                kind: self::kind($parameter),
+                required: $definition->required || !$parameter->isDefaultValueAvailable(),
+                bindable: !$definition->immutable,
+                enum: $definition->enum ?? self::enumType($parameter),
+            );
+        }
+
+        $events = [];
+        foreach ($reflection->getAttributes(Event::class) as $attribute) {
+            $definition = $attribute->newInstance();
+            if (!class_exists($definition->payload) && !interface_exists($definition->payload)) {
+                throw new RuntimeException(
+                    "Component event {$component}.{$definition->name} has unknown payload {$definition->payload}.",
+                );
+            }
+            $events[] = new EventContract($definition->name, $definition->payload);
+        }
+
+        $slots = [];
+        foreach ($reflection->getAttributes(Slot::class) as $attribute) {
+            $definition = $attribute->newInstance();
+            if ($definition->minimum < 0 || ($definition->maximum !== null && $definition->maximum < $definition->minimum)) {
+                throw new RuntimeException("Component slot {$component}.{$definition->name} has invalid cardinality.");
+            }
+            $slots[] = new SlotContract(
+                $definition->name,
+                $definition->minimum,
+                $definition->maximum,
+            );
+        }
+
+        return new TagContract($tag, $props, $events, $slots);
+    }
+
+    private static function kind(ReflectionParameter $parameter): ValueKind
+    {
+        $type = $parameter->getType();
+        if ($type instanceof ReflectionUnionType) {
+            $nonNull = [];
+            foreach ($type->getTypes() as $candidate) {
+                if (!$candidate instanceof ReflectionNamedType) {
+                    return ValueKind::Any;
+                }
+                if ($candidate->getName() !== 'null') {
+                    $nonNull[] = $candidate;
+                }
+            }
+            return count($nonNull) === 1 ? self::namedKind($nonNull[0]) : ValueKind::Any;
+        }
+        return $type instanceof ReflectionNamedType ? self::namedKind($type) : ValueKind::Any;
+    }
+
+    /** @return class-string<BackedEnum>|null */
+    private static function enumType(ReflectionParameter $parameter): ?string
+    {
+        $type = $parameter->getType();
+        if (!$type instanceof ReflectionNamedType) {
+            return null;
+        }
+        $name = $type->getName();
+
+        return is_a($name, BackedEnum::class, true) ? $name : null;
+    }
+
+    private static function namedKind(ReflectionNamedType $type): ValueKind
+    {
+        return match ($type->getName()) {
+            'string' => ValueKind::String,
+            'int' => ValueKind::Integer,
+            'float' => ValueKind::Float,
+            'bool' => ValueKind::Boolean,
+            'array', 'iterable' => ValueKind::Array,
+            'mixed' => ValueKind::Any,
+            default => is_a($type->getName(), BackedEnum::class, true)
+                ? ValueKind::Enum
+                : ValueKind::Object,
+        };
+    }
+}

--- a/packages/native/src/UI/Contract/ContractValidator.php
+++ b/packages/native/src/UI/Contract/ContractValidator.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\UI\Contract;
+
+use BackedEnum;
+use Pam\Native\Renderable;
+use RuntimeException;
+
+final class ContractValidator
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $props
+     * @param array<string, list<Renderable>> $slots
+     * @param array<string, mixed> $events
+     */
+    public static function validate(
+        TagContract $contract,
+        array $props,
+        array $slots,
+        array $events,
+    ): void {
+        $known = [];
+        foreach ($contract->props as $prop) {
+            $known[$prop->name] = true;
+            if (!array_key_exists($prop->name, $props)) {
+                if ($prop->required) {
+                    throw new RuntimeException(
+                        "Required prop {$contract->name}.{$prop->name} is missing.",
+                    );
+                }
+                continue;
+            }
+            if (!self::matches($props[$prop->name], $prop)) {
+                throw new RuntimeException(
+                    "Prop {$contract->name}.{$prop->name} violates its typed contract.",
+                );
+            }
+        }
+        $unknown = array_diff_key($props, $known);
+        if ($unknown !== []) {
+            throw new RuntimeException(
+                "Unknown props for {$contract->name}: ".implode(', ', array_keys($unknown)).'.',
+            );
+        }
+
+        $knownEvents = [];
+        foreach ($contract->events as $event) {
+            $knownEvents[$event->name] = true;
+        }
+        $unknownEvents = array_diff_key($events, $knownEvents);
+        if ($unknownEvents !== []) {
+            throw new RuntimeException(
+                "Unknown events for {$contract->name}: ".implode(', ', array_keys($unknownEvents)).'.',
+            );
+        }
+
+        foreach ($contract->slots as $slot) {
+            $count = count($slots[$slot->name] ?? []);
+            if ($count < $slot->minimum || ($slot->maximum !== null && $count > $slot->maximum)) {
+                throw new RuntimeException(
+                    "Slot {$contract->name}.{$slot->name} violates its cardinality contract.",
+                );
+            }
+        }
+    }
+
+    private static function matches(mixed $value, PropContract $prop): bool
+    {
+        if ($value === null && !$prop->required) {
+            return true;
+        }
+        if ($prop->enum !== null) {
+            return $value instanceof BackedEnum && $value::class === $prop->enum;
+        }
+
+        return match ($prop->kind) {
+            ValueKind::String => is_string($value),
+            ValueKind::Integer => is_int($value),
+            ValueKind::Float => is_float($value) || is_int($value),
+            ValueKind::Boolean => is_bool($value),
+            ValueKind::Array => is_array($value),
+            ValueKind::Object => is_object($value),
+            ValueKind::Enum => $value instanceof BackedEnum,
+            ValueKind::Renderable => $value instanceof Renderable,
+            ValueKind::Any => true,
+        };
+    }
+}

--- a/packages/native/src/UI/Contract/EventContract.php
+++ b/packages/native/src/UI/Contract/EventContract.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\UI\Contract;
+
+final readonly class EventContract
+{
+    /** @param class-string|null $payload */
+    public function __construct(
+        public string $name,
+        public ?string $payload = null,
+    ) {
+    }
+}

--- a/packages/native/src/UI/Contract/PropContract.php
+++ b/packages/native/src/UI/Contract/PropContract.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\UI\Contract;
+
+final readonly class PropContract
+{
+    public function __construct(
+        public string $name,
+        public ValueKind $kind,
+        public bool $required = false,
+        public bool $bindable = false,
+        public ?string $enum = null,
+    ) {
+    }
+}

--- a/packages/native/src/UI/Contract/SlotContract.php
+++ b/packages/native/src/UI/Contract/SlotContract.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\UI\Contract;
+
+final readonly class SlotContract
+{
+    public function __construct(
+        public string $name = 'slot',
+        public int $minimum = 0,
+        public ?int $maximum = null,
+    ) {
+    }
+}

--- a/packages/native/src/UI/Contract/TagContract.php
+++ b/packages/native/src/UI/Contract/TagContract.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\UI\Contract;
+
+use InvalidArgumentException;
+
+final readonly class TagContract
+{
+    /**
+     * @param list<PropContract> $props
+     * @param list<EventContract> $events
+     * @param list<SlotContract> $slots
+     */
+    public function __construct(
+        public string $name,
+        public array $props = [],
+        public array $events = [],
+        public array $slots = [],
+    ) {
+        if (preg_match('/^[A-Za-z][A-Za-z0-9_.-]{0,127}$/D', $name) !== 1) {
+            throw new InvalidArgumentException('Tag contract names must be safe identifiers.');
+        }
+    }
+}

--- a/packages/native/src/UI/Contract/ValueKind.php
+++ b/packages/native/src/UI/Contract/ValueKind.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\UI\Contract;
+
+enum ValueKind: int
+{
+    case String = 1;
+    case Integer = 2;
+    case Float = 3;
+    case Boolean = 4;
+    case Array = 5;
+    case Object = 6;
+    case Enum = 7;
+    case Renderable = 8;
+    case Any = 9;
+}

--- a/packages/native/src/UI/Ir/UiCapability.php
+++ b/packages/native/src/UI/Ir/UiCapability.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\UI\Ir;
+
+/** Stable, append-only Language 2 capability identifiers. */
+enum UiCapability: int
+{
+    case TypedContracts = 1;
+    case InteractionStates = 2;
+    case DesignTokens = 3;
+    case Recipes = 4;
+    case ResponsiveQueries = 5;
+    case DeclarativeFlow = 6;
+    case StableVirtualization = 7;
+    case NativeAnimations = 8;
+    case AsyncBranches = 9;
+    case AccessibilityDiagnostics = 10;
+    case ComposerTags = 11;
+    case LanguageTooling = 12;
+}

--- a/packages/native/src/UI/Ir/UiIr.php
+++ b/packages/native/src/UI/Ir/UiIr.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\UI\Ir;
+
+use Pam\Native\LanguageVersion;
+
+final readonly class UiIr
+{
+    public const int VERSION = 2;
+
+    /** @return array{version: int, language: int, capabilities: list<int>} */
+    public static function manifest(LanguageVersion $language): array
+    {
+        return [
+            'version' => self::VERSION,
+            'language' => $language->value,
+            'capabilities' => $language === LanguageVersion::Language2
+                ? array_map(
+                    static fn (UiCapability $capability): int => $capability->value,
+                    UiCapability::cases(),
+                )
+                : [],
+        ];
+    }
+}

--- a/packages/native/tests/language2.php
+++ b/packages/native/tests/language2.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+use Pam\Native\AsyncValue;
+use Pam\Native\Internal\CompiledTemplateNode;
+use Pam\Native\Internal\PamPhpCompiler;
+use Pam\Native\Internal\ScopedStyleCompiler;
+use Pam\Native\Internal\TemplateCompiler;
+use Pam\Native\Internal\TemplateRenderer;
+use Pam\Native\LanguageVersion;
+use Pam\Native\NodeKind;
+use Pam\Native\PropKey;
+use Pam\Native\Tooling\PamFormatter;
+
+$language2Tree = TemplateCompiler::compile(
+    '<Show when="$ready"><Text>Language 2</Text></Show>',
+    'Language2Show.pam',
+    LanguageVersion::Language2,
+);
+$language2Element = TemplateRenderer::render($language2Tree, null, ['ready' => true]);
+$assert(
+    $language2Element->kind() === NodeKind::Text
+        && $language2Element->properties()[PropKey::Text->value] === 'Language 2',
+    'Language 2 Show must render its typed truthy branch.',
+);
+
+$matchTree = TemplateCompiler::compile(
+    '<Match value="$mode"><Case value="compact"><Text>Compact</Text></Case><Default><Text>Default</Text></Default></Match>',
+    'Language2Match.pam',
+    LanguageVersion::Language2,
+);
+$matchElement = TemplateRenderer::render($matchTree, null, ['mode' => 'compact']);
+$assert(
+    $matchElement->properties()[PropKey::Text->value] === 'Compact',
+    'Language 2 Match must use strict case selection.',
+);
+
+$awaitTree = TemplateCompiler::compile(
+    '<Await value="$request"><Pending><Text>Loading</Text></Pending><Content><Text>{{ $data }}</Text></Content></Await>',
+    'Language2Await.pam',
+    LanguageVersion::Language2,
+);
+$awaitElement = TemplateRenderer::render(
+    $awaitTree,
+    null,
+    ['request' => AsyncValue::content('Ready')],
+);
+$assert(
+    $awaitElement->properties()[PropKey::Text->value] === 'Ready',
+    'Language 2 Await must expose typed async content to its Content branch.',
+);
+
+$language2Styles = ScopedStyleCompiler::compile(<<<'CSS'
+@tokens {
+    color.brand: #4F46E5;
+    space.md: 16px;
+}
+
+@recipe card {
+    base {
+        padding: var(--space-md);
+    }
+    variant tone=primary {
+        background: var(--color-brand);
+    }
+}
+
+.touchable {
+    opacity: 1;
+}
+
+.touchable:pressed {
+    opacity: 0.72;
+    transform: scale(0.98);
+}
+
+@media (min-width: 768dp) {
+    .card { padding: 24px; }
+}
+
+@container card (min-width: 320dp) {
+    .title { font-size: 20px; }
+}
+
+@keyframes enter {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0px); }
+}
+CSS, 'Language2Styles.pam');
+$assert(
+    ($language2Styles['tokens']['--color-brand'] ?? null) === '#4F46E5'
+        && ($language2Styles['recipes']['card']['variants']['tone']['primary']['backgroundColor'] ?? null) === 0xFF4F46E5
+        && ($language2Styles['states']['.touchable']['pressed']['opacity'] ?? null) === '0.72'
+        && count($language2Styles['queries']) === 2
+        && count($language2Styles['keyframes']['enter'] ?? []) === 2,
+    'Language 2 styles must compile tokens, recipes, states, queries and compositor keyframes to IR.',
+);
+
+$styledTemplate = TemplateCompiler::compile(
+    '<Pressable class="touchable"><View recipe="card" variant:tone="primary" /></Pressable>',
+    'Language2StyledRuntime.pam',
+    LanguageVersion::Language2,
+);
+$styledRoot = new CompiledTemplateNode(
+    kind: $styledTemplate->kind,
+    name: $styledTemplate->name,
+    attributes: ['__pamStyles' => json_encode($language2Styles, JSON_THROW_ON_ERROR)],
+    source: $styledTemplate->source,
+    line: $styledTemplate->line,
+    column: $styledTemplate->column,
+);
+$styledRoot->children = $styledTemplate->children;
+$styledElement = TemplateRenderer::render($styledRoot, null, []);
+$styledChild = $styledElement->children()[0] ?? null;
+$assert(
+    (float) ($styledElement->properties()[PropKey::PressOpacity->value] ?? 0) === 0.72
+        && (float) ($styledElement->properties()[PropKey::PressScale->value] ?? 0) === 0.98
+        && $styledChild instanceof \Pam\Native\Element
+        && (float) ($styledChild->properties()[PropKey::PaddingLeft->value] ?? 0) === 16.0
+        && ($styledChild->properties()[PropKey::BackgroundColor->value] ?? null) === 0xFF4F46E5,
+    'Compiled states and recipe variants must reach native element properties.',
+);
+
+$virtualKeyRejected = false;
+try {
+    TemplateCompiler::compile(
+        '<VirtualizedList><Text p-for="$item in $items">{{ $item }}</Text></VirtualizedList>',
+        'Language2VirtualList.pam',
+        LanguageVersion::Language2,
+    );
+} catch (RuntimeException $error) {
+    $virtualKeyRejected = str_contains($error->getMessage(), 'PAM2201');
+}
+$assert($virtualKeyRejected, 'Language 2 virtualized loops must require stable p-key identity.');
+
+$imageA11yRejected = false;
+try {
+    TemplateCompiler::compile(
+        '<Image source="asset://photo.jpg" />',
+        'Language2Image.pam',
+        LanguageVersion::Language2,
+    );
+} catch (RuntimeException $error) {
+    $imageA11yRejected = str_contains($error->getMessage(), 'PAM2301');
+}
+$assert($imageA11yRejected, 'Language 2 must diagnose unlabeled non-decorative images.');
+
+$formattedLanguage2 = PamFormatter::format(<<<'PAM'
+<?php
+declare(strict_types=1);
+final class LanguageTwoFormat {}
+?>
+<template language="2"><Image decorative="true" /></template>
+PAM, 'LanguageTwoFormat.pam');
+$assert(
+    str_contains($formattedLanguage2, '<template language="2">'),
+    'The formatter must preserve the Language 2 opt-in contract.',
+);
+
+$showcaseLanguage2 = PamPhpCompiler::compileFile(
+    dirname(__DIR__, 3).'/examples/showcase/resources/components/LanguageTwoCard.pam',
+    $pamPhpCache,
+);
+$assert(
+    $showcaseLanguage2->language === LanguageVersion::Language2
+        && $showcaseLanguage2->tag === 'LanguageTwoCard',
+    'The public showcase Language 2 component must compile with its #[Tag] contract.',
+);

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4563,7 +4563,7 @@ file_put_contents(
     "protocol": 1,
     "pamNative": {
         "minimum": "0.3.0",
-        "maximumExclusive": "0.8.0"
+        "maximumExclusive": "0.9.0"
     },
     "php": {
         "provider": "Pam\\Native\\Tests\\Fixtures\\ExamplePluginProvider"
@@ -6215,8 +6215,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.7.0',
-    'The runtime SDK contract must match the 0.7.0 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.8.0',
+    'The runtime SDK contract must match the 0.8.0 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,
@@ -6922,6 +6922,7 @@ $assert(
     'Component shutdown must guarantee effect and component cleanup.',
 );
 
+require __DIR__.'/language2.php';
 require __DIR__.'/singularity.php';
 
 echo "Pam Native PHP SDK tests passed.\n";


### PR DESCRIPTION
## Outcome

Ships PAM Native UI Language 2 as an opt-in, additive language while freezing Language 1 compatibility and keeping PHP 8.5 attributes as the canonical component API.

## The 12 pillars

- typed prop/action/event/slot/tag contracts
- native interaction-state IR
- compiled design tokens
- recipes and typed variants
- viewport and container queries
- `Show` and strict `Match` flow
- stable keyed virtualized loops
- compositor keyframes on native worklets
- typed `Await` async branches
- compiler accessibility diagnostics
- Composer-extensible tags
- expanded editor-neutral LSP

## Architecture

- `<template language="2">` opts in per component
- UI IR v2 uses stable sequential integer capability IDs 1..12
- no custom PHP grammar, DOM, WebView, JavaScript runtime, runtime CSS parser, or `eval`
- `#[Prop]`, `#[State]`, `#[Action]`, `#[Event]`, `#[Slot]`, and `#[Tag]` remain machine-readable PHP contracts
- release version is `0.8.0`

## Verification

- PHP SDK suite and 1,000-frame deterministic fuzz
- PHPStan level 9 for the new Language 2 surface
- Rust workspace tests, fmt, and clippy with warnings denied
- compiler/runtime Language 2 integration tests
- package, navigation, and mobile benchmark gates
- LSP integration tests
- protocol parity, JSON schemas, release workflow contracts
- reproducible Composer subtree verification

Android/iOS source builds remain mandatory PR checks. The local Android SDK lacked the licensed NDK 27 package; CI installs the pinned NDK and executes the official renderer suites.
