### PR TITLE
chore(release): PAM Native 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.0 - 2026-08-24
+
+- Introduces PAM Style Language 1.0 with deterministic PAMS IR, bytecode, fingerprints, source maps, compatibility metadata, and granular invalidation dependencies.
+- Adds compiled compound, ID, attribute, child, and descendant selectors with specificity, source order, cascade layers, and `!important`.
+- Adds native Grid lowering, modern media/container queries, CSS math and relative units, native environment values, and scoped/module/global ownership.
+- Adds typed design-token generation for PHP, Kotlin, and Swift plus `pam style inspect`, `manifest`, and `tokens` tooling.
+- Certifies the new style pipeline on PHP 8.5, Rust, Android API 26–36, Swift/UIKit, and an Android API 36 visual consumer.
+
 ## 0.8.8 - 2026-08-24
 
 - Align the public PHP SDK contract with the runtime release so the immutable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.8.8"
+version = "0.9.0"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.8"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/examples/community-plugin/pam-native.plugin.json
+++ b/examples/community-plugin/pam-native.plugin.json
@@ -4,7 +4,7 @@
     "protocol": 1,
     "pamNative": {
         "minimum": "0.8.0",
-        "maximumExclusive": "0.9.0"
+        "maximumExclusive": "0.10.0"
     },
     "php": {
         "provider": "PamCommunity\\Example\\ExamplePluginProvider"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.8.8';
+    public const string SDK_VERSION = '0.9.0';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4587,7 +4587,7 @@ file_put_contents(
     "protocol": 1,
     "pamNative": {
         "minimum": "0.3.0",
-        "maximumExclusive": "0.9.0"
+        "maximumExclusive": "0.10.0"
     },
     "php": {
         "provider": "Pam\\Native\\Tests\\Fixtures\\ExamplePluginProvider"
@@ -6239,8 +6239,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.8.8',
-    'The runtime SDK contract must match the 0.8.8 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.9.0',
+    'The runtime SDK contract must match the 0.9.0 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,


### PR DESCRIPTION
Publishes PAM Style Engine 1.0 as PAM Native 0.9.0.

- bumps Rust workspace and PHP SDK contracts
- updates plugin compatibility through the 0.9 line
- records the complete Style Engine feature set and certification evidence

Local gates: PHP SDK, Cargo metadata, release workflow contracts, hot-reload evidence, and diff checks pass. The tag will be created only after CI is green.