### PR TITLE
feat: PAM Style Engine 1.0

### DIFF
--- a/packages/native/bin/pam-native-style
+++ b/packages/native/bin/pam-native-style
@@ -1,0 +1,63 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$autoloadCandidates = [dirname(__DIR__, 3).'/autoload.php', dirname(__DIR__).'/vendor/autoload.php'];
+$loaded = false;
+foreach ($autoloadCandidates as $autoload) {
+    if (is_file($autoload)) { require $autoload; $loaded = true; break; }
+}
+if (!$loaded) {
+    spl_autoload_register(static function (string $class): void {
+        $prefix = 'Pam\\Native\\';
+        if (!str_starts_with($class, $prefix)) return;
+        $path = dirname(__DIR__).'/src/'.str_replace('\\', '/', substr($class, strlen($prefix))).'.php';
+        if (is_file($path)) require $path;
+    });
+}
+
+use Pam\Native\Internal\ScopedStyleCompiler;
+use Pam\Native\Internal\StyleTokenGenerator;
+use Pam\Native\Style\StylePropertyCatalog;
+
+$command = $argv[1] ?? '';
+try {
+    if ($command === 'manifest') {
+        fwrite(STDOUT, json_encode(StylePropertyCatalog::manifest(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n");
+        exit(0);
+    }
+    $file = $argv[2] ?? '';
+    if (!in_array($command, ['inspect', 'tokens'], true) || $file === '' || !is_file($file)) {
+        fwrite(STDERR, "Usage:\n  pam-native-style manifest\n  pam-native-style inspect <file.css>\n  pam-native-style tokens <file.css> [output-directory]\n");
+        exit(2);
+    }
+    $source = file_get_contents($file);
+    if (!is_string($source)) throw new RuntimeException("Cannot read {$file}.");
+    $sheet = ScopedStyleCompiler::compile($source, $file);
+    if ($command === 'inspect') {
+        $report = [
+            'valid' => true,
+            'fingerprint' => $sheet['styleFingerprint'],
+            'scope' => $sheet['scope'],
+            'rules' => count($sheet['cascadeRules']),
+            'queries' => count($sheet['queries']),
+            'keyframes' => count($sheet['keyframes']),
+            'dependencies' => $sheet['styleIr']['dependencies'],
+            'compatibility' => $sheet['styleCompatibility'],
+            'sourceMap' => $sheet['styleSourceMap'],
+        ];
+        fwrite(STDOUT, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n");
+        exit(0);
+    }
+    $output = $argv[3] ?? 'generated/style';
+    if (!is_dir($output) && !mkdir($output, 0755, true) && !is_dir($output)) throw new RuntimeException("Cannot create {$output}.");
+    $generated = StyleTokenGenerator::generate($sheet['tokens']);
+    foreach (['php' => 'Tokens.php', 'kotlin' => 'Tokens.kt', 'swift' => 'Tokens.swift'] as $language => $target) {
+        if (file_put_contents(rtrim($output, '/').'/'.$target, $generated[$language]) === false) throw new RuntimeException("Cannot write {$target}.");
+    }
+    fwrite(STDOUT, "Generated typed style tokens in {$output}.\n");
+} catch (Throwable $error) {
+    fwrite(STDERR, $error->getMessage()."\n");
+    exit(1);
+}

--- a/packages/native/composer.json
+++ b/packages/native/composer.json
@@ -29,7 +29,8 @@
         "bin/pam-native-format",
         "bin/pam-native-language-server",
         "bin/pam-native-optimize",
-        "bin/pam-native-routes"
+        "bin/pam-native-routes",
+        "bin/pam-native-style"
     ],
     "extra": {
         "pam": {
@@ -180,6 +181,10 @@
                 "native:routes": {
                     "script": "bin/pam-native-routes",
                     "description": "Inspect PAM Native routes"
+                },
+                "style": {
+                    "script": "bin/pam-native-style",
+                    "description": "Inspect, explain and generate PAM Native styles"
                 },
                 "make:component": {
                     "bin": "bin/pam-native",

--- a/packages/native/phpstan-singularity.neon
+++ b/packages/native/phpstan-singularity.neon
@@ -37,5 +37,22 @@ parameters:
         - src/Component.php
         - src/Internal/CompiledTemplateNode.php
         - src/Internal/ScopedStyleCompiler.php
+        - src/Internal/StyleIrCompiler.php
+        - src/Internal/StyleQueryCompiler.php
+        - src/Internal/StyleSelectorCompiler.php
+        - src/Internal/StyleTokenGenerator.php
+        - src/Internal/StyleValueCompiler.php
         - src/Renderable.php
+        - src/Style/StyleCompatibility.php
+        - src/Style/StyleExpressionKind.php
+        - src/Style/StyleInvalidationKind.php
+        - src/Style/StylePropertyCatalog.php
+        - src/Style/StylePropertyDefinition.php
+        - src/Style/StyleQueryFeature.php
+        - src/Style/StyleQueryKind.php
+        - src/Style/StyleQueryOperator.php
+        - src/Style/StyleQueryValueKind.php
+        - src/Style/StyleRenderCost.php
+        - src/Style/StyleScope.php
+        - src/Style/StyleValueUnit.php
         - src/TemplateRegistry.php

--- a/packages/native/src/Internal/Language2StyleCompiler.php
+++ b/packages/native/src/Internal/Language2StyleCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pam\Native\Internal;
 
+use Pam\Native\Style\StyleQueryKind;
 use RuntimeException;
 
 /** Extracts Language 2 constructs into a deterministic, runtime-free style IR. */
@@ -44,10 +45,13 @@ final class Language2StyleCompiler
                 continue;
             }
 
-            if (preg_match('/^(.+):(pressed|focused|disabled|selected|checked|hovered)$/D', $header, $match) === 1) {
+            if (preg_match('/^(.+):(pressed|focus|focused|focus-visible|disabled|selected|checked|hover|hovered|active|loading|error)$/D', $header, $match) === 1) {
                 $selector = trim($match[1]);
                 self::assertSelector($selector, $name);
-                $states[$selector][$match[2]] = ScopedStyleCompiler::compileDeclarations(
+                $state = match ($match[2]) {
+                    'focused' => 'focus', 'hovered' => 'hover', default => $match[2],
+                };
+                $states[$selector][$state] = ScopedStyleCompiler::compileDeclarations(
                     $body,
                     $tokens,
                     $name,
@@ -61,10 +65,13 @@ final class Language2StyleCompiler
             }
 
             if (preg_match('/^@(media|container)\s+(.+)$/D', $header, $match) === 1) {
-                self::assertQuery($match[1], trim($match[2]), $name);
+                $queryAst = StyleQueryCompiler::compile(trim($match[2]), $name);
                 $queries[] = [
-                    'kind' => $match[1] === 'media' ? 1 : 2,
+                    'kind' => $match[1] === 'media'
+                        ? StyleQueryKind::Media->value
+                        : StyleQueryKind::Container->value,
                     'condition' => trim($match[2]),
+                    'ast' => $queryAst,
                     'styles' => ScopedStyleCompiler::compile($body, $name.' '.$header),
                 ];
                 continue;
@@ -72,6 +79,17 @@ final class Language2StyleCompiler
 
             if (preg_match('/^@keyframes\s+([A-Za-z][A-Za-z0-9_-]*)$/D', $header, $match) === 1) {
                 $keyframes[$match[1]] = self::keyframes($body, $tokens, $name);
+                continue;
+            }
+
+            if (preg_match('/^@layer\s+([A-Za-z][A-Za-z0-9_.-]*)$/D', $header) === 1) {
+                $layer = self::extract($body, $name.' '.$header);
+                $tokens = [...$tokens, ...$layer['tokens']];
+                $states = array_replace_recursive($states, $layer['states']);
+                $recipes = array_replace_recursive($recipes, $layer['recipes']);
+                $queries = [...$queries, ...$layer['queries']];
+                $keyframes = [...$keyframes, ...$layer['keyframes']];
+                $legacy[] = $layer['source'];
                 continue;
             }
 
@@ -229,19 +247,7 @@ final class Language2StyleCompiler
 
     private static function assertSelector(string $selector, string $name): void
     {
-        if (
-            preg_match('/^(?:\.[A-Za-z_][A-Za-z0-9_-]*|[A-Za-z][A-Za-z0-9_.-]*)$/D', $selector) !== 1
-        ) {
-            throw new RuntimeException("Unsupported state selector {$selector} in {$name}.");
-        }
+        StyleSelectorCompiler::compile($selector, $name);
     }
 
-    private static function assertQuery(string $kind, string $condition, string $name): void
-    {
-        $media = '/^\((?:min|max)-(?:width|height):\s*[0-9]+(?:\.[0-9]+)?(?:dp|px)\)$/D';
-        $container = '/^(?:[A-Za-z][A-Za-z0-9_-]*\s+)?\((?:min|max)-(?:width|height):\s*[0-9]+(?:\.[0-9]+)?(?:dp|px)\)$/D';
-        if (preg_match($kind === 'media' ? $media : $container, $condition) !== 1) {
-            throw new RuntimeException("Unsupported @{$kind} condition {$condition} in {$name}.");
-        }
-    }
 }

--- a/packages/native/src/Internal/PamPhpCompiler.php
+++ b/packages/native/src/Internal/PamPhpCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pam\Native\Internal;
 
+use Pam\Native\Style\StyleScope;
 use FilesystemIterator;
 use JsonException;
 use RecursiveDirectoryIterator;
@@ -112,7 +113,8 @@ final class PamPhpCompiler
             );
         }
 
-        [$php, $template, $templateLine, $style, $language] = self::split($contents, $source);
+        [$php, $template, $templateLine, $style, $language, $styleScope] =
+            self::split($contents, $source);
         $style = self::resolvedStyleSheet($style, $source);
         self::validateHotPath($php, $source);
         [$className, $tag] = self::classIdentity($php, $source);
@@ -123,7 +125,7 @@ final class PamPhpCompiler
             .DIRECTORY_SEPARATOR.$cacheKey.'.template.json';
         $metadataFile = rtrim($cachePath, DIRECTORY_SEPARATOR)
             .DIRECTORY_SEPARATOR.$cacheKey.'.json';
-        $hash = hash('sha256', $contents."\0".$style);
+        $hash = hash('sha256', $contents."\0".$style."\0".$styleScope->value);
         $tree = self::cachedTree(
             $metadataFile,
             $templateFile,
@@ -141,7 +143,7 @@ final class PamPhpCompiler
             if ($style !== '') {
                 $tree = self::withStyleSheet(
                     $tree,
-                    ScopedStyleCompiler::compile($style, $source),
+                    ScopedStyleCompiler::compile($style, $source, $styleScope),
                 );
             }
             self::writeAtomic($classFile, rtrim($php)."\n");
@@ -249,7 +251,7 @@ final class PamPhpCompiler
         }
     }
 
-    /** @return array{string, string, int, string, LanguageVersion} */
+    /** @return array{string, string, int, string, LanguageVersion, StyleScope} */
     private static function split(string $source, string $name): array
     {
         $tokens = token_get_all($source);
@@ -283,7 +285,7 @@ final class PamPhpCompiler
 
         if (preg_match(
             '/\A\s*<template(?:\s+([^>]*))?>([\s\S]*?)<\/template>'
-            .'\s*(?:<style(?:\s+scoped)?\s*>([\s\S]*?)<\/style>)?\s*\z/D',
+            .'\s*(?:<style(?:\s+(scoped|module|global))?\s*>([\s\S]*?)<\/style>)?\s*\z/D',
             $markup,
             $match,
             PREG_OFFSET_CAPTURE,
@@ -296,9 +298,20 @@ final class PamPhpCompiler
             ? (string) ($match[1][0] ?? '')
             : '';
         $capture = $match[2];
-        $style = is_array($match[3] ?? null)
-            ? (string) ($match[3][0] ?? '')
+        $styleMode = is_array($match[3] ?? null)
+            ? strtolower((string) ($match[3][0] ?? ''))
             : '';
+        $style = is_array($match[4] ?? null)
+            ? (string) ($match[4][0] ?? '')
+            : '';
+        $styleScope = match ($styleMode) {
+            '', 'scoped' => StyleScope::Scoped,
+            'module' => StyleScope::Module,
+            'global' => StyleScope::Global,
+            default => throw new RuntimeException(
+                "Unsupported PAM style scope {$styleMode} in {$name}.",
+            ),
+        };
 
         $language = LanguageVersion::Language1;
         if (preg_match('/(?:language|version)\s*=\s*(["\'])2\1/D', trim($templateAttributes)) === 1) {
@@ -312,7 +325,7 @@ final class PamPhpCompiler
         $templateOffset = $closeOffset + $closeLength + $capture[1];
         $templateLine = substr_count(substr($source, 0, $templateOffset), "\n") + 1;
 
-        return [$php, $capture[0], $templateLine, $style, $language];
+        return [$php, $capture[0], $templateLine, $style, $language, $styleScope];
     }
 
     /**

--- a/packages/native/src/Internal/ScopedStyleCompiler.php
+++ b/packages/native/src/Internal/ScopedStyleCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pam\Native\Internal;
 
+use Pam\Native\Style\StyleScope;
 use RuntimeException;
 
 /**
@@ -94,9 +95,14 @@ final class ScopedStyleCompiler
      *     fonts: array<string, list<array{source: string, weight: string, style: string}>>
      * }
      */
-    public static function compile(string $source, string $name): array
+    public static function compile(
+        string $source,
+        string $name,
+        StyleScope $scope = StyleScope::Scoped,
+    ): array
     {
         $source = self::resolveImports($source, $name);
+        $irSource = $source;
         $language2 = Language2StyleCompiler::extract($source, $name);
         $source = $language2['source'];
         $clean = preg_replace('/\/\*[\s\S]*?\*\//', '', $source);
@@ -108,6 +114,7 @@ final class ScopedStyleCompiler
         $tags = [];
         $fonts = [];
         $classCascade = [];
+        $cascadeRules = [];
         $rules = [];
         $matchedBytes = 0;
         preg_match_all(
@@ -162,6 +169,20 @@ final class ScopedStyleCompiler
             }
             $declarations = self::declarations($body, $variables, $name);
             foreach (array_map('trim', explode(',', $selectorSource)) as $selector) {
+                $compiledSelector = StyleSelectorCompiler::compile($selector, $name);
+                $important = self::importantProperties($body);
+                $cascadeDeclarations = [];
+                foreach ($declarations as $attribute => $value) {
+                    $cascadeDeclarations[$attribute] = [
+                        'value' => $value,
+                        'important' => isset($important[$attribute]),
+                    ];
+                }
+                $cascadeRules[] = [
+                    'selector' => $compiledSelector,
+                    'declarations' => $cascadeDeclarations,
+                    'order' => $sourceOrder,
+                ];
                 if (preg_match('/^\.([A-Za-z_][A-Za-z0-9_-]*)$/D', $selector, $match) === 1) {
                     $classes[$match[1]] = [
                         ...($classes[$match[1]] ?? []),
@@ -182,23 +203,34 @@ final class ScopedStyleCompiler
                     ];
                     continue;
                 }
-                throw new RuntimeException(
-                    "Unsupported scoped selector {$selector} in {$name}; use a tag or .class.",
-                );
+                // Complex selectors are evaluated from cascadeRules at render time.
             }
             $sourceOrder++;
         }
 
-        return [
+        $sheet = [
+            'scope' => $scope->value,
+            'scopeId' => substr(hash('sha256', $name), 0, 16),
             'classes' => $classes,
             'tags' => $tags,
             'classCascade' => $classCascade,
+            'cascadeRules' => $cascadeRules,
             'fonts' => $fonts,
             'tokens' => $language2['tokens'],
             'states' => $language2['states'],
             'recipes' => $language2['recipes'],
             'queries' => $language2['queries'],
             'keyframes' => $language2['keyframes'],
+        ];
+        $compiledIr = StyleIrCompiler::compile($sheet, $irSource, $name);
+
+        return [
+            ...$sheet,
+            'styleIr' => $compiledIr['ir'],
+            'styleBytecode' => $compiledIr['bytecode'],
+            'styleFingerprint' => $compiledIr['fingerprint'],
+            'styleSourceMap' => $compiledIr['sourceMap'],
+            'styleCompatibility' => $compiledIr['compatibility'],
         ];
     }
 
@@ -471,7 +503,8 @@ final class ScopedStyleCompiler
                     "Custom properties in {$name} must be declared in :root.",
                 );
             }
-            $value = self::resolveVariables($rawValue, $variables, $name);
+            $value = preg_replace('/\s*!important\s*$/i', '', $rawValue) ?? $rawValue;
+            $value = self::resolveVariables($value, $variables, $name);
             if (in_array($property, ['padding', 'margin'], true)) {
                 self::expandBox($output, $property, $value, $name);
                 continue;
@@ -560,6 +593,23 @@ final class ScopedStyleCompiler
                 $output[$property === 'column-gap' ? 'gridColumnGap' : 'gridRowGap'] = self::scalar($value, $name);
                 continue;
             }
+            if ($property === 'grid-template-columns') {
+                $output['columns'] = self::gridColumns($value, $name);
+                continue;
+            }
+            if ($property === 'grid-column') {
+                if (preg_match('/^span\s+([1-9]|[1-5][0-9]|6[0-4])$/iD', trim($value), $match) !== 1) {
+                    throw new RuntimeException("Native grid-column in {$name} must be 'span 1' through 'span 64'.");
+                }
+                $output['span'] = $match[1];
+                continue;
+            }
+            if ($property === 'place-items') {
+                $parts = self::cssValueParts($value, $name);
+                $output['alignItems'] = self::unquote($parts[0] ?? 'stretch');
+                $output['justifyContent'] = self::unquote($parts[1] ?? $parts[0] ?? 'stretch');
+                continue;
+            }
             $attribute = self::PROPERTIES[$property] ?? null;
             if ($attribute === null) {
                 throw new RuntimeException(
@@ -596,6 +646,22 @@ final class ScopedStyleCompiler
         }
 
         return $output;
+    }
+
+    /** @return array<string, true> Native attribute names marked important. */
+    private static function importantProperties(string $source): array
+    {
+        $important = [];
+        foreach (self::rawDeclarations($source, 'style rule') as $property => $value) {
+            if (preg_match('/!important\s*$/i', $value) !== 1) {
+                continue;
+            }
+            $native = self::PROPERTIES[$property] ?? null;
+            if ($native !== null) {
+                $important[$native] = true;
+            }
+        }
+        return $important;
     }
 
     /**
@@ -984,9 +1050,9 @@ final class ScopedStyleCompiler
         if ($property === 'display') {
             return match (strtolower($value)) {
                 'none' => false,
-                'flex' => true,
+                'flex', 'grid' => true,
                 default => throw new RuntimeException(
-                    "Native display in {$name} supports only flex or none.",
+                    "Native display in {$name} supports flex, grid, or none.",
                 ),
             };
         }
@@ -1100,6 +1166,9 @@ final class ScopedStyleCompiler
     private static function scalar(string $value, string $name): string
     {
         $trimmed = trim($value);
+        if (StyleValueCompiler::isDynamic($trimmed)) {
+            return StyleValueCompiler::encode($trimmed, $name);
+        }
         if (preg_match('/^-?(?:\d+|\d*\.\d+)(?:px|dp|pt|rem)?$/D', $trimmed) !== 1) {
             throw new RuntimeException("Expected a native numeric CSS value in {$name}, got {$value}.");
         }
@@ -1108,6 +1177,24 @@ final class ScopedStyleCompiler
         }
 
         return preg_replace('/(?:px|dp|pt)$/', '', $trimmed) ?? $trimmed;
+    }
+
+    private static function gridColumns(string $value, string $name): string
+    {
+        $trimmed = trim($value);
+        if (preg_match('/^repeat\(\s*([1-9]|[1-5][0-9]|6[0-4])\s*,\s*(?:minmax\([^)]*\)|[^)]+)\)$/iD', $trimmed, $match) === 1) {
+            return $match[1];
+        }
+        $tracks = self::cssValueParts($trimmed, $name);
+        if ($tracks === [] || count($tracks) > 64) {
+            throw new RuntimeException("Native grid-template-columns in {$name} supports 1 through 64 tracks.");
+        }
+        foreach ($tracks as $track) {
+            if (preg_match('/^(?:\d+(?:\.\d+)?fr|auto|min-content|max-content|minmax\([^)]*\))$/iD', $track) !== 1) {
+                throw new RuntimeException("Unsupported native grid track {$track} in {$name}.");
+            }
+        }
+        return (string) count($tracks);
     }
 
     /** @param array<string, string|int|bool> $output */

--- a/packages/native/src/Internal/ScopedStyleCompiler.php
+++ b/packages/native/src/Internal/ScopedStyleCompiler.php
@@ -208,6 +208,16 @@ final class ScopedStyleCompiler
             $sourceOrder++;
         }
 
+        $stateRules = [];
+        foreach ($language2['states'] as $selector => $states) {
+            foreach ($states as $state => $stateDeclarations) {
+                $stateRules[] = [
+                    'selector' => StyleSelectorCompiler::compile($selector, $name),
+                    'state' => $state,
+                    'declarations' => $stateDeclarations,
+                ];
+            }
+        }
         $sheet = [
             'scope' => $scope->value,
             'scopeId' => substr(hash('sha256', $name), 0, 16),
@@ -218,6 +228,7 @@ final class ScopedStyleCompiler
             'fonts' => $fonts,
             'tokens' => $language2['tokens'],
             'states' => $language2['states'],
+            'stateRules' => $stateRules,
             'recipes' => $language2['recipes'],
             'queries' => $language2['queries'],
             'keyframes' => $language2['keyframes'],

--- a/packages/native/src/Internal/StyleIrCompiler.php
+++ b/packages/native/src/Internal/StyleIrCompiler.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Internal;
+
+use JsonException;
+use Pam\Native\Style\StyleInvalidationKind;
+use Pam\Native\Style\StylePropertyCatalog;
+use RuntimeException;
+
+/** Produces the stable PAM Style IR, bytecode envelope and source map. */
+final class StyleIrCompiler
+{
+    public const VERSION = 1;
+    private const MAGIC = "PAMS\x01";
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $sheet
+     * @return array{
+     *   ir: array<string, mixed>,
+     *   bytecode: string,
+     *   fingerprint: string,
+     *   sourceMap: list<array<string, int|string>>,
+     *   compatibility: list<array<string, int|string|list<string>|null>>
+     * }
+     */
+    public static function compile(
+        array $sheet,
+        string $source,
+        string $name,
+    ): array {
+        $sourceMap = self::sourceMap($source, $name);
+        $dependencies = self::dependencies($source);
+        $ir = [
+            'version' => self::VERSION,
+            'scope' => $sheet['scope'] ?? 1,
+            'scopeId' => $sheet['scopeId'] ?? '',
+            'rules' => [
+                'classes' => $sheet['classes'] ?? [],
+                'tags' => $sheet['tags'] ?? [],
+                'cascade' => $sheet['classCascade'] ?? [],
+                'selectors' => $sheet['cascadeRules'] ?? [],
+            ],
+            'tokens' => $sheet['tokens'] ?? [],
+            'states' => $sheet['states'] ?? [],
+            'recipes' => $sheet['recipes'] ?? [],
+            'queries' => $sheet['queries'] ?? [],
+            'keyframes' => $sheet['keyframes'] ?? [],
+            'fonts' => $sheet['fonts'] ?? [],
+            'dependencies' => $dependencies,
+        ];
+        try {
+            $json = json_encode(
+                $ir,
+                JSON_THROW_ON_ERROR
+                    | JSON_UNESCAPED_SLASHES
+                    | JSON_PRESERVE_ZERO_FRACTION,
+            );
+        } catch (JsonException $error) {
+            throw new RuntimeException(
+                "Cannot encode PAM Style IR for {$name}.",
+                previous: $error,
+            );
+        }
+        $binary = self::MAGIC.pack('N', strlen($json)).$json;
+
+        return [
+            'ir' => $ir,
+            'bytecode' => base64_encode($binary),
+            'fingerprint' => hash('sha256', $binary),
+            'sourceMap' => $sourceMap,
+            'compatibility' => StylePropertyCatalog::manifest(),
+        ];
+    }
+
+    /** @return array<string, int> */
+    private static function dependencies(string $source): array
+    {
+        $dependencies = [];
+        if (str_contains($source, 'var(')) {
+            $dependencies['variables'] = StyleInvalidationKind::Value->value;
+        }
+        if (preg_match('/:(?:pressed|focused|focus-visible|disabled|selected|checked|hover|hovered|state\()/i', $source) === 1) {
+            $dependencies['states'] = StyleInvalidationKind::State->value;
+        }
+        if (str_contains($source, '@container')) {
+            $dependencies['container'] = StyleInvalidationKind::Container->value;
+        }
+        if (str_contains($source, '@media')) {
+            $dependencies['viewport'] = StyleInvalidationKind::Viewport->value;
+        }
+        if (preg_match('/(?:prefers-color-scheme|light-dark\(|dynamic-color\()/i', $source) === 1) {
+            $dependencies['theme'] = StyleInvalidationKind::Theme->value;
+        }
+        if (preg_match('/(?:env\(|android-resource\(|android-attribute\()/i', $source) === 1) {
+            $dependencies['environment'] = StyleInvalidationKind::Environment->value;
+        }
+        ksort($dependencies, SORT_STRING);
+
+        return $dependencies;
+    }
+
+    /** @return list<array<string, int|string>> */
+    private static function sourceMap(string $source, string $name): array
+    {
+        $entries = [];
+        if (preg_match_all('/(^|[;{])\s*([a-zA-Z-]+)\s*:/m', $source, $matches, PREG_OFFSET_CAPTURE) === false) {
+            return [];
+        }
+        foreach ($matches[2] as [$property, $offset]) {
+            $definition = StylePropertyCatalog::find($property);
+            if ($definition === null) {
+                continue;
+            }
+            $prefix = substr($source, 0, $offset);
+            $line = substr_count($prefix, "\n") + 1;
+            $lastNewline = strrpos($prefix, "\n");
+            $column = $lastNewline === false ? $offset + 1 : $offset - $lastNewline;
+            $entries[] = [
+                'propertyId' => $definition->id,
+                'source' => $name,
+                'line' => $line,
+                'column' => $column,
+            ];
+        }
+
+        return $entries;
+    }
+}

--- a/packages/native/src/Internal/StyleIrCompiler.php
+++ b/packages/native/src/Internal/StyleIrCompiler.php
@@ -48,6 +48,7 @@ final class StyleIrCompiler
             ],
             'tokens' => $sheet['tokens'] ?? [],
             'states' => $sheet['states'] ?? [],
+            'stateRules' => $sheet['stateRules'] ?? [],
             'recipes' => $sheet['recipes'] ?? [],
             'queries' => $sheet['queries'] ?? [],
             'keyframes' => $sheet['keyframes'] ?? [],

--- a/packages/native/src/Internal/StyleQueryCompiler.php
+++ b/packages/native/src/Internal/StyleQueryCompiler.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Internal;
+
+use Pam\Native\Style\StyleQueryFeature;
+use Pam\Native\Style\StyleQueryOperator;
+use Pam\Native\Style\StyleQueryValueKind;
+use RuntimeException;
+
+/** Compiles native media/container conditions into a typed, string-free IR. */
+final class StyleQueryCompiler
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @return array{
+     *   feature: int,
+     *   operator: int,
+     *   valueKind: int,
+     *   number: float|null,
+     *   keyword: string|null,
+     *   unit: string|null
+     * }
+     */
+    public static function compile(string $condition, string $name): array
+    {
+        $condition = trim($condition);
+        // Named containers are part of the selector, not of the condition AST.
+        $condition = preg_replace('/^[A-Za-z][A-Za-z0-9_-]*\s+(?=\()/', '', $condition)
+            ?? $condition;
+        if (preg_match(
+            '/^\((min|max)-(width|height):\s*([0-9]+(?:\.[0-9]+)?)(dp|px)\)$/Di',
+            $condition,
+            $match,
+        ) === 1) {
+            return self::number(
+                self::feature($match[2]),
+                $match[1] === 'min'
+                    ? StyleQueryOperator::GreaterThanOrEqual
+                    : StyleQueryOperator::LessThanOrEqual,
+                (float) $match[3],
+                strtolower($match[4]),
+            );
+        }
+        if (preg_match(
+            '/^\((width|height|refresh-rate|memory-class|performance-tier)\s*(>=|<=|>|<|=)\s*([0-9]+(?:\.[0-9]+)?)(dp|px|hz|mb)?\)$/Di',
+            $condition,
+            $match,
+        ) === 1) {
+            return self::number(
+                self::feature($match[1]),
+                self::operator($match[2]),
+                (float) $match[3],
+                strtolower($match[4] !== '' ? $match[4] : 'number'),
+            );
+        }
+        if (preg_match(
+            '/^\((orientation|prefers-color-scheme|prefers-reduced-motion|pointer|device-type|dynamic-range|display-mode|fold-posture|input-mode):\s*([a-z][a-z0-9-]*)\)$/Di',
+            $condition,
+            $match,
+        ) === 1) {
+            return [
+                'feature' => self::feature($match[1])->value,
+                'operator' => StyleQueryOperator::Equal->value,
+                'valueKind' => StyleQueryValueKind::Keyword->value,
+                'number' => null,
+                'keyword' => strtolower($match[2]),
+                'unit' => null,
+            ];
+        }
+
+        throw new RuntimeException("Unsupported native style query {$condition} in {$name}.");
+    }
+
+    /** @param array<string, float|int|string|bool|null> $environment */
+    public static function matches(array $query, array $environment): bool
+    {
+        $feature = StyleQueryFeature::tryFrom((int) ($query['feature'] ?? 0));
+        $operator = StyleQueryOperator::tryFrom((int) ($query['operator'] ?? 0));
+        $kind = StyleQueryValueKind::tryFrom((int) ($query['valueKind'] ?? 0));
+        if ($feature === null || $operator === null || $kind === null) {
+            return false;
+        }
+        $actual = $environment[self::environmentKey($feature)] ?? null;
+        if ($kind === StyleQueryValueKind::Keyword) {
+            return is_string($actual)
+                && $operator === StyleQueryOperator::Equal
+                && strtolower($actual) === ($query['keyword'] ?? null);
+        }
+        if (!is_int($actual) && !is_float($actual)) {
+            return false;
+        }
+        $expected = $query['number'] ?? null;
+        if (!is_int($expected) && !is_float($expected)) {
+            return false;
+        }
+
+        return match ($operator) {
+            StyleQueryOperator::Equal => (float) $actual === (float) $expected,
+            StyleQueryOperator::GreaterThanOrEqual => $actual >= $expected,
+            StyleQueryOperator::LessThanOrEqual => $actual <= $expected,
+            StyleQueryOperator::GreaterThan => $actual > $expected,
+            StyleQueryOperator::LessThan => $actual < $expected,
+        };
+    }
+
+    /** @return array{feature:int,operator:int,valueKind:int,number:float,keyword:null,unit:string} */
+    private static function number(
+        StyleQueryFeature $feature,
+        StyleQueryOperator $operator,
+        float $number,
+        string $unit,
+    ): array {
+        return [
+            'feature' => $feature->value,
+            'operator' => $operator->value,
+            'valueKind' => StyleQueryValueKind::Number->value,
+            'number' => $number,
+            'keyword' => null,
+            'unit' => $unit,
+        ];
+    }
+
+    private static function operator(string $operator): StyleQueryOperator
+    {
+        return match ($operator) {
+            '=' => StyleQueryOperator::Equal,
+            '>=' => StyleQueryOperator::GreaterThanOrEqual,
+            '<=' => StyleQueryOperator::LessThanOrEqual,
+            '>' => StyleQueryOperator::GreaterThan,
+            '<' => StyleQueryOperator::LessThan,
+        };
+    }
+
+    private static function feature(string $feature): StyleQueryFeature
+    {
+        return match (strtolower($feature)) {
+            'width' => StyleQueryFeature::Width,
+            'height' => StyleQueryFeature::Height,
+            'orientation' => StyleQueryFeature::Orientation,
+            'prefers-color-scheme' => StyleQueryFeature::ColorScheme,
+            'prefers-reduced-motion' => StyleQueryFeature::ReducedMotion,
+            'pointer' => StyleQueryFeature::Pointer,
+            'device-type' => StyleQueryFeature::DeviceType,
+            'refresh-rate' => StyleQueryFeature::RefreshRate,
+            'dynamic-range' => StyleQueryFeature::DynamicRange,
+            'display-mode' => StyleQueryFeature::DisplayMode,
+            'fold-posture' => StyleQueryFeature::FoldPosture,
+            'input-mode' => StyleQueryFeature::InputMode,
+            'memory-class' => StyleQueryFeature::MemoryClass,
+            'performance-tier' => StyleQueryFeature::PerformanceTier,
+            default => throw new RuntimeException("Unknown native style query feature {$feature}."),
+        };
+    }
+
+    private static function environmentKey(StyleQueryFeature $feature): string
+    {
+        return match ($feature) {
+            StyleQueryFeature::Width => 'width',
+            StyleQueryFeature::Height => 'height',
+            StyleQueryFeature::Orientation => 'orientation',
+            StyleQueryFeature::ColorScheme => 'colorScheme',
+            StyleQueryFeature::ReducedMotion => 'reducedMotion',
+            StyleQueryFeature::Pointer => 'pointer',
+            StyleQueryFeature::DeviceType => 'deviceType',
+            StyleQueryFeature::RefreshRate => 'refreshRate',
+            StyleQueryFeature::DynamicRange => 'dynamicRange',
+            StyleQueryFeature::DisplayMode => 'displayMode',
+            StyleQueryFeature::FoldPosture => 'foldPosture',
+            StyleQueryFeature::InputMode => 'inputMode',
+            StyleQueryFeature::MemoryClass => 'memoryClass',
+            StyleQueryFeature::PerformanceTier => 'performanceTier',
+        };
+    }
+}

--- a/packages/native/src/Internal/StyleSelectorCompiler.php
+++ b/packages/native/src/Internal/StyleSelectorCompiler.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Internal;
+
+use RuntimeException;
+
+/** Compiles the native-safe selector grammar to a deterministic matcher IR. */
+final class StyleSelectorCompiler
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @return array{source:string, compounds:list<array{combinator:string,tag:?string,id:?string,classes:list<string>,attributes:list<array{name:string,operator:string,value:?string}>,pseudos:list<string>}>,specificity:list<int>}
+     */
+    public static function compile(string $selector, string $name): array
+    {
+        $selector = trim($selector);
+        if ($selector === '' || str_contains($selector, '::')) {
+            throw new RuntimeException("Unsupported native selector {$selector} in {$name}.");
+        }
+        $parts = preg_split('/\s*(>)\s*|\s+/', $selector, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        if (!is_array($parts) || $parts === []) {
+            throw new RuntimeException("Invalid native selector {$selector} in {$name}.");
+        }
+        $compounds = [];
+        $combinator = 'self';
+        foreach ($parts as $part) {
+            if ($part === '>') {
+                $combinator = 'child';
+                continue;
+            }
+            $compound = self::compound(trim($part), $selector, $name);
+            $compound['combinator'] = $compounds === [] ? 'self' : $combinator;
+            $compounds[] = $compound;
+            $combinator = 'descendant';
+        }
+        $ids = 0;
+        $classes = 0;
+        $tags = 0;
+        foreach ($compounds as $compound) {
+            $ids += $compound['id'] === null ? 0 : 1;
+            $classes += count($compound['classes']) + count($compound['attributes']) + count($compound['pseudos']);
+            $tags += $compound['tag'] === null || $compound['tag'] === '*' ? 0 : 1;
+        }
+
+        return ['source' => $selector, 'compounds' => $compounds, 'specificity' => [$ids, $classes, $tags]];
+    }
+
+    /** @return array{tag:?string,id:?string,classes:list<string>,attributes:list<array{name:string,operator:string,value:?string}>,pseudos:list<string>} */
+    private static function compound(string $source, string $selector, string $name): array
+    {
+        $tag = null;
+        $id = null;
+        $classes = [];
+        $attributes = [];
+        $pseudos = [];
+        $offset = 0;
+        if (preg_match('/^(\*|[A-Za-z][A-Za-z0-9_-]*)/', $source, $match) === 1) {
+            $tag = $match[1];
+            $offset = strlen($match[0]);
+        }
+        while ($offset < strlen($source)) {
+            $tail = substr($source, $offset);
+            if (preg_match('/^#([A-Za-z_][A-Za-z0-9_-]*)/', $tail, $match) === 1) {
+                if ($id !== null) {
+                    throw new RuntimeException("Selector {$selector} has multiple ids in {$name}.");
+                }
+                $id = $match[1];
+            } elseif (preg_match('/^\.([A-Za-z_][A-Za-z0-9_-]*)/', $tail, $match) === 1) {
+                $classes[] = $match[1];
+            } elseif (preg_match('/^\[([A-Za-z_:][A-Za-z0-9_:.-]*)(?:\s*(=|~=|\|=|\^=|\$=|\*=)\s*(?:"([^"]*)"|\'([^\']*)\'|([^\]\s]+)))?\s*\]/', $tail, $match) === 1) {
+                $attributes[] = [
+                    'name' => $match[1],
+                    'operator' => $match[2] ?? '',
+                    'value' => ($match[3] ?? '') !== '' ? $match[3] : ((($match[4] ?? '') !== '') ? $match[4] : (($match[5] ?? '') !== '' ? $match[5] : null)),
+                ];
+            } elseif (preg_match('/^:(pressed|hover|focus|focus-visible|disabled|checked|selected|active|loading|error|empty|first-child|last-child)/', $tail, $match) === 1) {
+                $pseudos[] = $match[1];
+            } else {
+                throw new RuntimeException("Unsupported native selector fragment {$tail} in {$selector} ({$name}).");
+            }
+            $offset += strlen($match[0]);
+        }
+        if ($tag === null && $id === null && $classes === [] && $attributes === [] && $pseudos === []) {
+            throw new RuntimeException("Invalid native selector {$selector} in {$name}.");
+        }
+
+        return compact('tag', 'id', 'classes', 'attributes', 'pseudos');
+    }
+}

--- a/packages/native/src/Internal/StyleTokenGenerator.php
+++ b/packages/native/src/Internal/StyleTokenGenerator.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Internal;
+
+use RuntimeException;
+
+/** Generates typed, dependency-free token APIs for every PAM Native language. */
+final class StyleTokenGenerator
+{
+    private function __construct()
+    {
+    }
+
+    /** @param array<string,string> $tokens @return array{php:string,kotlin:string,swift:string} */
+    public static function generate(array $tokens, string $namespace = 'App\\Style', string $type = 'Tokens'): array
+    {
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/D', $type) !== 1) {
+            throw new RuntimeException('Invalid generated token type name.');
+        }
+        $php = ["<?php", '', 'declare(strict_types=1);', '', "namespace {$namespace};", '', "final class {$type}", '{'];
+        $kotlin = ["package dev.pam.generated", '', "public object {$type} {"];
+        $swift = ["public enum {$type} {"];
+        foreach ($tokens as $name => $value) {
+            $identifier = self::identifier($name);
+            $literal = var_export($value, true);
+            $php[] = "    public const string {$identifier} = {$literal};";
+            $escaped = addcslashes($value, "\\\"");
+            $kotlin[] = "    public const val {$identifier}: String = \"{$escaped}\"";
+            $swift[] = "    public static let {$identifier}: String = \"{$escaped}\"";
+        }
+        $php[] = '}';
+        $kotlin[] = '}';
+        $swift[] = '}';
+        return ['php' => implode("\n", $php)."\n", 'kotlin' => implode("\n", $kotlin)."\n", 'swift' => implode("\n", $swift)."\n"];
+    }
+
+    private static function identifier(string $name): string
+    {
+        $identifier = strtoupper((string) preg_replace('/[^A-Za-z0-9]+/', '_', trim($name, '-')));
+        if ($identifier === '' || ctype_digit($identifier[0])) {
+            $identifier = 'TOKEN_'.$identifier;
+        }
+        return $identifier;
+    }
+}

--- a/packages/native/src/Internal/StyleValueCompiler.php
+++ b/packages/native/src/Internal/StyleValueCompiler.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Internal;
+
+use JsonException;
+use Pam\Native\Style\StyleExpressionKind;
+use Pam\Native\Style\StyleValueUnit;
+use RuntimeException;
+
+/** Compile-time parser and allocation-free-at-call-site evaluator for CSS math. */
+final class StyleValueCompiler
+{
+    private const PREFIX = '@pam-style:';
+
+    /** @var list<array{type:string,value:string}> */
+    private array $tokens = [];
+    private int $position = 0;
+
+    private function __construct(private readonly string $name)
+    {
+    }
+
+    public static function isDynamic(string $value): bool
+    {
+        return preg_match(
+            '/(?:calc|min|max|clamp|env)\(|-?(?:\d+|\d*\.\d+)(?:vw|vh|vmin|vmax|sp|%)(?:$|[^a-z])/i',
+            trim($value),
+        ) === 1;
+    }
+
+    public static function encode(string $value, string $name): string
+    {
+        $compiler = new self($name);
+        $compiler->tokens = self::tokenize(trim($value), $name);
+        $node = $compiler->expression();
+        if ($compiler->peek() !== null) {
+            throw new RuntimeException("Unexpected CSS math token in {$name}: {$value}.");
+        }
+        try {
+            return self::PREFIX.base64_encode(json_encode(
+                $node,
+                JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION,
+            ));
+        } catch (JsonException $error) {
+            throw new RuntimeException("Cannot encode CSS math in {$name}.", previous: $error);
+        }
+    }
+
+    public static function encoded(string $value): bool
+    {
+        return str_starts_with($value, self::PREFIX);
+    }
+
+    /** @param array<string, float|int> $environment */
+    public static function resolve(string $value, array $environment): float
+    {
+        if (!self::encoded($value)) {
+            throw new RuntimeException('Expected compiled PAM style expression.');
+        }
+        $json = base64_decode(substr($value, strlen(self::PREFIX)), true);
+        if (!is_string($json)) {
+            throw new RuntimeException('Invalid PAM style expression envelope.');
+        }
+        try {
+            $node = json_decode($json, true, 24, JSON_THROW_ON_ERROR);
+        } catch (JsonException $error) {
+            throw new RuntimeException('Invalid PAM style expression bytecode.', previous: $error);
+        }
+        if (!is_array($node)) {
+            throw new RuntimeException('Invalid PAM style expression root.');
+        }
+
+        return self::evaluate($node, $environment, 0);
+    }
+
+    /** @return array<string, mixed> */
+    private function expression(int $minimumPrecedence = 0): array
+    {
+        $left = $this->primary();
+        while (($token = $this->peek()) !== null && $token['type'] === 'operator') {
+            $precedence = in_array($token['value'], ['*', '/'], true) ? 20 : 10;
+            if ($precedence < $minimumPrecedence) {
+                break;
+            }
+            $this->position++;
+            $right = $this->expression($precedence + 1);
+            $left = [
+                'kind' => match ($token['value']) {
+                    '+' => StyleExpressionKind::Add->value,
+                    '-' => StyleExpressionKind::Subtract->value,
+                    '*' => StyleExpressionKind::Multiply->value,
+                    '/' => StyleExpressionKind::Divide->value,
+                },
+                'children' => [$left, $right],
+            ];
+        }
+
+        return $left;
+    }
+
+    /** @return array<string, mixed> */
+    private function primary(): array
+    {
+        $token = $this->take();
+        if ($token === null) {
+            throw new RuntimeException("Incomplete CSS math expression in {$this->name}.");
+        }
+        if ($token['type'] === 'operator' && in_array($token['value'], ['+', '-'], true)) {
+            $node = $this->primary();
+            if ($token['value'] === '+') {
+                return $node;
+            }
+            return [
+                'kind' => StyleExpressionKind::Multiply->value,
+                'children' => [self::literal(-1.0, StyleValueUnit::Number), $node],
+            ];
+        }
+        if ($token['type'] === 'number') {
+            if (preg_match('/^((?:\d+|\d*\.\d+))(px|dp|sp|pt|rem|%|vw|vh|vmin|vmax)?$/Di', $token['value'], $match) !== 1) {
+                throw new RuntimeException("Invalid CSS number {$token['value']} in {$this->name}.");
+            }
+            return self::literal(
+                (float) $match[1],
+                self::unit(strtolower($match[2] ?? '')),
+            );
+        }
+        if ($token['type'] === 'left') {
+            $node = $this->expression();
+            $this->expect('right');
+            return $node;
+        }
+        if ($token['type'] !== 'identifier') {
+            throw new RuntimeException("Invalid CSS math expression in {$this->name}.");
+        }
+        $function = strtolower($token['value']);
+        $this->expect('left');
+        if ($function === 'env') {
+            $name = $this->take();
+            if ($name === null || $name['type'] !== 'identifier') {
+                throw new RuntimeException("env() requires a native environment name in {$this->name}.");
+            }
+            $this->expect('right');
+            return [
+                'kind' => StyleExpressionKind::Environment->value,
+                'name' => $name['value'],
+            ];
+        }
+        if ($function === 'calc') {
+            $node = $this->expression();
+            $this->expect('right');
+            return $node;
+        }
+        if (!in_array($function, ['min', 'max', 'clamp'], true)) {
+            throw new RuntimeException("Unsupported CSS math function {$function}() in {$this->name}.");
+        }
+        $children = [$this->expression()];
+        while (($next = $this->peek()) !== null && $next['type'] === 'comma') {
+            $this->position++;
+            $children[] = $this->expression();
+        }
+        $this->expect('right');
+        if (($function === 'clamp' && count($children) !== 3) || ($function !== 'clamp' && count($children) < 1)) {
+            throw new RuntimeException("Invalid {$function}() arity in {$this->name}.");
+        }
+        return [
+            'kind' => match ($function) {
+                'min' => StyleExpressionKind::Minimum->value,
+                'max' => StyleExpressionKind::Maximum->value,
+                'clamp' => StyleExpressionKind::Clamp->value,
+            },
+            'children' => $children,
+        ];
+    }
+
+    /** @return array{kind:int,value:float,unit:int} */
+    private static function literal(float $value, StyleValueUnit $unit): array
+    {
+        return ['kind' => StyleExpressionKind::Literal->value, 'value' => $value, 'unit' => $unit->value];
+    }
+
+    /** @param array<string, mixed> $node @param array<string, float|int> $environment */
+    private static function evaluate(array $node, array $environment, int $depth): float
+    {
+        if ($depth > 24) {
+            throw new RuntimeException('PAM style expression exceeds the evaluation depth limit.');
+        }
+        $kind = StyleExpressionKind::tryFrom((int) ($node['kind'] ?? 0));
+        if ($kind === null) {
+            throw new RuntimeException('Unknown PAM style expression operation.');
+        }
+        if ($kind === StyleExpressionKind::Literal) {
+            $unit = StyleValueUnit::tryFrom((int) ($node['unit'] ?? 0));
+            $number = $node['value'] ?? null;
+            if ($unit === null || (!is_int($number) && !is_float($number))) {
+                throw new RuntimeException('Invalid PAM style literal.');
+            }
+            return self::resolveUnit((float) $number, $unit, $environment);
+        }
+        if ($kind === StyleExpressionKind::Environment) {
+            $name = $node['name'] ?? null;
+            $value = is_string($name) ? ($environment['env.'.$name] ?? null) : null;
+            if (!is_int($value) && !is_float($value)) {
+                throw new RuntimeException("Native style environment value {$name} is unavailable.");
+            }
+            return (float) $value;
+        }
+        $children = $node['children'] ?? null;
+        if (!is_array($children)) {
+            throw new RuntimeException('Invalid PAM style expression operands.');
+        }
+        $values = array_map(
+            static fn (mixed $child): float => is_array($child)
+                ? self::evaluate($child, $environment, $depth + 1)
+                : throw new RuntimeException('Invalid PAM style expression child.'),
+            $children,
+        );
+        return match ($kind) {
+            StyleExpressionKind::Add => $values[0] + $values[1],
+            StyleExpressionKind::Subtract => $values[0] - $values[1],
+            StyleExpressionKind::Multiply => $values[0] * $values[1],
+            StyleExpressionKind::Divide => $values[1] == 0.0
+                ? throw new RuntimeException('CSS calc() division by zero.')
+                : $values[0] / $values[1],
+            StyleExpressionKind::Minimum => min($values),
+            StyleExpressionKind::Maximum => max($values),
+            StyleExpressionKind::Clamp => max($values[0], min($values[1], $values[2])),
+            default => throw new RuntimeException('Invalid PAM style expression operation.'),
+        };
+    }
+
+    /** @param array<string, float|int> $environment */
+    private static function resolveUnit(float $value, StyleValueUnit $unit, array $environment): float
+    {
+        $width = (float) ($environment['width'] ?? 0.0);
+        $height = (float) ($environment['height'] ?? 0.0);
+        return match ($unit) {
+            StyleValueUnit::Number, StyleValueUnit::Px, StyleValueUnit::Dp, StyleValueUnit::Pt => $value,
+            StyleValueUnit::Sp => $value * (float) ($environment['fontScale'] ?? 1.0),
+            StyleValueUnit::Rem => $value * (float) ($environment['rootFontSize'] ?? 16.0),
+            StyleValueUnit::Percent => $value * (float) ($environment['reference'] ?? 0.0) / 100.0,
+            StyleValueUnit::Vw => $value * $width / 100.0,
+            StyleValueUnit::Vh => $value * $height / 100.0,
+            StyleValueUnit::Vmin => $value * min($width, $height) / 100.0,
+            StyleValueUnit::Vmax => $value * max($width, $height) / 100.0,
+        };
+    }
+
+    /** @return list<array{type:string,value:string}> */
+    private static function tokenize(string $value, string $name): array
+    {
+        $tokens = [];
+        $length = strlen($value);
+        for ($index = 0; $index < $length;) {
+            if (ctype_space($value[$index])) {
+                $index++;
+                continue;
+            }
+            $rest = substr($value, $index);
+            if (preg_match('/^(?:\d+|\d*\.\d+)(?:px|dp|sp|pt|rem|%|vw|vh|vmin|vmax)?/i', $rest, $match) === 1) {
+                $tokens[] = ['type' => 'number', 'value' => $match[0]];
+                $index += strlen($match[0]);
+                continue;
+            }
+            if (preg_match('/^[A-Za-z][A-Za-z0-9-]*/', $rest, $match) === 1) {
+                $tokens[] = ['type' => 'identifier', 'value' => $match[0]];
+                $index += strlen($match[0]);
+                continue;
+            }
+            $tokens[] = match ($value[$index]) {
+                '+', '-', '*', '/' => ['type' => 'operator', 'value' => $value[$index]],
+                '(' => ['type' => 'left', 'value' => '('],
+                ')' => ['type' => 'right', 'value' => ')'],
+                ',' => ['type' => 'comma', 'value' => ','],
+                default => throw new RuntimeException("Invalid CSS math character {$value[$index]} in {$name}."),
+            };
+            $index++;
+        }
+        return $tokens;
+    }
+
+    private static function unit(string $unit): StyleValueUnit
+    {
+        return match ($unit) {
+            '' => StyleValueUnit::Number,
+            'px' => StyleValueUnit::Px,
+            'dp' => StyleValueUnit::Dp,
+            'sp' => StyleValueUnit::Sp,
+            'pt' => StyleValueUnit::Pt,
+            'rem' => StyleValueUnit::Rem,
+            '%' => StyleValueUnit::Percent,
+            'vw' => StyleValueUnit::Vw,
+            'vh' => StyleValueUnit::Vh,
+            'vmin' => StyleValueUnit::Vmin,
+            'vmax' => StyleValueUnit::Vmax,
+        };
+    }
+
+    /** @return array{type:string,value:string}|null */
+    private function peek(): ?array
+    {
+        return $this->tokens[$this->position] ?? null;
+    }
+
+    /** @return array{type:string,value:string}|null */
+    private function take(): ?array
+    {
+        return $this->tokens[$this->position++] ?? null;
+    }
+
+    private function expect(string $type): void
+    {
+        $token = $this->take();
+        if ($token === null || $token['type'] !== $type) {
+            throw new RuntimeException("Expected {$type} in CSS math expression in {$this->name}.");
+        }
+    }
+}

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -1076,6 +1076,10 @@ final class TemplateRenderer
         }
         $childData = [
             ...$data,
+            '__pamStyleAncestors' => [
+                ...(is_array($data['__pamStyleAncestors'] ?? null) ? $data['__pamStyleAncestors'] : []),
+                self::styleNodeDescriptor($tag, $resolvedClass, $declaredAttributes, $scope, $data),
+            ],
             '__pamContainerWidth' => is_numeric($values['width'] ?? null)
                 ? (float) $values['width']
                 : ($data['__pamContainerWidth'] ?? null),
@@ -2457,6 +2461,7 @@ final class TemplateRenderer
                 'classes' => [],
                 'tags' => [],
                 'classCascade' => [],
+                'cascadeRules' => [],
                 'fonts' => [],
             ];
         }
@@ -2483,12 +2488,24 @@ final class TemplateRenderer
             'classes' => $classes,
             'tags' => $tags,
             'classCascade' => $classCascade,
+            'cascadeRules' => self::safeStyleMetadata($decoded['cascadeRules'] ?? [], $tree->source),
             'fonts' => $fonts,
+            'scope' => is_int($decoded['scope'] ?? null) ? $decoded['scope'] : 1,
+            'scopeId' => is_string($decoded['scopeId'] ?? null) ? $decoded['scopeId'] : '',
             'tokens' => self::safeStyleMetadata($decoded['tokens'] ?? [], $tree->source),
             'states' => self::safeStyleMetadata($decoded['states'] ?? [], $tree->source),
             'recipes' => self::safeStyleMetadata($decoded['recipes'] ?? [], $tree->source),
             'queries' => self::safeStyleMetadata($decoded['queries'] ?? [], $tree->source),
             'keyframes' => self::safeStyleMetadata($decoded['keyframes'] ?? [], $tree->source),
+            'styleIr' => self::safeStyleMetadata($decoded['styleIr'] ?? [], $tree->source),
+            'styleBytecode' => is_string($decoded['styleBytecode'] ?? null)
+                ? $decoded['styleBytecode']
+                : '',
+            'styleFingerprint' => is_string($decoded['styleFingerprint'] ?? null)
+                ? $decoded['styleFingerprint']
+                : '',
+            'styleSourceMap' => self::safeStyleMetadata($decoded['styleSourceMap'] ?? [], $tree->source),
+            'styleCompatibility' => self::safeStyleMetadata($decoded['styleCompatibility'] ?? [], $tree->source),
         ];
     }
 
