### PR TITLE
feat: harden declarative native first frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.8.5 - 2026-08-23
+
+- Add Vue-like `p-model` and `p-model:checked` two-way bindings to Language 2,
+  while keeping the existing binding spellings compatible.
+- Apply accessible semantic theme defaults to imperative element trees without
+  replacing authored styles, preventing invisible dark-on-dark first frames.
+- Expose the live native appearance to plugins so PAM Native UI follows system
+  light and dark mode without environment configuration.
+- Move Android application-bundle staging out of purgeable cache storage and
+  certify a non-uniform visible first frame on API 36.1 and physical hardware.
+- Add an Android pixel-level first-frame regression and a bounded theme-default
+  performance budget for retained trees.
+
 ## 0.8.2 - 2026-08-23
 
 - Resolve Android runtime bundles from the latest PAM runtime release instead

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.8.4"
+version = "0.8.5"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamRendererInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamRendererInstrumentedTest.kt
@@ -192,6 +192,68 @@ class PamRendererInstrumentedTest {
     }
 
     @Test
+    fun themedStarterPaintsAVisibleNonUniformFirstFrame() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        val surface = 0xFF0F172A.toInt()
+        val foreground = 0xFFF8FAFC.toInt()
+        val accent = 0xFF4ADE80.toInt()
+        val onAccent = 0xFF052E16.toInt()
+        try {
+            onMain(instrumentation) {
+                val renderer = PamRenderer(activity, activity.host) { _, _, _ -> }
+                renderer.commit(
+                    listOf(
+                        listOf(
+                            Mutation.Create(node(1, 0, NodeKind.SCREEN, mapOf(
+                                PropKey.BACKGROUND_COLOR to PropValue.Integer(surface.toLong()),
+                            ))),
+                            Mutation.Create(node(2, 1, NodeKind.TEXT, mapOf(
+                                PropKey.TEXT to PropValue.Text("Visible PAM Native"),
+                                PropKey.TEXT_COLOR to PropValue.Integer(foreground.toLong()),
+                            ))),
+                            Mutation.Create(node(3, 1, NodeKind.BUTTON, mapOf(
+                                PropKey.TEXT to PropValue.Text("Continue"),
+                                PropKey.BACKGROUND_COLOR to PropValue.Integer(accent.toLong()),
+                                PropKey.TEXT_COLOR to PropValue.Integer(onAccent.toLong()),
+                            ))),
+                            Mutation.Layout(1, Frame(0f, 0f, 360f, 720f)),
+                            Mutation.Layout(2, Frame(24f, 48f, 312f, 64f)),
+                            Mutation.Layout(3, Frame(24f, 136f, 312f, 56f)),
+                            Mutation.SetRoot(1),
+                        ),
+                    ),
+                )
+                activity.host.measure(
+                    View.MeasureSpec.makeMeasureSpec(360, View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(720, View.MeasureSpec.EXACTLY),
+                )
+                activity.host.layout(0, 0, 360, 720)
+
+                val text = activity.host.getChildAt(0)
+                    .let { it as ViewGroup }
+                    .getChildAt(0) as TextView
+                val button = (text.parent as ViewGroup).getChildAt(1) as Button
+                assertEquals(foreground, text.currentTextColor)
+                assertEquals(onAccent, button.currentTextColor)
+
+                val bitmap = Bitmap.createBitmap(360, 720, Bitmap.Config.ARGB_8888)
+                activity.host.draw(Canvas(bitmap))
+                assertEquals(surface, bitmap.getPixel(350, 700))
+                assertTrue(
+                    "A mounted starter must paint more than one visible color",
+                    (0 until bitmap.height step 24)
+                        .flatMap { y -> (0 until bitmap.width step 24).map { x -> bitmap.getPixel(x, y) } }
+                        .toSet()
+                        .size >= 3,
+                )
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
+    @Test
     fun largeAccessibilityScaleHonorsOptOutAndMaximumMultiplier() {
         assertEquals(1f, resolvedFontScale(false, 3f, 1.5f), 0.0001f)
         assertEquals(1.5f, resolvedFontScale(true, 3f, 1.5f), 0.0001f)

--- a/android/app/src/main/java/dev/pam/nativeapp/AssetInstaller.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/AssetInstaller.kt
@@ -16,7 +16,11 @@ internal class AssetInstaller(private val context: Context) {
             scheduleReleaseCleanup(release)
             return entry
         }
-        val staging = File(context.cacheDir, "pam-install-$version")
+        // Android may purge cacheDir while a large Composer tree is being
+        // copied, producing a valid entry path whose nested templates vanish
+        // before PHP starts. Installation is transactional application state,
+        // not disposable cache, so stage beside the content-addressed releases.
+        val staging = installationStagingDirectory(context.filesDir, version)
         staging.deleteRecursively()
         check(staging.mkdirs()) { "Cannot create Pam Native staging directory" }
         copyDirectory(ASSET_ROOT, staging)
@@ -163,4 +167,9 @@ internal fun staleReleaseDirectories(
         .sortedByDescending(File::lastModified)
         .drop(retainedInactiveReleases)
         .toList()
+}
+
+internal fun installationStagingDirectory(filesDirectory: File, version: String): File {
+    require(version.matches(Regex("[a-f0-9]{64}")))
+    return File(filesDirectory, "pam/staging/pam-install-$version")
 }

--- a/android/app/src/test/java/dev/pam/nativeapp/AssetInstallerTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/AssetInstallerTest.kt
@@ -67,4 +67,20 @@ class AssetInstallerTest {
             root.toFile().deleteRecursively()
         }
     }
+
+    @Test
+    fun stagesApplicationBundlesInDurableFilesInsteadOfPurgeableCache() {
+        val files = Files.createTempDirectory("pam-files-test")
+        try {
+            val version = "a".repeat(64)
+            val staging = installationStagingDirectory(files.toFile(), version)
+            assertEquals(
+                files.resolve("pam/staging/pam-install-$version").toFile(),
+                staging,
+            )
+            assertTrue(staging.canonicalPath.startsWith(files.toFile().canonicalPath))
+        } finally {
+            files.toFile().deleteRecursively()
+        }
+    }
 }

--- a/docs/ui-language-2.md
+++ b/docs/ui-language-2.md
@@ -205,6 +205,18 @@ and accepts only `Case` plus one optional `Default`:
 
 Existing `p-if`, `p-else-if`, `p-else` and `p-for` remain supported.
 
+Two-way bindings use the Vue-like `p-model` directive. It binds `value` for
+inputs and `checked` for `Switch`/`Toggle` without evaluating PHP in markup:
+
+```xml
+<Input p-model="$search" />
+<Switch p-model="$enabled" />
+```
+
+`p-model:checked` is available when a custom checked control needs an explicit
+binding target. The older `bind:value` and `bind:checked` spellings remain
+compatible aliases.
+
 ### 7. Stable virtual lists
 
 Every Language 2 loop below `VirtualizedList` or `VirtualGrid` requires

--- a/packages/native/bin/pam-native-language-server
+++ b/packages/native/bin/pam-native-language-server
@@ -278,7 +278,7 @@ function completionItems(string $source, ?string $workspaceRoot): array
     foreach (componentDefinitions($workspaceRoot) as $name => $_definition) {
         $items[] = ['label' => $name, 'kind' => 7, 'detail' => 'Project PAM component'];
     }
-    foreach (['p-if', 'p-else-if', 'p-else', 'p-for', 'p-key', 'p-index', 'bind:value', 'bind:checked', 'recipe', 'variant:'] as $directive) {
+    foreach (['p-if', 'p-else-if', 'p-else', 'p-for', 'p-key', 'p-index', 'p-model', 'p-model:checked', 'bind:value', 'bind:checked', 'recipe', 'variant:'] as $directive) {
         $items[] = ['label' => $directive, 'kind' => 14, 'detail' => 'PAM template directive'];
     }
     preg_match_all('/public\s+(?:readonly\s+)?[\\?A-Za-z0-9_|]+\s+\$([A-Za-z_][A-Za-z0-9_]*)/', $source, $properties);
@@ -384,6 +384,8 @@ function pamHelp(string $word): ?string
         'p-for' => '**p-for** — Repeats the element for an iterable or positive integer. Pair it with a stable key.',
         'bind:value' => '**bind:value** — Two-way native input binding to typed component state.',
         'bind:checked' => '**bind:checked** — Two-way native boolean binding.',
+        'p-model' => '**p-model** — Vue-like two-way binding. Inputs bind value; Switch and Toggle bind checked state.',
+        'p-model:checked' => '**p-model:checked** — Explicit two-way boolean binding for checked controls.',
         '@press' => '**@press** — Calls a component action after a native press event.',
         'Show' => '**Show** — Declarative conditional rendering with a typed `when` expression.',
         'Match' => '**Match** — Strictly matches a value against `Case` branches.',

--- a/packages/native/resources/pam-native.custom-data.json
+++ b/packages/native/resources/pam-native.custom-data.json
@@ -288,6 +288,8 @@
         { "name": "borderStyle", "values": [{ "name": "solid" }, { "name": "dashed" }, { "name": "dotted" }] },
         { "name": "opacity" },
         { "name": "model", "description": "Two-way component property binding for Input." },
+        { "name": "p-model", "description": "Vue-like two-way binding to typed component state." },
+        { "name": "p-model:checked", "description": "Explicit two-way boolean binding for checked controls." },
         { "name": "bind:value", "description": "Two-way Input binding to a component property." },
         { "name": "bind:checked", "description": "Two-way Switch binding to a boolean component property." },
         { "name": "@press", "description": "Short event syntax for a component method." },

--- a/packages/native/src/App.php
+++ b/packages/native/src/App.php
@@ -13,6 +13,8 @@ use Throwable;
 
 final class App
 {
+    private static ?Theme $activeTheme = null;
+
     private function __construct()
     {
     }
@@ -61,7 +63,18 @@ final class App
 
     public static function theme(Theme $theme): void
     {
+        self::$activeTheme = $theme;
         $theme->apply();
+    }
+
+    public static function activeTheme(): ?Theme
+    {
+        return self::$activeTheme;
+    }
+
+    public static function appearance(): UserInterfaceAppearance
+    {
+        return Runtime::windowMetrics()->appearance;
     }
 
     public static function component(string $tag, string $view): void

--- a/packages/native/src/Element.php
+++ b/packages/native/src/Element.php
@@ -258,6 +258,28 @@ abstract class Element implements Renderable
         return $this->elementKey;
     }
 
+    /**
+     * Applies semantic theme defaults without replacing authored properties.
+     * Descendants are handled in one retained-tree pass before encoding.
+     *
+     * @param array<int, array<int, string|int|float|bool>> $defaultsByKind
+     */
+    final public function withThemeDefaults(array $defaultsByKind): static
+    {
+        $copy = clone $this;
+        foreach ($defaultsByKind[$this->kind->value] ?? [] as $key => $value) {
+            if (!array_key_exists($key, $copy->properties)) {
+                $copy->properties[$key] = $value;
+            }
+        }
+        $copy->children = array_map(
+            static fn (Element $child): Element => $child->withThemeDefaults($defaultsByKind),
+            $copy->children,
+        );
+
+        return $copy;
+    }
+
     final protected function withProperty(
         PropKey $key,
         string|int|float|bool|BinaryValue $value,

--- a/packages/native/src/Internal/Runtime.php
+++ b/packages/native/src/Internal/Runtime.php
@@ -8,6 +8,7 @@ use Closure;
 use JsonException;
 use LogicException;
 use Pam\Native\AppState;
+use Pam\Native\App;
 use Pam\Native\Element;
 use Pam\Native\EventKind;
 use Pam\Native\MemoryPressure;
@@ -106,6 +107,13 @@ final class Runtime
 
                 if (!$element instanceof Element) {
                     throw new LogicException('The Pam Native root must be renderable.');
+                }
+                $theme = App::activeTheme();
+                if ($theme !== null) {
+                    $element = Profiler::measure(
+                        'php.theme',
+                        static fn (): Element => $theme->applyTo($element),
+                    );
                 }
 
                 $encoder = self::$encoder ??= new TreeEncoder();

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -911,6 +911,27 @@ final class TemplateRenderer
             $attributes,
             self::styleSheetFonts($data),
         );
+        if (isset($attributes['p-model'])) {
+            $binding = in_array($tag, ['Switch', 'Toggle'], true)
+                ? 'bind:checked'
+                : 'bind:value';
+            if (isset($attributes[$binding])) {
+                throw new RuntimeException(
+                    "p-model cannot be combined with {$binding} on {$tag}.",
+                );
+            }
+            $attributes[$binding] = $attributes['p-model'];
+            unset($attributes['p-model']);
+        }
+        if (isset($attributes['p-model:checked'])) {
+            if (isset($attributes['bind:checked'])) {
+                throw new RuntimeException(
+                    "p-model:checked cannot be combined with bind:checked on {$tag}.",
+                );
+            }
+            $attributes['bind:checked'] = $attributes['p-model:checked'];
+            unset($attributes['p-model:checked']);
+        }
         if (isset($attributes['bind:value'])) {
             $attributes[':value'] = $attributes['bind:value'];
             $attributes['model'] = ltrim(

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.8.4';
+    public const string SDK_VERSION = '0.8.5';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/src/Theme.php
+++ b/packages/native/src/Theme.php
@@ -9,6 +9,8 @@ final readonly class Theme
     /** @param array<string, array<int, string|int|float|bool>> $classes */
     public function __construct(
         public array $classes,
+        /** @var array<int, array<int, string|int|float|bool>> */
+        public array $elementDefaults = [],
     ) {
     }
 
@@ -137,6 +139,27 @@ final readonly class Theme
                 PropKey::BorderColor->value => $palette['focus'],
                 PropKey::BorderWidth->value => 3.0,
             ],
+        ], [
+            NodeKind::Screen->value => [
+                PropKey::FlexGrow->value => 1.0,
+                PropKey::BackgroundColor->value => $palette['surface'],
+            ],
+            NodeKind::Text->value => [
+                PropKey::TextColor->value => $palette['text'],
+            ],
+            NodeKind::Button->value => [
+                PropKey::BackgroundColor->value => $palette['accent'],
+                PropKey::TextColor->value => $palette['onAccent'],
+                PropKey::MinHeight->value => DesignTokens::TouchTarget,
+                PropKey::PaddingHorizontal->value => DesignTokens::Space4,
+                PropKey::BorderRadius->value => DesignTokens::RadiusMedium,
+            ],
+            NodeKind::Input->value => [
+                PropKey::BackgroundColor->value => $palette['surfaceMuted'],
+                PropKey::TextColor->value => $palette['text'],
+                PropKey::PlaceholderColor->value => $palette['mutedText'],
+                PropKey::MinHeight->value => DesignTokens::TouchTarget,
+            ],
         ]);
     }
 
@@ -153,6 +176,11 @@ final readonly class Theme
         foreach ($this->classes as $name => $properties) {
             TemplateRegistry::style($name, $properties);
         }
+    }
+
+    public function applyTo(Element $element): Element
+    {
+        return $element->withThemeDefaults($this->elementDefaults);
     }
 
     /** @param array<string, int> $palette */

