### PR TITLE
ci: certify PAM Native Camera

### DIFF
--- a/.github/workflows/ecosystem-ios.yml
+++ b/.github/workflows/ecosystem-ios.yml
@@ -39,6 +39,7 @@ jobs:
             pam-native-media pam-native-nfc pam-native-payments
             pam-native-realtime pam-native-scanner pam-native-share-extension
             pam-native-subscriptions pam-native-video pam-native-widgets
+            pam-native-camera
           )
           for repo in "${repos[@]}"; do
             git clone --depth 1 --branch main \
@@ -56,6 +57,7 @@ jobs:
             pam-native-media pam-native-nfc pam-native-payments
             pam-native-realtime pam-native-scanner pam-native-share-extension
             pam-native-subscriptions pam-native-video pam-native-widgets
+            pam-native-camera
           )
           targets=(
             PamPlugin0PushinbrPamNativeAuth
@@ -76,6 +78,7 @@ jobs:
             PamPlugin15PushinbrPamNativeSubscriptions
             PamPlugin16PushinbrPamNativeVideo
             PamPlugin17PushinbrPamNativeWidgets
+            PamPlugin18PushinbrPamNativeCamera
           )
           for index in "${!repos[@]}"; do
             source="${RUNNER_TEMP}/${repos[$index]}/ios/Sources"

--- a/.github/workflows/publish-ecosystem.yml
+++ b/.github/workflows/publish-ecosystem.yml
@@ -36,6 +36,7 @@ jobs:
             pam-native-payments pam-native-realtime pam-native-scanner
             pam-native-share-extension pam-native-subscriptions pam-native-video
             pam-native-widgets pam-native-firebase pam-native-laravel-sync
+            pam-native-camera
           )
           if [[ "${SELECTED_PACKAGE}" != all ]]; then
             valid=false

--- a/certification/ios-ecosystem/Package.swift
+++ b/certification/ios-ecosystem/Package.swift
@@ -117,6 +117,12 @@ let package = Package(
             linkerSettings: [.linkedFramework("WidgetKit"), .linkedFramework("SwiftUI")],
         ),
         .target(
+            name: "PamPlugin18PushinbrPamNativeCamera",
+            dependencies: [.product(name: "PamNative", package: "ios")],
+            path: "Sources/PamPlugin18PushinbrPamNativeCamera",
+            linkerSettings: [.linkedFramework("AVFoundation"), .linkedFramework("CoreImage"), .linkedFramework("CoreMedia"), .linkedFramework("CoreVideo"), .linkedFramework("Metal"), .linkedFramework("Vision")],
+        ),
+        .target(
             name: "PamExtensionIntents",
             path: "Sources/PamExtensionIntents",
             linkerSettings: [.linkedFramework("AppIntents")],
@@ -138,7 +144,7 @@ let package = Package(
         ),
         .target(
             name: "PamNativePlugins",
-            dependencies: ["PamPlugin0PushinbrPamNativeAuth", "PamPlugin1PushinbrPamNativeBackgroundTransfer", "PamPlugin2PushinbrPamNativeBluetooth", "PamPlugin3PushinbrPamNativeFeatureFlags", "PamPlugin4PushinbrPamNativeFirebase", "PamPlugin5PushinbrPamNativeHealth", "PamPlugin6PushinbrPamNativeIntents", "PamPlugin7PushinbrPamNativeLiveActivities", "PamPlugin8PushinbrPamNativeMaps", "PamPlugin9PushinbrPamNativeMedia", "PamPlugin10PushinbrPamNativeNfc", "PamPlugin11PushinbrPamNativePayments", "PamPlugin12PushinbrPamNativeRealtime", "PamPlugin13PushinbrPamNativeScanner", "PamPlugin14PushinbrPamNativeShareExtension", "PamPlugin15PushinbrPamNativeSubscriptions", "PamPlugin16PushinbrPamNativeVideo", "PamPlugin17PushinbrPamNativeWidgets", "PamExtensionIntents", "PamExtensionLiveActivities", "PamExtensionShare", "PamExtensionWidgets"],
+            dependencies: ["PamPlugin0PushinbrPamNativeAuth", "PamPlugin1PushinbrPamNativeBackgroundTransfer", "PamPlugin2PushinbrPamNativeBluetooth", "PamPlugin3PushinbrPamNativeFeatureFlags", "PamPlugin4PushinbrPamNativeFirebase", "PamPlugin5PushinbrPamNativeHealth", "PamPlugin6PushinbrPamNativeIntents", "PamPlugin7PushinbrPamNativeLiveActivities", "PamPlugin8PushinbrPamNativeMaps", "PamPlugin9PushinbrPamNativeMedia", "PamPlugin10PushinbrPamNativeNfc", "PamPlugin11PushinbrPamNativePayments", "PamPlugin12PushinbrPamNativeRealtime", "PamPlugin13PushinbrPamNativeScanner", "PamPlugin14PushinbrPamNativeShareExtension", "PamPlugin15PushinbrPamNativeSubscriptions", "PamPlugin16PushinbrPamNativeVideo", "PamPlugin17PushinbrPamNativeWidgets", "PamPlugin18PushinbrPamNativeCamera", "PamExtensionIntents", "PamExtensionLiveActivities", "PamExtensionShare", "PamExtensionWidgets"],
             path: "Sources/PamNativePlugins"
         ),
     ]


### PR DESCRIPTION
Adds the independent camera capability to the official iOS aggregate compiler and ecosystem publication allowlist. No vertical template or feed aggregate is introduced.