@@ -2521,8 +2538,19 @@ final class TemplateRenderer
     {
         $sheet = $data['__pamStyles'] ?? null;
         $classes = is_array($sheet) ? ($sheet['classes'] ?? null) : null;
-
-        return is_array($classes) ? $classes : [];
+        $known = is_array($classes) ? $classes : [];
+        if (is_array($sheet)) {
+            foreach (($sheet['cascadeRules'] ?? []) as $rule) {
+                foreach (($rule['selector']['compounds'] ?? []) as $compound) {
+                    foreach (($compound['classes'] ?? []) as $class) {
+                        if (is_string($class) && $class !== '') {
+                            $known[$class] ??= [];
+                        }
+                    }
+                }
+            }
+        }
+        return $known;
     }
 
     /**
@@ -2541,6 +2569,11 @@ final class TemplateRenderer
             return [];
         }
         $sheet = self::responsiveStyleSheet($sheet, $data);
+        $descriptor = self::styleNodeDescriptor($tag, $classes, $rawAttributes, $scope, $data);
+        $cascadeRules = is_array($sheet['cascadeRules'] ?? null) ? $sheet['cascadeRules'] : [];
+        $attributes = $cascadeRules !== []
+            ? self::cascadeStyleAttributes($cascadeRules, $descriptor, $data)
+            : [];
         $classCascade = is_array($sheet['classCascade'] ?? null)
             ? $sheet['classCascade']
             : [];
@@ -2549,8 +2582,10 @@ final class TemplateRenderer
             true,
         );
         $tags = is_array($sheet['tags'] ?? null) ? $sheet['tags'] : [];
-        $attributes = is_array($tags[$tag] ?? null) ? $tags[$tag] : [];
-        if ($classCascade !== []) {
+        if ($cascadeRules === []) {
+            $attributes = is_array($tags[$tag] ?? null) ? $tags[$tag] : [];
+        }
+        if ($cascadeRules === [] && $classCascade !== []) {
             $winners = [];
             foreach (array_keys($classNames) as $class) {
                 $declarations = $classCascade[$class] ?? null;
@@ -2576,7 +2611,7 @@ final class TemplateRenderer
             foreach ($winners as $attribute => $entry) {
                 $attributes[$attribute] = $entry['value'];
             }
-        } else {
+        } elseif ($cascadeRules === []) {
             // Backward compatibility for templates compiled before cascade indexes.
             $classRules = is_array($sheet['classes'] ?? null) ? $sheet['classes'] : [];
             foreach (array_keys($classNames) as $class) {
@@ -2640,6 +2675,167 @@ final class TemplateRenderer
             }
         }
 
+        return self::resolveDynamicStyles($attributes, $data);
+    }
+
+    /** @param array<string, mixed> $raw @param array<string, mixed> $data @return array<string,mixed> */
+    private static function styleNodeDescriptor(string $tag, ?string $classes, array $raw, ?object $scope, array $data): array
+    {
+        $attributes = [];
+        foreach ($raw as $name => $value) {
+            if (str_starts_with($name, '@') || str_starts_with($name, 'on:')) {
+                continue;
+            }
+            try {
+                $attributes[ltrim($name, ':')] = str_starts_with($name, ':')
+                    ? self::dynamicValue($value, $scope, $data)
+                    : self::value($value, $scope, $data);
+            } catch (RuntimeException) {
+            }
+        }
+        $classList = array_values(array_filter(preg_split('/\s+/', trim($classes ?? '')) ?: []));
+        $pseudos = [];
+        foreach (['disabled', 'checked', 'selected', 'active', 'loading', 'error'] as $pseudo) {
+            if (($attributes[$pseudo] ?? false) === true) {
+                $pseudos[] = $pseudo;
+            }
+        }
+        if (($attributes['value'] ?? null) === '' || ($attributes['items'] ?? null) === []) {
+            $pseudos[] = 'empty';
+        }
+        return ['tag' => $tag, 'id' => isset($attributes['id']) ? (string) $attributes['id'] : null, 'classes' => $classList, 'attributes' => $attributes, 'pseudos' => $pseudos];
+    }
+
+    /** @param list<mixed> $rules @param array<string,mixed> $node @param array<string,mixed> $data @return array<string,string|int|bool> */
+    private static function cascadeStyleAttributes(array $rules, array $node, array $data): array
+    {
+        $ancestors = is_array($data['__pamStyleAncestors'] ?? null) ? $data['__pamStyleAncestors'] : [];
+        $winners = [];
+        foreach ($rules as $rule) {
+            if (!is_array($rule) || !is_array($rule['selector'] ?? null) || !self::styleSelectorMatches($rule['selector'], $node, $ancestors)) {
+                continue;
+            }
+            $specificity = $rule['selector']['specificity'] ?? [0, 0, 0];
+            $score = ((int) ($specificity[0] ?? 0) * 1_000_000) + ((int) ($specificity[1] ?? 0) * 1_000) + (int) ($specificity[2] ?? 0);
+            foreach (($rule['declarations'] ?? []) as $attribute => $entry) {
+                if (!is_array($entry) || !array_key_exists('value', $entry)) {
+                    continue;
+                }
+                $rank = [(bool) ($entry['important'] ?? false) ? 1 : 0, $score, (int) ($rule['order'] ?? 0)];
+                if (!isset($winners[$attribute]) || $rank >= $winners[$attribute]['rank']) {
+                    $winners[$attribute] = ['rank' => $rank, 'value' => $entry['value']];
+                }
+            }
+        }
+        return array_map(static fn (array $winner): mixed => $winner['value'], $winners);
+    }
+
+    /** @param array<string,mixed> $selector @param array<string,mixed> $node @param list<mixed> $ancestors */
+    private static function styleSelectorMatches(array $selector, array $node, array $ancestors): bool
+    {
+        $compounds = $selector['compounds'] ?? null;
+        if (!is_array($compounds) || $compounds === []) return false;
+        $index = count($compounds) - 1;
+        if (!self::styleCompoundMatches($compounds[$index], $node)) return false;
+        $ancestorIndex = count($ancestors) - 1;
+        while ($index > 0) {
+            $relation = $compounds[$index]['combinator'] ?? 'descendant';
+            $index--;
+            if ($relation === 'child') {
+                if ($ancestorIndex < 0 || !self::styleCompoundMatches($compounds[$index], $ancestors[$ancestorIndex])) return false;
+                $ancestorIndex--;
+                continue;
+            }
+            $found = false;
+            while ($ancestorIndex >= 0) {
+                if (self::styleCompoundMatches($compounds[$index], $ancestors[$ancestorIndex])) { $found = true; $ancestorIndex--; break; }
+                $ancestorIndex--;
+            }
+            if (!$found) return false;
+        }
+        return true;
+    }
+
+    /** @param array<string,mixed> $compound */
+    private static function styleCompoundMatches(array $compound, mixed $node): bool
+    {
+        if (!is_array($node)) return false;
+        $tag = $compound['tag'] ?? null;
+        if ($tag !== null && $tag !== '*' && strcasecmp((string) ($node['tag'] ?? ''), (string) $tag) !== 0) return false;
+        if (($compound['id'] ?? null) !== null && ($node['id'] ?? null) !== $compound['id']) return false;
+        foreach (($compound['classes'] ?? []) as $class) if (!in_array($class, $node['classes'] ?? [], true)) return false;
+        foreach (($compound['pseudos'] ?? []) as $pseudo) {
+            if (in_array($pseudo, ['pressed', 'hover', 'focus', 'focus-visible', 'first-child', 'last-child'], true) || !in_array($pseudo, $node['pseudos'] ?? [], true)) return false;
+        }
+        foreach (($compound['attributes'] ?? []) as $condition) {
+            $nodeAttributes = $node['attributes'] ?? [];
+            if (!is_array($nodeAttributes) || !array_key_exists($condition['name'], $nodeAttributes)) return false;
+            $operator = $condition['operator'] ?? '';
+            if ($operator === '') continue;
+            $actual = (string) $nodeAttributes[$condition['name']];
+            $expected = (string) ($condition['value'] ?? '');
+            $matches = match ($operator) {
+                '=' => $actual === $expected,
+                '~=' => in_array($expected, preg_split('/\s+/', $actual) ?: [], true),
+                '|=' => $actual === $expected || str_starts_with($actual, $expected.'-'),
+                '^=' => str_starts_with($actual, $expected), '$=' => str_ends_with($actual, $expected),
+                '*=' => str_contains($actual, $expected), default => false,
+            };
+            if (!$matches) return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param array<string, string|int|bool> $attributes
+     * @param array<string, mixed> $data
+     * @return array<string, string|int|float|bool>
+     */
+    private static function resolveDynamicStyles(array $attributes, array $data): array
+    {
+        $metrics = Runtime::windowMetrics();
+        $containerWidth = $data['__pamContainerWidth'] ?? $metrics->width;
+        $containerHeight = $data['__pamContainerHeight'] ?? $metrics->height;
+        $provided = is_array($data['__pamStyleEnvironment'] ?? null)
+            ? $data['__pamStyleEnvironment']
+            : [];
+        $environment = [
+            'width' => $metrics->width,
+            'height' => $metrics->height,
+            'fontScale' => is_numeric($provided['fontScale'] ?? null)
+                ? (float) $provided['fontScale']
+                : 1.0,
+            'rootFontSize' => is_numeric($provided['rootFontSize'] ?? null)
+                ? (float) $provided['rootFontSize']
+                : 16.0,
+        ];
+        foreach ($provided as $name => $value) {
+            if (is_string($name) && (is_int($value) || is_float($value))) {
+                $environment[$name] = $value;
+            }
+        }
+        $vertical = [
+            'height' => true,
+            'minHeight' => true,
+            'maxHeight' => true,
+            'top' => true,
+            'bottom' => true,
+            'paddingTop' => true,
+            'paddingBottom' => true,
+            'marginTop' => true,
+            'marginBottom' => true,
+            'translationY' => true,
+        ];
+        foreach ($attributes as $name => $value) {
+            if (!is_string($value) || !StyleValueCompiler::encoded($value)) {
+                continue;
+            }
+            $environment['reference'] = isset($vertical[$name])
+                ? (float) $containerHeight
+                : (float) $containerWidth;
+            $attributes[$name] = StyleValueCompiler::resolve($value, $environment);
+        }
+
         return $attributes;
     }
 
@@ -2662,7 +2858,22 @@ final class TemplateRenderer
             $metrics = Runtime::windowMetrics();
             $width = $kind === 1 ? $metrics->width : ($data['__pamContainerWidth'] ?? null);
             $height = $kind === 1 ? $metrics->height : ($data['__pamContainerHeight'] ?? null);
-            if (!self::queryMatches($condition, $width, $height)) {
+            $providedEnvironment = is_array($data['__pamStyleEnvironment'] ?? null)
+                ? $data['__pamStyleEnvironment']
+                : [];
+            $environment = [
+                ...$providedEnvironment,
+                'width' => $width,
+                'height' => $height,
+                'orientation' => is_int($width) || is_float($width)
+                    ? ((is_int($height) || is_float($height)) && $width > $height
+                        ? 'landscape'
+                        : 'portrait')
+                    : null,
+                'colorScheme' => $metrics->appearance->value === 2 ? 'dark' : 'light',
+            ];
+            $ast = is_array($query['ast'] ?? null) ? $query['ast'] : null;
+            if (!self::queryMatches($condition, $ast, $environment)) {
                 continue;
             }
             foreach (['classes', 'tags'] as $group) {
@@ -2679,6 +2890,17 @@ final class TemplateRenderer
                     }
                 }
             }
+            $incomingRules = $query['styles']['cascadeRules'] ?? [];
+            if (is_array($incomingRules)) {
+                $baseOrder = count(is_array($sheet['cascadeRules'] ?? null) ? $sheet['cascadeRules'] : []);
+                foreach ($incomingRules as $incomingRule) {
+                    if (!is_array($incomingRule)) {
+                        continue;
+                    }
+                    $incomingRule['order'] = $baseOrder + (int) ($incomingRule['order'] ?? 0);
+                    $sheet['cascadeRules'][] = $incomingRule;
+                }
+            }
             // Query rules are later than base rules by definition.
             $sheet['classCascade'] = [];
         }
