### PR TITLE
fix: resolve Android runtime from PAM releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.8.2 - 2026-08-23
+
+- Resolve Android runtime bundles from the latest PAM runtime release instead
+  of incorrectly treating the independently versioned Native SDK as a PAM tag.
+- Preserve explicit `PAM_RELEASE_BASE_URL` mirrors while normalizing trailing
+  slashes before resolving verified runtime assets.
+
 ## 0.8.1 - 2026-08-23
 
 - Added production-grade camera, media editing, retained canvas, GPU shader and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.8.1"
+version = "0.8.2"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -2277,10 +2277,8 @@ fn install_android_runtime_bundle(
     native_home: &Path,
 ) -> Result<(), String> {
     let asset = "pam-android-runtime.tar.gz";
-    let release_tag = format!("v{}", env!("CARGO_PKG_VERSION"));
-    let base = std::env::var("PAM_RELEASE_BASE_URL").unwrap_or_else(|_| {
-        format!("https://github.com/push-in/pam/releases/download/{release_tag}")
-    });
+    let configured_base = std::env::var("PAM_RELEASE_BASE_URL").ok();
+    let base = android_runtime_release_base(configured_base.as_deref());
     if !base.starts_with("https://") && std::env::var_os("PAM_RELEASE_BASE_URL").is_none() {
         return Err("refusing a non-HTTPS Android runtime release URL".to_owned());
     }
@@ -2375,6 +2373,13 @@ fn install_android_runtime_bundle(
         )),
         (Ok(()), Ok(())) => Ok(()),
     }
+}
+
+fn android_runtime_release_base(configured: Option<&str>) -> String {
+    configured
+        .unwrap_or("https://github.com/push-in/pam/releases/latest/download")
+        .trim_end_matches('/')
+        .to_owned()
 }
 
 fn download_release_asset(url: &str, destination: &Path, maximum_bytes: u64) -> Result<(), String> {
@@ -7596,6 +7601,19 @@ mod tests {
         assert!(!safe_android_runtime_archive_path(Path::new(
             "native/Cargo.toml"
         )));
+    }
+
+    #[test]
+    fn android_runtime_download_uses_the_pam_release_channel_not_the_sdk_version() {
+        assert_eq!(
+            android_runtime_release_base(None),
+            "https://github.com/push-in/pam/releases/latest/download"
+        );
+        assert_eq!(
+            android_runtime_release_base(Some("https://mirror.example/pam/v2.0.10/")),
+            "https://mirror.example/pam/v2.0.10"
+        );
+        assert!(!android_runtime_release_base(None).contains(env!("CARGO_PKG_VERSION")));
     }
 
     #[test]

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.8.1';
+    public const string SDK_VERSION = '0.8.2';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6215,8 +6215,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.8.1',
-    'The runtime SDK contract must match the 0.8.1 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.8.2',
+    'The runtime SDK contract must match the 0.8.2 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- stop deriving PAM runtime release tags from the independently versioned Native SDK
- resolve the verified Android bundle through the PAM stable release channel
- preserve explicit mirror URLs and normalize trailing slashes
- bump the Native SDK contract to 0.8.2

## Public failure reproduced
`pam runtime:install .` from PAM 2.0.10 / Native 0.8.1 requested `push-in/pam/releases/download/v0.8.1/pam-android-runtime.tar.gz` and received 404.

## Validation
- all 26 `pam-native-cli` tests pass
- PHP SDK suite passes on PAM PHP 8.5.9
- end-to-end download from `releases/latest/download`, SHA-256 verification, extraction and installation succeeded
- doctor reports both PHP 8.5 Android ABIs and both prebuilt Native engines as `[ok]`