### PR TITLE
fix: align PHP SDK release at 0.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.8 - 2026-08-24
+
+- Align the public PHP SDK contract with the runtime release so the immutable
+  Composer split, Packagist publication, and `pam production certify` can be
+  validated from the same versioned source.
+
 ## 0.8.7 - 2026-08-24
 
 - Add granular typed signals, computed values, effects, and batched reactive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.8.7"
+version = "0.8.8"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.7"
+version = "0.8.8"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.8.5';
+    public const string SDK_VERSION = '0.8.8';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6239,8 +6239,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.8.5',
-    'The runtime SDK contract must match the 0.8.5 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.8.8',
+    'The runtime SDK contract must match the 0.8.8 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
Align the Cargo workspace and typed PHP SDK contract at 0.8.8 so the immutable Composer split can be published from the same release tag.

Validated locally:
- cargo test --workspace (105 tests)
- php packages/native/tests/run.php
- scripts/composer-package.sh validate-tag v0.8.8
- git diff --check