@@ -2687,13 +2909,16 @@ final class TemplateRenderer
 
     private static function queryMatches(
         string $condition,
-        mixed $width,
-        mixed $height,
+        ?array $ast,
+        array $environment,
     ): bool {
+        if ($ast !== null) {
+            return StyleQueryCompiler::matches($ast, $environment);
+        }
         if (preg_match('/\((min|max)-(width|height):\s*([0-9]+(?:\.[0-9]+)?)(?:dp|px)\)/D', $condition, $match) !== 1) {
             return false;
         }
-        $actual = $match[2] === 'width' ? $width : $height;
+        $actual = $environment[$match[2]] ?? null;
         if (!is_int($actual) && !is_float($actual)) {
             return false;
         }

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -2494,6 +2494,7 @@ final class TemplateRenderer
             'scopeId' => is_string($decoded['scopeId'] ?? null) ? $decoded['scopeId'] : '',
             'tokens' => self::safeStyleMetadata($decoded['tokens'] ?? [], $tree->source),
             'states' => self::safeStyleMetadata($decoded['states'] ?? [], $tree->source),
+            'stateRules' => self::safeStyleMetadata($decoded['stateRules'] ?? [], $tree->source),
             'recipes' => self::safeStyleMetadata($decoded['recipes'] ?? [], $tree->source),
             'queries' => self::safeStyleMetadata($decoded['queries'] ?? [], $tree->source),
             'keyframes' => self::safeStyleMetadata($decoded['keyframes'] ?? [], $tree->source),
@@ -2671,6 +2672,24 @@ final class TemplateRenderer
                 isset($pressed['scaleX'], $pressed['scaleY'])
                 && $pressed['scaleX'] === $pressed['scaleY']
             ) {
+                $attributes['pressedScale'] = $pressed['scaleX'];
+            }
+        }
+        foreach (($sheet['stateRules'] ?? []) as $stateRule) {
+            if (!is_array($stateRule)
+                || ($stateRule['state'] ?? null) !== 'pressed'
+                || !is_array($stateRule['selector'] ?? null)
+                || !self::styleSelectorMatches(
+                    $stateRule['selector'],
+                    $descriptor,
+                    is_array($data['__pamStyleAncestors'] ?? null) ? $data['__pamStyleAncestors'] : [],
+                )) {
+                continue;
+            }
+            $pressed = $stateRule['declarations'] ?? [];
+            if (!is_array($pressed)) continue;
+            if (isset($pressed['opacity'])) $attributes['pressedOpacity'] = $pressed['opacity'];
+            if (isset($pressed['scaleX'], $pressed['scaleY']) && $pressed['scaleX'] === $pressed['scaleY']) {
                 $attributes['pressedScale'] = $pressed['scaleX'];
             }
         }