--- a/packages/native/tests/language2.php
+++ b/packages/native/tests/language2.php
@@ -25,6 +25,32 @@ $assert(
     'Language 2 Show must render its typed truthy branch.',
 );
 
+$modelScope = new class extends \Pam\Native\Component {
+    public string $search = 'Loki';
+    public bool $enabled = false;
+};
+$modelTree = TemplateCompiler::compile(
+    '<Column><Input p-model="$search" /><Switch p-model="$enabled" /></Column>',
+    'Language2Model.pam',
+    LanguageVersion::Language2,
+);
+$modelElement = TemplateRenderer::render($modelTree, $modelScope, []);
+$modelInput = $modelElement->children()[0] ?? null;
+$modelSwitch = $modelElement->children()[1] ?? null;
+$assert(
+    $modelInput instanceof \Pam\Native\Element
+        && $modelSwitch instanceof \Pam\Native\Element
+        && ($modelInput->properties()[PropKey::Value->value] ?? null) === 'Loki'
+        && ($modelSwitch->properties()[PropKey::Checked->value] ?? null) === false,
+    'p-model must read typed input and checked state without PHP markup expressions.',
+);
+($modelInput->events()[\Pam\Native\EventKind::Change->value])('IPTV');
+($modelSwitch->events()[\Pam\Native\EventKind::Toggle->value])(true);
+$assert(
+    $modelScope->search === 'IPTV' && $modelScope->enabled,
+    'p-model must write native input and checked events back to component state.',
+);
+
 $matchTree = TemplateCompiler::compile(
     '<Match value="$mode"><Case value="compact"><Text>Compact</Text></Case><Default><Text>Default</Text></Default></Match>',
     'Language2Match.pam',

--- a/packages/native/tests/performance.php
+++ b/packages/native/tests/performance.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Pam\Native\Internal\TreeEncoder;
+use Pam\Native\Theme;
 use Pam\Native\UI\Column;
 use Pam\Native\UI\Text;
 
@@ -32,16 +33,28 @@ for ($iteration = 0; $iteration < 500; $iteration++) {
 }
 $steadyMs = (hrtime(true) - $started) / 1_000_000 / 500;
 
+$theme = Theme::pamLab();
+$started = hrtime(true);
+for ($iteration = 0; $iteration < 500; $iteration++) {
+    $theme->applyTo($tree);
+}
+$themeMs = (hrtime(true) - $started) / 1_000_000 / 500;
+
 $firstBudget = (float) (getenv('PAM_PERF_FIRST_FRAME_MS') ?: 40);
 $steadyBudget = (float) (getenv('PAM_PERF_STEADY_FRAME_MS') ?: 1);
 fwrite(STDOUT, json_encode([
     'nodes' => 1_001,
     'firstFrameMs' => round($firstMs, 3),
     'steadyFrameMs' => round($steadyMs, 3),
-    'budgets' => ['firstFrameMs' => $firstBudget, 'steadyFrameMs' => $steadyBudget],
+    'themeDefaultsMs' => round($themeMs, 3),
+    'budgets' => [
+        'firstFrameMs' => $firstBudget,
+        'steadyFrameMs' => $steadyBudget,
+        'themeDefaultsMs' => $steadyBudget,
+    ],
 ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES)."\n");
 
-if ($firstMs > $firstBudget || $steadyMs > $steadyBudget) {
+if ($firstMs > $firstBudget || $steadyMs > $steadyBudget || $themeMs > $steadyBudget) {
     fwrite(STDERR, "Pam Native performance budget exceeded.\n");
     exit(1);
 }

--- a/packages/native/tests/performance.php
+++ b/packages/native/tests/performance.php
@@ -42,6 +42,7 @@ $themeMs = (hrtime(true) - $started) / 1_000_000 / 500;
 
 $firstBudget = (float) (getenv('PAM_PERF_FIRST_FRAME_MS') ?: 40);
 $steadyBudget = (float) (getenv('PAM_PERF_STEADY_FRAME_MS') ?: 1);
+$themeBudget = (float) (getenv('PAM_PERF_THEME_DEFAULTS_MS') ?: 4);
 fwrite(STDOUT, json_encode([
     'nodes' => 1_001,
     'firstFrameMs' => round($firstMs, 3),
@@ -50,11 +51,13 @@ fwrite(STDOUT, json_encode([
     'budgets' => [
         'firstFrameMs' => $firstBudget,
         'steadyFrameMs' => $steadyBudget,
-        'themeDefaultsMs' => $steadyBudget,
+        // Theme application intentionally clones the complete immutable tree once.
+        // Keep its cross-runner budget separate from the retained steady-frame path.
+        'themeDefaultsMs' => $themeBudget,
     ],
 ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES)."\n");
 
-if ($firstMs > $firstBudget || $steadyMs > $steadyBudget || $themeMs > $steadyBudget) {
+if ($firstMs > $firstBudget || $steadyMs > $steadyBudget || $themeMs > $themeBudget) {
     fwrite(STDERR, "Pam Native performance budget exceeded.\n");
     exit(1);
 }

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4423,6 +4423,30 @@ $assert(
         && Theme::contrastRatio(0xFF4ADE80, 0xFF052E16) >= 4.5,
     'Theme contrast validation must enforce WCAG AA semantic pairs.',
 );
+$darkDefaults = Theme::pamLab()->applyTo(
+    Screen::make(
+        Text::make('Visible'),
+        Button::make('Action'),
+    ),
+);
+$defaultText = $darkDefaults->children()[0] ?? null;
+$defaultButton = $darkDefaults->children()[1] ?? null;
+$assert(
+    isset($darkDefaults->properties()[PropKey::BackgroundColor->value])
+        && $defaultText instanceof \Pam\Native\Element
+        && isset($defaultText->properties()[PropKey::TextColor->value])
+        && $defaultButton instanceof \Pam\Native\Element
+        && isset($defaultButton->properties()[PropKey::BackgroundColor->value])
+        && isset($defaultButton->properties()[PropKey::TextColor->value]),
+    'Applied themes must give imperative trees visible semantic defaults.',
+);
+$authoredText = Theme::pamLab()->applyTo(
+    Text::make('Brand')->style(new Style(textColor: 0xFFFF00FF)),
+);
+$assert(
+    $authoredText->properties()[PropKey::TextColor->value] === 0xFFFF00FF,
+    'Theme defaults must never replace authored imperative properties.',
+);
 
 $template = new class extends Component {
     private string $name = 'PHP';
@@ -6215,8 +6239,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.8.4',
-    'The runtime SDK contract must match the 0.8.4 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.8.5',
+    'The runtime SDK contract must match the 0.8.5 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
## Summary
- add Vue-like p-model bindings with editor support
- apply semantic defaults to imperative trees and expose native appearance
- stage Android bundles in durable storage instead of purgeable cache
- add pixel-level first-frame and performance regressions
- prepare Native 0.8.5

## Validation
- PHP SDK, performance and navigation suites
- Cargo tests and Clippy
- 53 Android instrumented tests on API 36.1
- visual launch and screenshot assertions on API 36.1 emulator and Samsung SM-S918B
