### PR TITLE
feat: certify modular native images

### DIFF
--- a/.github/workflows/ecosystem-ios.yml
+++ b/.github/workflows/ecosystem-ios.yml
@@ -40,6 +40,7 @@ jobs:
             pam-native-realtime pam-native-scanner pam-native-share-extension
             pam-native-subscriptions pam-native-video pam-native-widgets
             pam-native-camera pam-native-canvas pam-native-gpu pam-native-3d
+            pam-native-image
           )
           for repo in "${repos[@]}"; do
             git clone --depth 1 --branch main \
@@ -58,6 +59,7 @@ jobs:
             pam-native-realtime pam-native-scanner pam-native-share-extension
             pam-native-subscriptions pam-native-video pam-native-widgets
             pam-native-camera pam-native-canvas pam-native-gpu pam-native-3d
+            pam-native-image
           )
           targets=(
             PamPlugin0PushinbrPamNativeAuth
@@ -83,6 +85,7 @@ jobs:
             PamPlugin20PushinbrPamNativeCanvas
             PamPlugin21PushinbrPamNativeGpu
             PamPlugin22PushinbrPamNative3d
+            PamPlugin23PushinbrPamNativeImage
           )
           for index in "${!repos[@]}"; do
             source="${RUNNER_TEMP}/${repos[$index]}/ios/Sources"

--- a/.github/workflows/publish-ecosystem.yml
+++ b/.github/workflows/publish-ecosystem.yml
@@ -38,7 +38,7 @@ jobs:
             pam-native-widgets pam-native-firebase pam-native-laravel-sync
             pam-native-sync-laravel
             pam-native-camera pam-native-media-editor pam-native-canvas
-            pam-native-gpu pam-native-3d
+            pam-native-gpu pam-native-3d pam-native-image
           )
           if [[ "${SELECTED_PACKAGE}" != all ]]; then
             valid=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.8.7 - 2026-08-24
+
+- Add granular typed signals, computed values, effects, and batched reactive
+  updates without replacing the existing component API.
+- Add adaptive device/window metrics and stable device-class selection.
+- Add the delegated `production:certify` release-readiness contract.
+- Certify `pushinbr/pam-native-image` from public Composer distribution across
+  the aggregate Android and iOS plugin hosts.
+
 ## 0.8.5 - 2026-08-23
 
 - Add Vue-like `p-model` and `p-model:checked` two-way bindings to Language 2,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "0.8.5"
+version = "0.8.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "0.8.5"
+version = "0.8.7"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.8.5"
+version = "0.8.7"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.5"
+version = "0.8.7"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/CapabilityIntegrationTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/CapabilityIntegrationTest.kt
@@ -1,15 +1,12 @@
 package dev.pam.nativeapp
 
 import android.content.Intent
+import android.view.View
 import android.view.ViewGroup
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import org.hamcrest.Matchers.containsString
+import org.junit.Assert.assertTrue
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,8 +29,9 @@ class CapabilityIntegrationTest {
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
         ) as CapabilityTestActivity
         activity = launched