--- a/packages/native/src/Style/StyleCompatibility.php
+++ b/packages/native/src/Style/StyleCompatibility.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleCompatibility: int
+{
+    case Native = 1;
+    case Adapted = 2;
+    case AndroidOnly = 3;
+    case IosOnly = 4;
+    case Fallback = 5;
+    case Invalid = 6;
+}

--- a/packages/native/src/Style/StyleExpressionKind.php
+++ b/packages/native/src/Style/StyleExpressionKind.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleExpressionKind: int
+{
+    case Literal = 1;
+    case Add = 2;
+    case Subtract = 3;
+    case Multiply = 4;
+    case Divide = 5;
+    case Minimum = 6;
+    case Maximum = 7;
+    case Clamp = 8;
+    case Environment = 9;
+}

--- a/packages/native/src/Style/StyleInvalidationKind.php
+++ b/packages/native/src/Style/StyleInvalidationKind.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleInvalidationKind: int
+{
+    case Value = 1;
+    case State = 2;
+    case Container = 3;
+    case Viewport = 4;
+    case Theme = 5;
+    case Environment = 6;
+}

--- a/packages/native/src/Style/StylePropertyCatalog.php
+++ b/packages/native/src/Style/StylePropertyCatalog.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+/**
+ * Stable, generated-documentation source of truth for CSS-to-native support.
+ * IDs are public ABI and must remain sequential and append-only.
+ */
+final class StylePropertyCatalog
+{
+    /** @var list<StylePropertyDefinition>|null */
+    private static ?array $definitions = null;
+
+    private function __construct()
+    {
+    }
+
+    /** @return list<StylePropertyDefinition> */
+    public static function all(): array
+    {
+        return self::$definitions ??= self::build();
+    }
+
+    public static function find(string $cssName): ?StylePropertyDefinition
+    {
+        $normalized = strtolower(trim($cssName));
+        foreach (self::all() as $definition) {
+            if (
+                $definition->cssName === $normalized
+                || in_array($normalized, $definition->aliases, true)
+            ) {
+                return $definition;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return list<array<string, int|string|list<string>|null>> */
+    public static function manifest(): array
+    {
+        return array_map(
+            static fn (StylePropertyDefinition $definition): array =>
+                $definition->toArray(),
+            self::all(),
+        );
+    }
+
+    /** @return list<StylePropertyDefinition> */
+    private static function build(): array
+    {
+        $rows = [
+            ['align-items', 'alignItems', StyleRenderCost::Layout],
+            ['align-self', 'alignSelf', StyleRenderCost::Layout],
+            ['aspect-ratio', 'aspectRatio', StyleRenderCost::Layout],
+            ['background-color', 'backgroundColor', StyleRenderCost::Paint, ['background']],
+            ['border-color', 'borderColor', StyleRenderCost::Paint],
+            ['border-radius', 'borderRadius', StyleRenderCost::Paint],
+            ['border-style', 'borderStyle', StyleRenderCost::Paint],
+            ['border-width', 'borderWidth', StyleRenderCost::Layout],
+            ['bottom', 'bottom', StyleRenderCost::Layout],
+            ['box-shadow', 'shadow', StyleRenderCost::Paint],
+            ['color', 'textColor', StyleRenderCost::Paint],
+            ['column-gap', 'gridColumnGap', StyleRenderCost::Layout],
+            ['display', 'display', StyleRenderCost::Layout],
+            ['elevation', 'elevation', StyleRenderCost::Paint],
+            ['flex', 'flex', StyleRenderCost::Layout],
+            ['flex-basis', 'flexBasis', StyleRenderCost::Layout],
+            ['flex-direction', 'flexDirection', StyleRenderCost::Layout],
+            ['flex-grow', 'flexGrow', StyleRenderCost::Layout],
+            ['flex-shrink', 'flexShrink', StyleRenderCost::Layout],
+            ['flex-wrap', 'flexWrap', StyleRenderCost::Layout],
+            ['font-family', 'fontFamily', StyleRenderCost::Layout],
+            ['font-size', 'fontSize', StyleRenderCost::Layout],
+            ['font-style', 'fontStyle', StyleRenderCost::Layout],
+            ['font-weight', 'fontWeight', StyleRenderCost::Layout],
+            ['gap', 'gap', StyleRenderCost::Layout],
+            ['grid-column', 'gridSpan', StyleRenderCost::Layout],
+            ['grid-template-columns', 'gridColumns', StyleRenderCost::Layout],
+            ['height', 'height', StyleRenderCost::Layout],
+            ['inset', 'inset', StyleRenderCost::Layout],
+            ['justify-content', 'justifyContent', StyleRenderCost::Layout],
+            ['left', 'left', StyleRenderCost::Layout],
+            ['letter-spacing', 'letterSpacing', StyleRenderCost::Layout],
+            ['line-height', 'lineHeight', StyleRenderCost::Layout],
+            ['margin', 'margin', StyleRenderCost::Layout],
+            ['max-height', 'maxHeight', StyleRenderCost::Layout],
+            ['max-width', 'maxWidth', StyleRenderCost::Layout],
+            ['min-height', 'minHeight', StyleRenderCost::Layout],
+            ['min-width', 'minWidth', StyleRenderCost::Layout],
+            ['object-fit', 'imageFit', StyleRenderCost::Paint],
+            ['opacity', 'opacity', StyleRenderCost::Composite],
+            ['overflow', 'overflow', StyleRenderCost::Paint],
+            ['padding', 'padding', StyleRenderCost::Layout],
+            ['position', 'positionType', StyleRenderCost::Layout],
+            ['place-items', 'placeItems', StyleRenderCost::Layout],
+            ['right', 'right', StyleRenderCost::Layout],
+            ['row-gap', 'gridRowGap', StyleRenderCost::Layout],
+            ['text-align', 'textAlign', StyleRenderCost::Layout],
+            ['text-decoration', 'textDecoration', StyleRenderCost::Paint],
+            ['text-transform', 'textTransform', StyleRenderCost::Layout],
+            ['top', 'top', StyleRenderCost::Layout],
+            ['transform', 'transform', StyleRenderCost::Composite],
+            ['visibility', 'visible', StyleRenderCost::Paint],
+            ['width', 'width', StyleRenderCost::Layout],
+            ['z-index', 'zIndex', StyleRenderCost::Composite],
+        ];
+        $definitions = [];
+        foreach ($rows as $index => $row) {
+            /** @var list<string> $aliases */
+            $aliases = $row[3] ?? [];
+            $definitions[] = new StylePropertyDefinition(
+                id: $index + 1,
+                cssName: $row[0],
+                nativeName: $row[1],
+                compatibility: StyleCompatibility::Native,
+                cost: $row[2],
+                aliases: $aliases,
+            );
+        }
+
+        return $definitions;
+    }
+}

--- a/packages/native/src/Style/StylePropertyDefinition.php
+++ b/packages/native/src/Style/StylePropertyDefinition.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+final readonly class StylePropertyDefinition
+{
+    /**
+     * @param list<string> $values
+     * @param list<string> $aliases
+     */
+    public function __construct(
+        public int $id,
+        public string $cssName,
+        public string $nativeName,
+        public StyleCompatibility $compatibility,
+        public StyleRenderCost $cost,
+        public int $minimumAndroidApi = 26,
+        public string $iosMinimum = '15.0',
+        public array $values = [],
+        public array $aliases = [],
+        public ?string $fallback = null,
+    ) {
+    }
+
+    /** @return array<string, int|string|list<string>|null> */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'cssName' => $this->cssName,
+            'nativeName' => $this->nativeName,
+            'compatibility' => $this->compatibility->value,
+            'cost' => $this->cost->value,
+            'minimumAndroidApi' => $this->minimumAndroidApi,
+            'iosMinimum' => $this->iosMinimum,
+            'values' => $this->values,
+            'aliases' => $this->aliases,
+            'fallback' => $this->fallback,
+        ];
+    }
+}

--- a/packages/native/src/Style/StyleQueryFeature.php
+++ b/packages/native/src/Style/StyleQueryFeature.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleQueryFeature: int
+{
+    case Width = 1;
+    case Height = 2;
+    case Orientation = 3;
+    case ColorScheme = 4;
+    case ReducedMotion = 5;
+    case Pointer = 6;
+    case DeviceType = 7;
+    case RefreshRate = 8;
+    case DynamicRange = 9;
+    case DisplayMode = 10;
+    case FoldPosture = 11;
+    case InputMode = 12;
+    case MemoryClass = 13;
+    case PerformanceTier = 14;
+}

--- a/packages/native/src/Style/StyleQueryKind.php
+++ b/packages/native/src/Style/StyleQueryKind.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleQueryKind: int
+{
+    case Media = 1;
+    case Container = 2;
+}

--- a/packages/native/src/Style/StyleQueryOperator.php
+++ b/packages/native/src/Style/StyleQueryOperator.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleQueryOperator: int
+{
+    case Equal = 1;
+    case GreaterThanOrEqual = 2;
+    case LessThanOrEqual = 3;
+    case GreaterThan = 4;
+    case LessThan = 5;
+}

--- a/packages/native/src/Style/StyleQueryValueKind.php
+++ b/packages/native/src/Style/StyleQueryValueKind.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleQueryValueKind: int
+{
+    case Number = 1;
+    case Keyword = 2;
+}

--- a/packages/native/src/Style/StyleRenderCost.php
+++ b/packages/native/src/Style/StyleRenderCost.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleRenderCost: int
+{
+    case Composite = 1;
+    case Paint = 2;
+    case Layout = 3;
+}

--- a/packages/native/src/Style/StyleScope.php
+++ b/packages/native/src/Style/StyleScope.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleScope: int
+{
+    case Scoped = 1;
+    case Module = 2;
+    case Global = 3;
+}

--- a/packages/native/src/Style/StyleValueUnit.php
+++ b/packages/native/src/Style/StyleValueUnit.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Style;
+
+enum StyleValueUnit: int
+{
+    case Number = 1;
+    case Px = 2;
+    case Dp = 3;
+    case Sp = 4;
+    case Pt = 5;
+    case Rem = 6;
+    case Percent = 7;
+    case Vw = 8;
+    case Vh = 9;
+    case Vmin = 10;
+    case Vmax = 11;
+}

--- a/packages/native/src/Tooling/PamFormatter.php
+++ b/packages/native/src/Tooling/PamFormatter.php
@@ -33,7 +33,8 @@ final class PamFormatter
             );
         }
 
-        [$php, $template, $style, $hasStyle, $language] = self::split($source, $name);
+        [$php, $template, $style, $hasStyle, $language, $styleScope] =
+            self::split($source, $name);
         $protectedTemplate = preg_replace_callback(
             '/<!--[\s\S]*?-->/',
             static fn (array $match): string =>
@@ -57,7 +58,7 @@ final class PamFormatter
 
         $formatted = rtrim($php)."\n?>\n\n".implode("\n", $lines);
         if ($hasStyle && trim($style) !== '') {
-            $formatted .= "\n\n<style scoped>\n"
+            $formatted .= "\n\n<style {$styleScope}>\n"
                 .self::style($style)
                 ."\n</style>";
         }
@@ -85,7 +86,7 @@ final class PamFormatter
         return true;
     }
 
-    /** @return array{string, string, string, bool, LanguageVersion} */
+    /** @return array{string, string, string, bool, LanguageVersion, string} */
     private static function split(string $source, string $name): array
     {
         $tokens = token_get_all($source);
@@ -111,12 +112,12 @@ final class PamFormatter
         $match = [];
         if (preg_match(
             '/\A\s*<template(?:\s+([^>]*))?>([\s\S]*?)<\/template>'
-                .'\s*(?:<style(?:\s+scoped)?\s*>([\s\S]*?)<\/style>)?\s*\z/D',
+                .'\s*(?:<style(?:\s+(scoped|module|global))?\s*>([\s\S]*?)<\/style>)?\s*\z/D',
             $markup,
             $match,
         ) !== 1) {
             throw new RuntimeException(
-                "PAM component {$name} must contain one template and optional scoped style.",
+                "PAM component {$name} must contain one template and an optional scoped, module, or global style.",
             );
         }
 
@@ -130,12 +131,18 @@ final class PamFormatter
             );
         }
 