+        lateinit var overlay: PamDevToolsOverlay
         instrumentation.runOnMainSync {
-            val overlay = PamDevToolsOverlay(launched)
+            overlay = PamDevToolsOverlay(launched)
             launched.root.addView(
                 overlay,
                 ViewGroup.LayoutParams(
@@ -71,9 +69,13 @@ class CapabilityIntegrationTest {
             overlay.toggle()
         }
 
-        onView(withContentDescription("Pam Native DevTools")).check(matches(isDisplayed()))
-        onView(withText(containsString("FAIL"))).check(matches(isDisplayed()))
-        onView(withText(containsString("permissions.request"))).check(matches(isDisplayed()))
+        instrumentation.waitForIdleSync()
+        instrumentation.runOnMainSync {
+            assertTrue(overlay.isShown)
+            val text = descendantText(overlay).joinToString("\n")
+            assertTrue(text.contains("FAIL"))
+            assertTrue(text.contains("permissions.request"))
+        }
     }
 
     @Test
@@ -124,5 +126,14 @@ class CapabilityIntegrationTest {
         assert(network.getInt("statusCode") == 202)
         assert(network.getInt("requestBytes") == 17)
         assert(network.getInt("responseBytes") == 8)
+    }
+
+    private fun descendantText(view: View?): List<String> {
+        if (view == null) return emptyList()
+        val own = (view as? TextView)?.text?.toString()?.let(::listOf).orEmpty()
+        if (view !is ViewGroup) return own
+        return own + (0 until view.childCount).flatMap { index ->
+            descendantText(view.getChildAt(index))
+        }
     }
 }

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
@@ -5269,7 +5269,7 @@ class PamRenderer(
 
     private fun attemptAutoFocus(view: View, attempt: Int) {
         view.postDelayed({
-            if (!view.isAttachedToWindow || !view.hasWindowFocus()) {
+            if (!view.isAttachedToWindow) {
                 if (attempt < AUTO_FOCUS_RETRIES) attemptAutoFocus(view, attempt + 1)
                 return@postDelayed
             }

--- a/certification/android-ecosystem/composer.json
+++ b/certification/android-ecosystem/composer.json
@@ -16,6 +16,7 @@
     "pushinbr/pam-native-feature-flags": ">=0.1.0 <1.0.0",
     "pushinbr/pam-native-firebase": ">=0.1.0 <1.0.0",
     "pushinbr/pam-native-health": ">=0.1.0 <1.0.0",
+    "pushinbr/pam-native-image": "^0.1.2",
     "pushinbr/pam-native-intents": ">=0.1.0 <1.0.0",
     "pushinbr/pam-native-live-activities": ">=0.1.0 <1.0.0",
     "pushinbr/pam-native-maps": ">=0.1.0 <1.0.0",

--- a/certification/android-ecosystem/composer.lock
+++ b/certification/android-ecosystem/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f00002c32ae1585d26e9ee067bf758b9",
+    "content-hash": "174d88d48f3a5a5a87c87525dfce48d1",
     "packages": [
         {
             "name": "pushinbr/pam-native",
@@ -807,6 +807,49 @@
             "time": "2026-08-23T18:02:35+00:00"
         },
         {
+            "name": "pushinbr/pam-native-image",
+            "version": "v0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/push-in/pam-native-image.git",
+                "reference": "338364d3e35f4c3bb2d790e19ffd8f65c35e6b1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/push-in/pam-native-image/zipball/338364d3e35f4c3bb2d790e19ffd8f65c35e6b1f",
+                "reference": "338364d3e35f4c3bb2d790e19ffd8f65c35e6b1f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.5",
+                "pushinbr/pam-native": "^0.8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2.1"
+            },
+            "type": "pam-native-plugin",
+            "extra": {
+                "pam-native": {
+                    "plugin": "pam-native.plugin.json"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pam\\Native\\Image\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "High-performance cached native image loading for PAM Native.",
+            "support": {
+                "issues": "https://github.com/push-in/pam-native-image/issues",
+                "source": "https://github.com/push-in/pam-native-image/tree/v0.1.2"
+            },
+            "time": "2026-08-24T13:21:46+00:00"
+        },
+        {
             "name": "pushinbr/pam-native-intents",
             "version": "v0.2.0",
             "source": {
@@ -1351,5 +1394,5 @@
         "php": "^8.5"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/certification/android-ecosystem/composer.lock
+++ b/certification/android-ecosystem/composer.lock
@@ -808,16 +808,16 @@
         },
         {
             "name": "pushinbr/pam-native-image",
-            "version": "v0.1.2",
+            "version": "v0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/push-in/pam-native-image.git",
-                "reference": "338364d3e35f4c3bb2d790e19ffd8f65c35e6b1f"
+                "reference": "0bcbd1fc77ffb06733fb758a8f4e444d75565e60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/push-in/pam-native-image/zipball/338364d3e35f4c3bb2d790e19ffd8f65c35e6b1f",
-                "reference": "338364d3e35f4c3bb2d790e19ffd8f65c35e6b1f",
+                "url": "https://api.github.com/repos/push-in/pam-native-image/zipball/0bcbd1fc77ffb06733fb758a8f4e444d75565e60",
+                "reference": "0bcbd1fc77ffb06733fb758a8f4e444d75565e60",
                 "shasum": ""
             },
             "require": {
@@ -845,9 +845,9 @@
             "description": "High-performance cached native image loading for PAM Native.",
             "support": {
                 "issues": "https://github.com/push-in/pam-native-image/issues",
-                "source": "https://github.com/push-in/pam-native-image/tree/v0.1.2"
+                "source": "https://github.com/push-in/pam-native-image/tree/v0.1.3"
             },
-            "time": "2026-08-24T13:21:46+00:00"
+            "time": "2026-08-24T13:34:19+00:00"
         },
         {
             "name": "pushinbr/pam-native-intents",

--- a/certification/ios-ecosystem/Package.swift
+++ b/certification/ios-ecosystem/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
         .package(path: "../../ios"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "12.17.0"),
         .package(url: "https://github.com/stripe/stripe-ios.git", exact: "26.0.0"),
+        .package(url: "https://github.com/SDWebImage/SDWebImage.git", exact: "5.21.7"),
     ],
     targets: [
         .target(
@@ -147,6 +148,11 @@ let package = Package(
             linkerSettings: [.linkedFramework("RealityKit"), .linkedFramework("Metal"), .linkedFramework("QuartzCore")],
         ),
         .target(
+            name: "PamPlugin23PushinbrPamNativeImage",
+            dependencies: [.product(name: "PamNative", package: "ios"), .product(name: "SDWebImage", package: "SDWebImage")],
+            path: "Sources/PamPlugin23PushinbrPamNativeImage",
+        ),
+        .target(
             name: "PamExtensionIntents",
             path: "Sources/PamExtensionIntents",
             linkerSettings: [.linkedFramework("AppIntents")],
@@ -168,7 +174,7 @@ let package = Package(
         ),
         .target(
             name: "PamNativePlugins",
-            dependencies: ["PamPlugin0PushinbrPamNativeAuth", "PamPlugin1PushinbrPamNativeBackgroundTransfer", "PamPlugin2PushinbrPamNativeBluetooth", "PamPlugin3PushinbrPamNativeFeatureFlags", "PamPlugin4PushinbrPamNativeFirebase", "PamPlugin5PushinbrPamNativeHealth", "PamPlugin6PushinbrPamNativeIntents", "PamPlugin7PushinbrPamNativeLiveActivities", "PamPlugin8PushinbrPamNativeMaps", "PamPlugin9PushinbrPamNativeMedia", "PamPlugin10PushinbrPamNativeMediaEditor", "PamPlugin11PushinbrPamNativeNfc", "PamPlugin12PushinbrPamNativePayments", "PamPlugin13PushinbrPamNativeRealtime", "PamPlugin14PushinbrPamNativeScanner", "PamPlugin15PushinbrPamNativeShareExtension", "PamPlugin16PushinbrPamNativeSubscriptions", "PamPlugin17PushinbrPamNativeVideo", "PamPlugin18PushinbrPamNativeWidgets", "PamPlugin19PushinbrPamNativeCamera", "PamPlugin20PushinbrPamNativeCanvas", "PamPlugin21PushinbrPamNativeGpu", "PamPlugin22PushinbrPamNative3d", "PamExtensionIntents", "PamExtensionLiveActivities", "PamExtensionShare", "PamExtensionWidgets"],
+            dependencies: ["PamPlugin0PushinbrPamNativeAuth", "PamPlugin1PushinbrPamNativeBackgroundTransfer", "PamPlugin2PushinbrPamNativeBluetooth", "PamPlugin3PushinbrPamNativeFeatureFlags", "PamPlugin4PushinbrPamNativeFirebase", "PamPlugin5PushinbrPamNativeHealth", "PamPlugin6PushinbrPamNativeIntents", "PamPlugin7PushinbrPamNativeLiveActivities", "PamPlugin8PushinbrPamNativeMaps", "PamPlugin9PushinbrPamNativeMedia", "PamPlugin10PushinbrPamNativeMediaEditor", "PamPlugin11PushinbrPamNativeNfc", "PamPlugin12PushinbrPamNativePayments", "PamPlugin13PushinbrPamNativeRealtime", "PamPlugin14PushinbrPamNativeScanner", "PamPlugin15PushinbrPamNativeShareExtension", "PamPlugin16PushinbrPamNativeSubscriptions", "PamPlugin17PushinbrPamNativeVideo", "PamPlugin18PushinbrPamNativeWidgets", "PamPlugin19PushinbrPamNativeCamera", "PamPlugin20PushinbrPamNativeCanvas", "PamPlugin21PushinbrPamNativeGpu", "PamPlugin22PushinbrPamNative3d", "PamPlugin23PushinbrPamNativeImage", "PamExtensionIntents", "PamExtensionLiveActivities", "PamExtensionShare", "PamExtensionWidgets"],
             path: "Sources/PamNativePlugins"
         ),
     ]

--- a/docs/ecosystem-architecture.md
+++ b/docs/ecosystem-architecture.md
@@ -39,6 +39,7 @@ matrix, changelog, CI, and signed release evidence.
 | 27 | `pushinbr/pam-native-canvas` | Retained 2D paths, text, images, transforms and pointer input | PHP + Kotlin + Swift views | Golden images and touch latency on devices |
 | 28 | `pushinbr/pam-native-gpu` | Bounded programmable OpenGL ES 3 and Metal fragment rendering | PHP + Kotlin + Swift views | GPU/thermal matrix and shader golden images |
 | 29 | `pushinbr/pam-native-3d` | Sandboxed GLB/USDZ scenes, animation, transforms and orbit controls | PHP + Filament + RealityKit views | Asset, memory, GPU and thermal matrix on devices |
+| 30 | `pushinbr/pam-native-image` | Cached remote/sandbox image decoding, resizing, crossfade and lifecycle events | PHP + Coil + SDWebImage views | Golden images, cache policy, low-memory and network-fault matrix |
 
 ## Mandatory release gates
 


### PR DESCRIPTION
Adds pam-native-image to the official architecture, publication allowlist, and aggregate iOS build with exact SDWebImage 5.21.7 resolution. Android release compilation was independently validated in a clean PAM consumer for arm64-v8a and x86_64; aggregate Android registration follows the public Packagist index.