+        $styleScope = strtolower((string) ($match[3] ?? ''));
+        if ($styleScope === '') {
+            $styleScope = 'scoped';
+        }
+
         return [
             $php,
             (string) $match[2],
-            (string) ($match[3] ?? ''),
-            array_key_exists(3, $match),
+            (string) ($match[4] ?? ''),
+            array_key_exists(4, $match),
             $language,
+            $styleScope,
         ];
     }
 

--- a/packages/native/tests/language2.php
+++ b/packages/native/tests/language2.php
@@ -6,11 +6,17 @@ use Pam\Native\AsyncValue;
 use Pam\Native\Internal\CompiledTemplateNode;
 use Pam\Native\Internal\PamPhpCompiler;
 use Pam\Native\Internal\ScopedStyleCompiler;
+use Pam\Native\Internal\StyleQueryCompiler;
+use Pam\Native\Internal\StyleTokenGenerator;
+use Pam\Native\Internal\StyleValueCompiler;
 use Pam\Native\Internal\TemplateCompiler;
 use Pam\Native\Internal\TemplateRenderer;
 use Pam\Native\LanguageVersion;
 use Pam\Native\NodeKind;
 use Pam\Native\PropKey;
+use Pam\Native\Style\StyleInvalidationKind;
+use Pam\Native\Style\StylePropertyCatalog;
+use Pam\Native\Style\StyleScope;
 use Pam\Native\Tooling\PamFormatter;
 
 $language2Tree = TemplateCompiler::compile(
@@ -119,8 +125,151 @@ $assert(
         && ($language2Styles['recipes']['card']['variants']['tone']['primary']['backgroundColor'] ?? null) === 0xFF4F46E5
         && ($language2Styles['states']['.touchable']['pressed']['opacity'] ?? null) === '0.72'
         && count($language2Styles['queries']) === 2
-        && count($language2Styles['keyframes']['enter'] ?? []) === 2,
+        && count($language2Styles['keyframes']['enter'] ?? []) === 2
+        && ($language2Styles['styleIr']['version'] ?? null) === 1
+        && ($language2Styles['styleIr']['dependencies']['container'] ?? null)
+            === StyleInvalidationKind::Container->value
+        && is_string($language2Styles['styleBytecode'] ?? null)
+        && base64_decode($language2Styles['styleBytecode'], true) !== false
+        && strlen((string) ($language2Styles['styleFingerprint'] ?? '')) === 64
+        && ($language2Styles['styleSourceMap'][0]['source'] ?? null)
+            === 'Language2Styles.pam',
     'Language 2 styles must compile tokens, recipes, states, queries and compositor keyframes to IR.',
+);
+$styleDefinitions = StylePropertyCatalog::all();
+foreach ($styleDefinitions as $index => $definition) {
+    $assert(
+        $definition->id === $index + 1,
+        'PAM Style property IDs must remain sequential and append-only.',
+    );
+}
+$assert(
+    StylePropertyCatalog::find('background')?->nativeName === 'backgroundColor'
+        && StylePropertyCatalog::find('transform')?->cost->value === 1,
+    'The public CSS compatibility catalog must resolve aliases and compositor costs.',
+);
+$moduleStyles = ScopedStyleCompiler::compile(
+    '.card { padding: 12px; }',
+    'ModuleStyles.pam',
+    StyleScope::Module,
+);
+$assert(
+    ($moduleStyles['scope'] ?? null) === StyleScope::Module->value
+        && strlen((string) ($moduleStyles['scopeId'] ?? '')) === 16
+        && ($moduleStyles['styleIr']['scope'] ?? null)
+            === StyleScope::Module->value,
+    'Style modules must carry an immutable numeric scope and deterministic scope ID.',
+);
+$generatedTokens = StyleTokenGenerator::generate([
+    '--color-brand' => '#4F46E5',
+    '--space-md' => '16px',
+]);
+$assert(
+    str_contains($generatedTokens['php'], 'public const string COLOR_BRAND')
+        && str_contains($generatedTokens['kotlin'], 'public const val SPACE_MD: String')
+        && str_contains($generatedTokens['swift'], 'public static let COLOR_BRAND: String'),
+    'Design tokens must generate typed PHP, Kotlin and Swift APIs deterministically.',
+);
+$layerStyles = ScopedStyleCompiler::compile(<<<'CSS'
+@layer reset { .card { padding: 4px; } }
+@layer components { .card { padding: 16px; } }
+CSS, 'LayerStyles.pam');
+$assert(
+    ($layerStyles['classes']['card']['paddingLeft'] ?? null) === '16',
+    'Named cascade layers must flatten in deterministic declaration order.',
+);
+$gridStyles = ScopedStyleCompiler::compile(
+    '.catalog { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; } .featured { grid-column: span 2; }',
+    'GridStyles.pam',
+);
+$assert(
+    ($gridStyles['classes']['catalog']['columns'] ?? null) === '4'
+        && ($gridStyles['classes']['featured']['span'] ?? null) === '2',
+    'CSS Grid tracks and spans must lower to the native grid layout protocol.',
+);
+$formattedModule = PamFormatter::format(<<<'PAM'
+<?php
+declare(strict_types=1);
+final class ModuleStyleExample {}
+?>
+<template language="2"><Column class="card" /></template>
+<style module>.card { padding: 12px; }</style>
+PAM, 'ModuleStyleExample.pam');
+$assert(
+    str_contains($formattedModule, '<style module>')
+        && PamFormatter::format($formattedModule, 'ModuleStyleExample.pam')
+            === $formattedModule,
+    'The formatter must preserve module style isolation idempotently.',
+);
+$modernWidthQuery = StyleQueryCompiler::compile(
+    '(width >= 840dp)',
+    'ModernQueries.pam',
+);
+$darkQuery = StyleQueryCompiler::compile(
+    '(prefers-color-scheme: dark)',
+    'ModernQueries.pam',
+);
+$assert(
+    StyleQueryCompiler::matches($modernWidthQuery, ['width' => 900.0])
+        && !StyleQueryCompiler::matches($modernWidthQuery, ['width' => 700.0])
+        && StyleQueryCompiler::matches($darkQuery, ['colorScheme' => 'dark'])
+        && !StyleQueryCompiler::matches($darkQuery, ['colorScheme' => 'light']),
+    'Modern comparison and platform preference queries must compile to typed IR and evaluate deterministically.',
+);
+$fluidStyles = ScopedStyleCompiler::compile(
+    '.fluid { width: calc(100vw - 32px); padding-left: clamp(12px, 2vw, 24px); }',
+    'FluidStyles.pam',
+);
+$fluidWidth = $fluidStyles['classes']['fluid']['width'] ?? null;
+$fluidPadding = $fluidStyles['classes']['fluid']['paddingLeft'] ?? null;
+$assert(
+    is_string($fluidWidth)
+        && is_string($fluidPadding)
+        && StyleValueCompiler::encoded($fluidWidth)
+        && StyleValueCompiler::encoded($fluidPadding)
+        && StyleValueCompiler::resolve($fluidWidth, ['width' => 400.0, 'height' => 800.0]) === 368.0
+        && StyleValueCompiler::resolve($fluidPadding, ['width' => 400.0, 'height' => 800.0]) === 12.0,
+    'CSS calc(), clamp() and viewport units must compile once and resolve deterministically.',
+);
+$safeInset = StyleValueCompiler::encode(
+    'calc(env(safe-area-inset-top) + 8dp)',
+    'SafeInset.pam',
+);
+$assert(
+    StyleValueCompiler::resolve($safeInset, [
+        'width' => 400.0,
+        'height' => 800.0,
+        'env.safe-area-inset-top' => 24.0,
+    ]) === 32.0,
+    'Native env() values must participate in compiled CSS math.',
+);
+
+$cascadeStyles = ScopedStyleCompiler::compile(<<<'CSS'
+View.card { padding: 8px; background: #111111; }
+#shell > View.card[role="region"] { padding: 12px; }
+.shell .card { background: #222222 !important; }
+View.card { background: #333333; }
+CSS, 'CascadeStyles.pam');
+$cascadeTemplate = TemplateCompiler::compile(
+    '<Column id="shell" class="shell"><View class="card" role="region" /></Column>',
+    'CascadeStyles.pam',
+    LanguageVersion::Language2,
+);
+$cascadeRoot = new CompiledTemplateNode(
+    kind: $cascadeTemplate->kind,
+    name: $cascadeTemplate->name,
+    attributes: ['__pamStyles' => json_encode($cascadeStyles, JSON_THROW_ON_ERROR)],
+    source: $cascadeTemplate->source,
+    line: $cascadeTemplate->line,
+    column: $cascadeTemplate->column,
+);
+$cascadeRoot->children = $cascadeTemplate->children;
+$cascadeElement = TemplateRenderer::render($cascadeRoot, null, [])->children()[0] ?? null;
+$assert(
+    $cascadeElement instanceof \Pam\Native\Element
+        && (float) ($cascadeElement->properties()[PropKey::PaddingLeft->value] ?? 0) === 12.0
+        && ($cascadeElement->properties()[PropKey::BackgroundColor->value] ?? null) === 0xFF222222,
+    'Compound, child, descendant and attribute selectors must honor specificity and !important.',
 );
 
 $styledTemplate = TemplateCompiler::compile(


### PR DESCRIPTION
## Outcome

Introduces the typed CSS-to-native foundation for PAM Native:

- deterministic PAMS v1 IR, bytecode, fingerprints, source maps, compatibility and render-cost manifest
- scoped/module/global ownership
- compiled selectors with compound, ID, attribute, descendant and child matching
- specificity, source order, cascade layers and !important
- modern media/container query AST with device-aware features
- calc/min/max/clamp, viewport/relative units and native env values
- native Grid lowering
- compound pressed-state lowering
- typed PHP/Kotlin/Swift token generation
- pam style inspect/manifest/tokens tooling

## Verification

- PHP SDK suite passes
- 66 pam-native-engine Rust tests pass
- Composer manifest validates strictly
- Android debug build succeeds
- API 36 emulator launch succeeds without fatal logcat entries
- visual showcase validates fluid type, tokens, complex cascade, Grid/span and native paint

The work intentionally keeps property/kind IDs as sequential integer enums and adds no runtime dependency.