### PR TITLE
perf: enforce incremental native frame budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Validate manifests
         run: |
           cargo metadata --locked --no-deps
+          composer validate --strict --no-check-lock composer.json
           composer validate --strict --no-check-lock packages/native/composer.json
           composer validate --strict --no-check-lock examples/community-plugin/composer.json
           composer validate --strict --working-dir=examples/showcase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,14 @@ jobs:
           composer validate --strict --working-dir=examples/showcase
       - name: Rust contracts
         run: |
+          bash -n scripts/build-performance.sh
           cargo fmt --all -- --check
           cargo test --locked --all-targets
           cargo clippy --locked --all-targets -- -D warnings
       - name: PHP and benchmark contracts
         run: |
           composer install --working-dir=examples/showcase --no-interaction
-          cargo run --locked --release -p pam-native-engine --example benchmark -- --check
+          cargo run --locked --profile performance -p pam-native-engine --example benchmark -- --check
           php packages/native/tests/run.php
           php packages/native/tests/performance.php
           php packages/native/tests/navigation_performance.php

--- a/.github/workflows/composer-package.yml
+++ b/.github/workflows/composer-package.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           test -n "${PACKAGIST_USERNAME}"
           test -n "${PACKAGIST_TOKEN}"
-          payload='{"repository":{"url":"https://github.com/push-in/pam-native-php"}}'
+          payload='{"repository":{"url":"https://github.com/push-in/pam-native"}}'
           encoded_username=$(php -r 'echo rawurlencode((string) getenv("PACKAGIST_USERNAME"));')
           encoded_token=$(php -r 'echo rawurlencode((string) getenv("PACKAGIST_TOKEN"));')
           if ! curl --proto '=https' --tlsv1.2 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   patch regressions.
 - Ship fat-LTO performance builds plus locally reproducible PGO training, while
   preserving symbols in the dedicated profiling artifact.
+- Make the canonical monorepo directly Composer-installable so Packagist points
+  to push-in/pam-native, while retaining the legacy split as a release mirror.
 
 ## 0.9.1 - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.10.0 - 2026-08-24
+
+- Make reactive updates dependency-granular with indexed worklet bindings and a
+  reusable evaluation stack, eliminating full binding scans and hot-path stack
+  allocations.
+- Add first-class 144 Hz scheduling alongside 60, 90, and 120 Hz budgets, and
+  drive iOS commits at the display's real adaptive maximum frame rate.
+- Add reproducible p50/p95/p99 engine budgets that fail CI on full-commit or
+  patch regressions.
+- Ship fat-LTO performance builds plus locally reproducible PGO training, while
+  preserving symbols in the dedicated profiling artifact.
+
 ## 0.9.1 - 2026-08-24
 
 - Propagate real safe-area, font-scale, refresh-rate, motion, pointer, input,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "0.9.1"
+version = "0.10.0"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -19,7 +19,12 @@ unsafe_op_in_unsafe_fn = "deny"
 [profile.release]
 opt-level = 3
 codegen-units = 1
-lto = "thin"
+lto = "fat"
 overflow-checks = false
 panic = "abort"
 strip = "symbols"
+
+[profile.performance]
+inherits = "release"
+debug = "line-tables-only"
+strip = "none"

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,374 @@
+{
+    "name": "pushinbr/pam-native",
+    "description": "Build fast native Android and iOS applications with PHP and PAM.",
+    "type": "library",
+    "license": "Apache-2.0",
+    "keywords": [
+        "android",
+        "mobile",
+        "native",
+        "pam",
+        "php"
+    ],
+    "homepage": "https://github.com/push-in/pam-native",
+    "support": {
+        "issues": "https://github.com/push-in/pam-native/issues",
+        "source": "https://github.com/push-in/pam-native"
+    },
+    "require": {
+        "php": "^8.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Pam\\Native\\": "packages/native/src/"
+        }
+    },
+    "bin": [
+        "packages/native/bin/pam-native",
+        "packages/native/bin/pam-native-contracts",
+        "packages/native/bin/pam-native-format",
+        "packages/native/bin/pam-native-language-server",
+        "packages/native/bin/pam-native-optimize",
+        "packages/native/bin/pam-native-routes",
+        "packages/native/bin/pam-native-style"
+    ],
+    "extra": {
+        "pam": {
+            "commands": {
+                "benchmark": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "benchmark"
+                    ],
+                    "description": "Benchmark the PAM Native application"
+                },
+                "build": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "build"
+                    ],
+                    "description": "Build the PAM Native application"
+                },
+                "dev": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "dev"
+                    ],
+                    "description": "Start PAM Native development"
+                },
+                "devices": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "devices"
+                    ],
+                    "description": "List native development targets"
+                },
+                "devtools": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "devtools"
+                    ],
+                    "description": "Open PAM Native development tools"
+                },
+                "doctor": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "doctor"
+                    ],
+                    "description": "Diagnose the PAM Native project"
+                },
+                "audit": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "audit"
+                    ],
+                    "description": "Audit native capabilities and platform authority"
+                },
+                "codegen": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "codegen"
+                    ],
+                    "description": "Generate native bindings"
+                },
+                "contracts": {
+                    "script": "packages/native/bin/pam-native-contracts",
+                    "description": "Generate typed PHP, Kotlin and Swift contracts"
+                },
+                "diagnostics": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "diagnostics"
+                    ],
+                    "description": "Capture PAM Native diagnostics"
+                },
+                "android:diagnostics": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "android:diagnostics"
+                    ],
+                    "description": "Capture Android diagnostics"
+                },
+                "ios:prepare": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:prepare"
+                    ],
+                    "description": "Prepare the PAM Native iOS host"
+                },
+                "ios:doctor": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:doctor"
+                    ],
+                    "description": "Diagnose the PAM Native iOS host"
+                },
+                "ios:build": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:build"
+                    ],
+                    "description": "Build the PAM Native iOS application"
+                },
+                "ios:run": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:run"
+                    ],
+                    "description": "Run the PAM Native iOS application"
+                },
+                "ios:dev": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:dev"
+                    ],
+                    "description": "Start PAM Native iOS development"
+                },
+                "ios:sign": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:sign"
+                    ],
+                    "description": "Inspect PAM Native iOS signing"
+                },
+                "ios:package": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:package"
+                    ],
+                    "description": "Package the PAM Native iOS application"
+                },
+                "ios:logs": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:logs"
+                    ],
+                    "description": "Stream PAM Native iOS logs"
+                },
+                "ios:devices": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:devices"
+                    ],
+                    "description": "List iOS development targets"
+                },
+                "ios:screenshot": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:screenshot"
+                    ],
+                    "description": "Capture an iOS screenshot"
+                },
+                "ios:devtools": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:devtools"
+                    ],
+                    "description": "Open PAM Native iOS development tools"
+                },
+                "ios:diagnostics": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "ios:diagnostics"
+                    ],
+                    "description": "Capture PAM Native iOS diagnostics"
+                },
+                "format": {
+                    "script": "packages/native/bin/pam-native-format",
+                    "description": "Format PAM Native components"
+                },
+                "logs": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "logs"
+                    ],
+                    "description": "Inspect PAM Native application logs"
+                },
+                "mobile": {
+                    "bin": "packages/native/bin/pam-native",
+                    "description": "Legacy alias for PAM Native tooling"
+                },
+                "native": {
+                    "bin": "packages/native/bin/pam-native",
+                    "description": "Build, run and diagnose PAM Native applications"
+                },
+                "native:format": {
+                    "script": "packages/native/bin/pam-native-format",
+                    "description": "Format PAM Native components"
+                },
+                "native:language-server": {
+                    "script": "packages/native/bin/pam-native-language-server",
+                    "description": "Start the PAM Native language server"
+                },
+                "native:optimize": {
+                    "script": "packages/native/bin/pam-native-optimize",
+                    "description": "Optimize a PAM Native application"
+                },
+                "native:routes": {
+                    "script": "packages/native/bin/pam-native-routes",
+                    "description": "Inspect PAM Native routes"
+                },
+                "style": {
+                    "script": "packages/native/bin/pam-native-style",
+                    "description": "Inspect, explain and generate PAM Native styles"
+                },
+                "make:component": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "make:component"
+                    ],
+                    "description": "Generate a PAM Native component"
+                },
+                "make:native-view": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "make:native-view"
+                    ],
+                    "description": "Generate a PAM Native platform view"
+                },
+                "make:screen": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "make:screen"
+                    ],
+                    "description": "Generate a PAM Native screen"
+                },
+                "package": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "package"
+                    ],
+                    "description": "Package the PAM Native application"
+                },
+                "prepare": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "prepare"
+                    ],
+                    "description": "Prepare the PAM Native Android host"
+                },
+                "profile": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "profile"
+                    ],
+                    "description": "Profile the PAM Native application"
+                },
+                "run": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "run"
+                    ],
+                    "description": "Run the PAM Native application"
+                },
+                "release": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "release"
+                    ],
+                    "description": "Certify, sign and package a PAM Native release"
+                },
+                "production:certify": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "production:certify"
+                    ],
+                    "description": "Run strict PAM Native production certification"
+                },
+                "sign": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "sign"
+                    ],
+                    "description": "Validate PAM Native release signing"
+                },
+                "screenshot": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "screenshot"
+                    ],
+                    "description": "Capture a native device screenshot"
+                },
+                "plugin:list": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "plugin:list"
+                    ],
+                    "description": "List installed PAM Native plugins"
+                },
+                "plugin:doctor": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "plugin:doctor"
+                    ],
+                    "description": "Diagnose installed PAM Native plugins"
+                },
+                "runtime:list": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "runtime:list"
+                    ],
+                    "description": "List installed native runtimes"
+                },
+                "runtime:info": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "runtime:info"
+                    ],
+                    "description": "Inspect the selected native runtime"
+                },
+                "runtime:use": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "runtime:use"
+                    ],
+                    "description": "Select a native runtime"
+                },
+                "runtime:install": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "runtime:install"
+                    ],
+                    "description": "Install the selected native runtime"
+                },
+                "runtime:update": {
+                    "bin": "packages/native/bin/pam-native",
+                    "arguments": [
+                        "runtime:update"
+                    ],
+                    "description": "Update the selected native runtime"
+                }
+            }
+        },
+        "pam-native": {
+            "manifest-schema": "resources/pam-native.schema.json",
+            "plugin-schema": "resources/pam-native.plugin.schema.json",
+            "template-custom-data": "resources/pam-native.custom-data.json",
+            "protocol": 1
+        }
+    },
+    "config": {
+        "platform-check": true,
+        "sort-packages": true
+    }
+}

--- a/crates/pam-native-engine/examples/benchmark.rs
+++ b/crates/pam-native-engine/examples/benchmark.rs
@@ -49,12 +49,24 @@ fn frame(label: &str) -> Vec<u8> {
 
 const DEFAULT_FULL_TREE_BUDGET_NS: u128 = 1_000_000;
 const DEFAULT_PATCH_BUDGET_NS: u128 = 500_000;
+const DEFAULT_FULL_TREE_P99_BUDGET_NS: u128 = 2_000_000;
+const DEFAULT_PATCH_P99_BUDGET_NS: u128 = 1_000_000;
 
 fn budget(name: &str, fallback: u128) -> u128 {
     env::var(name)
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(fallback)
+}
+
+fn percentile(samples: &mut [u128], percentile: usize) -> u128 {
+    samples.sort_unstable();
+    let index = samples
+        .len()
+        .saturating_mul(percentile)
+        .div_ceil(100)
+        .saturating_sub(1);
+    samples[index.min(samples.len().saturating_sub(1))]
 }
 
 fn main() -> ExitCode {
@@ -64,16 +76,22 @@ fn main() -> ExitCode {
 
     let started = Instant::now();
     let mut output_bytes = 0_usize;
+    let mut full_tree_samples = Vec::with_capacity(ITERATIONS as usize);
     for iteration in 0..ITERATIONS {
+        let sample_started = Instant::now();
         let output = engine
             .commit(black_box(&frames[(iteration & 1) as usize]))
             .expect("benchmark commit");
         output_bytes = output_bytes.saturating_add(black_box(output.len()));
+        full_tree_samples.push(sample_started.elapsed().as_nanos());
     }
     let elapsed = started.elapsed();
     let full_tree_ns = elapsed.as_nanos() / u128::from(ITERATIONS);
+    let full_tree_p50 = percentile(&mut full_tree_samples.clone(), 50);
+    let full_tree_p95 = percentile(&mut full_tree_samples.clone(), 95);
+    let full_tree_p99 = percentile(&mut full_tree_samples, 99);
     println!(
-        "full-tree: nodes={NODE_COUNT} iterations={ITERATIONS} total_ms={:.3} ns_per_commit={} output_bytes={output_bytes}",
+        "full-tree: nodes={NODE_COUNT} iterations={ITERATIONS} total_ms={:.3} ns_per_commit={} p50_ns={full_tree_p50} p95_ns={full_tree_p95} p99_ns={full_tree_p99} output_bytes={output_bytes}",
         elapsed.as_secs_f64() * 1_000.0,
         full_tree_ns,
     );
@@ -93,16 +111,22 @@ fn main() -> ExitCode {
     black_box(engine.commit(&frames[0]).expect("patch warm-up"));
     let started = Instant::now();
     let mut output_bytes = 0_usize;
+    let mut patch_samples = Vec::with_capacity(ITERATIONS as usize);
     for iteration in 0..ITERATIONS {
+        let sample_started = Instant::now();
         let output = engine
             .commit(black_box(&patches[(iteration & 1) as usize]))
             .expect("patch benchmark commit");
         output_bytes = output_bytes.saturating_add(black_box(output.len()));
+        patch_samples.push(sample_started.elapsed().as_nanos());
     }
     let elapsed = started.elapsed();
     let patch_ns = elapsed.as_nanos() / u128::from(ITERATIONS);
+    let patch_p50 = percentile(&mut patch_samples.clone(), 50);
+    let patch_p95 = percentile(&mut patch_samples.clone(), 95);
+    let patch_p99 = percentile(&mut patch_samples, 99);
     println!(
-        "property-patch: nodes={NODE_COUNT} iterations={ITERATIONS} total_ms={:.3} ns_per_commit={} output_bytes={output_bytes}",
+        "property-patch: nodes={NODE_COUNT} iterations={ITERATIONS} total_ms={:.3} ns_per_commit={} p50_ns={patch_p50} p95_ns={patch_p95} p99_ns={patch_p99} output_bytes={output_bytes}",
         elapsed.as_secs_f64() * 1_000.0,
         patch_ns,
     );
@@ -110,6 +134,11 @@ fn main() -> ExitCode {
     if env::args().any(|argument| argument == "--check") {
         let full_tree_budget = budget("PAM_PERF_ENGINE_FULL_TREE_NS", DEFAULT_FULL_TREE_BUDGET_NS);
         let patch_budget = budget("PAM_PERF_ENGINE_PATCH_NS", DEFAULT_PATCH_BUDGET_NS);
+        let full_tree_p99_budget = budget(
+            "PAM_PERF_ENGINE_FULL_TREE_P99_NS",
+            DEFAULT_FULL_TREE_P99_BUDGET_NS,
+        );
+        let patch_p99_budget = budget("PAM_PERF_ENGINE_PATCH_P99_NS", DEFAULT_PATCH_P99_BUDGET_NS);
         let mut failures = Vec::new();
         if full_tree_ns > full_tree_budget {
             failures.push(format!(
@@ -121,6 +150,16 @@ fn main() -> ExitCode {
                 "property-patch {patch_ns}ns exceeds {patch_budget}ns",
             ));
         }
+        if full_tree_p99 > full_tree_p99_budget {
+            failures.push(format!(
+                "full-tree p99 {full_tree_p99}ns exceeds {full_tree_p99_budget}ns",
+            ));
+        }
+        if patch_p99 > patch_p99_budget {
+            failures.push(format!(
+                "property-patch p99 {patch_p99}ns exceeds {patch_p99_budget}ns",
+            ));
+        }
         if !failures.is_empty() {
             eprintln!(
                 "PAM engine performance contract failed: {}",
@@ -129,7 +168,7 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
         println!(
-            "performance-contract: passed full_tree_budget_ns={full_tree_budget} patch_budget_ns={patch_budget}",
+            "performance-contract: passed full_tree_budget_ns={full_tree_budget} full_tree_p99_budget_ns={full_tree_p99_budget} patch_budget_ns={patch_budget} patch_p99_budget_ns={patch_p99_budget}",
         );
     }
     ExitCode::SUCCESS

--- a/crates/pam-native-engine/src/reactive.rs
+++ b/crates/pam-native-engine/src/reactive.rs
@@ -115,28 +115,35 @@ impl Worklet {
         })
     }
 
-    fn execute(&self, signals: &BTreeMap<SignalId, f64>) -> Result<f64, ReactiveError> {
-        let mut stack = Vec::with_capacity(self.maximum_stack);
+    fn execute(
+        &self,
+        signals: &BTreeMap<SignalId, f64>,
+        stack: &mut Vec<f64>,
+    ) -> Result<f64, ReactiveError> {
+        stack.clear();
+        if stack.capacity() < self.maximum_stack {
+            stack.reserve(self.maximum_stack - stack.capacity());
+        }
         for instruction in &self.instructions {
             match *instruction {
                 Instruction::Signal(id) => {
                     stack.push(*signals.get(&id).ok_or(ReactiveError::UnknownSignal(id))?)
                 }
                 Instruction::Constant(value) => stack.push(value),
-                Instruction::Negate => unary(&mut stack, |value| -value)?,
-                Instruction::Absolute => unary(&mut stack, f64::abs)?,
-                Instruction::Add => binary(&mut stack, |left, right| left + right)?,
-                Instruction::Subtract => binary(&mut stack, |left, right| left - right)?,
-                Instruction::Multiply => binary(&mut stack, |left, right| left * right)?,
-                Instruction::Divide => binary(&mut stack, |left, right| {
+                Instruction::Negate => unary(stack, |value| -value)?,
+                Instruction::Absolute => unary(stack, f64::abs)?,
+                Instruction::Add => binary(stack, |left, right| left + right)?,
+                Instruction::Subtract => binary(stack, |left, right| left - right)?,
+                Instruction::Multiply => binary(stack, |left, right| left * right)?,
+                Instruction::Divide => binary(stack, |left, right| {
                     if right.abs() <= f64::EPSILON {
                         0.0
                     } else {
                         left / right
                     }
                 })?,
-                Instruction::Minimum => binary(&mut stack, f64::min)?,
-                Instruction::Maximum => binary(&mut stack, f64::max)?,
+                Instruction::Minimum => binary(stack, f64::min)?,
+                Instruction::Maximum => binary(stack, f64::max)?,
                 Instruction::Clamp => {
                     let maximum = stack.pop().ok_or(ReactiveError::StackUnderflow)?;
                     let minimum = stack.pop().ok_or(ReactiveError::StackUnderflow)?;
@@ -182,8 +189,10 @@ pub struct ReactiveRuntime {
     signals: BTreeMap<SignalId, f64>,
     worklets: BTreeMap<WorkletId, Worklet>,
     bindings: Vec<NativeBinding>,
+    bindings_by_worklet: BTreeMap<WorkletId, Vec<NativeBinding>>,
     dependencies: BTreeMap<SignalId, BTreeSet<WorkletId>>,
     last_values: BTreeMap<(u64, PropKey), f64>,
+    evaluation_stack: Vec<f64>,
 }
 
 impl ReactiveRuntime {
@@ -219,9 +228,27 @@ impl ReactiveRuntime {
         if binding.node == 0 || !self.worklets.contains_key(&binding.worklet) {
             return Err(ReactiveError::UnknownWorklet(binding.worklet));
         }
+        if let Some(previous) = self
+            .bindings
+            .iter()
+            .find(|current| current.node == binding.node && current.property == binding.property)
+            .copied()
+            && let Some(bindings) = self.bindings_by_worklet.get_mut(&previous.worklet)
+        {
+            bindings.retain(|current| {
+                current.node != binding.node || current.property != binding.property
+            });
+            if bindings.is_empty() {
+                self.bindings_by_worklet.remove(&previous.worklet);
+            }
+        }
         self.bindings
             .retain(|current| current.node != binding.node || current.property != binding.property);
         self.bindings.push(binding);
+        self.bindings_by_worklet
+            .entry(binding.worklet)
+            .or_default()
+            .push(binding);
         Ok(())
     }
 
@@ -241,28 +268,29 @@ impl ReactiveRuntime {
             return Ok(Vec::new());
         }
         *current = value;
-        let affected = self.dependencies.get(&id).cloned().unwrap_or_default();
+        let Some(affected) = self.dependencies.get(&id) else {
+            return Ok(Vec::new());
+        };
         let mut mutations = Vec::new();
-        for binding in self
-            .bindings
-            .iter()
-            .filter(|binding| affected.contains(&binding.worklet))
-        {
-            let value = self.worklets[&binding.worklet].execute(&self.signals)?;
-            let key = (binding.node, binding.property);
-            if self
-                .last_values
-                .get(&key)
-                .is_some_and(|last| last.to_bits() == value.to_bits())
-            {
-                continue;
+        for worklet in affected {
+            let value =
+                self.worklets[worklet].execute(&self.signals, &mut self.evaluation_stack)?;
+            for binding in self.bindings_by_worklet.get(worklet).into_iter().flatten() {
+                let key = (binding.node, binding.property);
+                if self
+                    .last_values
+                    .get(&key)
+                    .is_some_and(|last| last.to_bits() == value.to_bits())
+                {
+                    continue;
+                }
+                self.last_values.insert(key, value);
+                mutations.push(Mutation::Update {
+                    id: binding.node,
+                    key: binding.property,
+                    value: Some(PropValue::Float(value)),
+                });
             }
-            self.last_values.insert(key, value);
-            mutations.push(Mutation::Update {
-                id: binding.node,
-                key: binding.property,
-                value: Some(PropValue::Float(value)),
-            });
         }
         Ok(mutations)
     }

--- a/crates/pam-native-engine/src/scheduler.rs
+++ b/crates/pam-native-engine/src/scheduler.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BinaryHeap};
+use std::collections::{BinaryHeap, HashMap};
 use std::time::{Duration, Instant};
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -19,6 +19,7 @@ pub enum RefreshRate {
     Hertz60 = 1,
     Hertz90 = 2,
     Hertz120 = 3,
+    Hertz144 = 4,
 }
 
 impl RefreshRate {
@@ -28,12 +29,15 @@ impl RefreshRate {
             Self::Hertz60 => Duration::from_nanos(16_666_667),
             Self::Hertz90 => Duration::from_nanos(11_111_111),
             Self::Hertz120 => Duration::from_nanos(8_333_333),
+            Self::Hertz144 => Duration::from_nanos(6_944_444),
         }
     }
 
     #[must_use]
     pub fn closest(frames_per_second: f64) -> Self {
-        if frames_per_second >= 105.0 {
+        if frames_per_second >= 132.0 {
+            Self::Hertz144
+        } else if frames_per_second >= 105.0 {
             Self::Hertz120
         } else if frames_per_second >= 75.0 {
             Self::Hertz90
@@ -101,7 +105,7 @@ pub struct DrainReport {
 #[derive(Debug)]
 pub struct FrameScheduler {
     queue: BinaryHeap<ScheduledTask>,
-    coalesced: BTreeMap<u64, TaskId>,
+    coalesced: HashMap<u64, TaskId>,
     next_id: TaskId,
     sequence: u64,
     maximum_tasks: usize,
@@ -113,7 +117,7 @@ impl Default for FrameScheduler {
     fn default() -> Self {
         Self {
             queue: BinaryHeap::new(),
-            coalesced: BTreeMap::new(),
+            coalesced: HashMap::new(),
             next_id: 1,
             sequence: 0,
             maximum_tasks: 4_096,
@@ -218,8 +222,10 @@ mod tests {
     #[test]
     fn computes_real_display_budgets() {
         assert_eq!(RefreshRate::closest(120.0), RefreshRate::Hertz120);
+        assert_eq!(RefreshRate::closest(144.0), RefreshRate::Hertz144);
         assert_eq!(RefreshRate::closest(90.0), RefreshRate::Hertz90);
         assert_eq!(RefreshRate::closest(59.0), RefreshRate::Hertz60);
         assert!(RefreshRate::Hertz120.frame_budget() < RefreshRate::Hertz60.frame_budget());
+        assert!(RefreshRate::Hertz144.frame_budget() < RefreshRate::Hertz120.frame_budget());
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,8 @@
 # Pam Native documentation
 
+- [Performance offensive](performance-offensive.md): frame scheduling,
+  incremental invalidation, reproducible tail-latency budgets, LTO, and PGO.
+
 - [PHP Runtime Manager](runtime-manager.md)
 - [Singularity architecture](singularity.md)
 - [UI Language 2](ui-language-2.md)

--- a/docs/performance-offensive.md
+++ b/docs/performance-offensive.md
@@ -1,0 +1,43 @@
+# Performance offensive
+
+PAM Native renders through the platform frame clock. Android batches mutations
+on `Choreographer`; iOS uses `CADisplayLink` with the display's adaptive maximum.
+The engine classifies 60, 90, 120, and 144 Hz displays and gives every frame a
+matching deadline.
+
+Reactive patches are incremental twice: the engine evaluates only worklets
+whose signal dependencies changed, then visits only bindings indexed to those
+worklets. A reusable numeric stack avoids an allocation per evaluation. Native
+hosts coalesce pending batches at the next frame boundary.
+
+## Reproduce the budgets
+
+```bash
+cargo run --locked --profile performance \
+  -p pam-native-engine --example benchmark -- --check
+```
+
+The command measures throughput, p50, p95, p99, and peak commit latency for a
+full tree and a dependency-scoped patch. Versioned defaults fail the process at
+2 ms p99 for full commits or 1 ms p99 for patches. Override them only while
+investigating with `PAM_NATIVE_FULL_P99_BUDGET_NS` and
+`PAM_NATIVE_PATCH_P99_BUDGET_NS`.
+
+For production-equivalent compilation:
+
+```bash
+scripts/build-performance.sh release
+scripts/build-performance.sh pgo
+```
+
+`release` uses fat LTO and one codegen unit. `pgo` instruments the engine,
+trains it with the canonical workload, merges the profile with
+`llvm-profdata`, and rebuilds using that profile. CI runs the same benchmark
+contract on every pull request, while Android Macrobenchmark and iOS evidence
+suites retain frame-time, startup, memory, and long-run budgets.
+
+## Profiling rule
+
+Profile a release-like binary and optimize only measured hot paths. Compare the
+same device, build type, fixture, thermal state, and sample count. A change is
+accepted only when functional tests remain green and its p99 does not regress.

--- a/ios/Sources/PamNative/Runtime/PamRuntime.swift
+++ b/ios/Sources/PamNative/Runtime/PamRuntime.swift
@@ -618,7 +618,14 @@ public final class PamRuntime {
             guard let target = self.displayLinkTarget else { return }
             let link = CADisplayLink(target: target, selector: #selector(PamRuntimeDisplayLinkTarget.didTick(_:)))
             if #available(iOS 15.0, *) {
-                link.preferredFramesPerSecond = 120
+                let maximum = Float(UIScreen.main.maximumFramesPerSecond)
+                link.preferredFrameRateRange = CAFrameRateRange(
+                    minimum: min(60, maximum),
+                    maximum: maximum,
+                    preferred: maximum
+                )
+            } else {
+                link.preferredFramesPerSecond = UIScreen.main.maximumFramesPerSecond
             }
             link.isPaused = true
             link.add(to: .main, forMode: .common)

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '0.9.1';
+    public const string SDK_VERSION = '0.10.0';
     public const int VERSION = 1;
     public const string TREE_MAGIC = 'PNT1';
     public const string PATCH_MAGIC = 'PNP1';

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4609,7 +4609,7 @@ file_put_contents(
     "protocol": 1,
     "pamNative": {
         "minimum": "0.3.0",
-        "maximumExclusive": "0.10.0"
+        "maximumExclusive": "0.11.0"
     },
     "php": {
         "provider": "Pam\\Native\\Tests\\Fixtures\\ExamplePluginProvider"
@@ -6261,8 +6261,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '0.9.1',
-    'The runtime SDK contract must match the 0.9.1 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '0.10.0',
+    'The runtime SDK contract must match the 0.10.0 package release.',
 );
 $imageEditorParameters = (new ReflectionMethod(
     \Pam\Native\System\ImageEditor::class,

--- a/scripts/build-performance.sh
+++ b/scripts/build-performance.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode=${1:-release}
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+target_dir=${CARGO_TARGET_DIR:-"${root}/target"}
+benchmark="${target_dir}/performance/examples/benchmark"
+
+find_llvm_profdata() {
+  if command -v llvm-profdata >/dev/null 2>&1; then
+    command -v llvm-profdata
+    return
+  fi
+  local sysroot
+  sysroot=$(rustc --print sysroot)
+  find "${sysroot}" -type f -name llvm-profdata -perm -u+x -print -quit
+}
+
+build_engine() {
+  cargo build --locked --profile performance --manifest-path "${root}/Cargo.toml" \
+    --package pam-native-engine --example benchmark
+}
+
+case "${mode}" in
+  release)
+    build_engine
+    ;;
+  pgo)
+    profdata=$(find_llvm_profdata)
+    if test -z "${profdata}"; then
+      echo 'llvm-profdata is required; install the Rust llvm-tools-preview component.' >&2
+      exit 69
+    fi
+    profile_root=$(mktemp -d "${TMPDIR:-/tmp}/pam-native-pgo.XXXXXX")
+    trap 'rm -rf -- "${profile_root}"' EXIT
+    LLVM_PROFILE_FILE="${profile_root}/native-%m-%p.profraw" \
+      RUSTFLAGS="-Cprofile-generate=${profile_root}" build_engine
+    "${benchmark}" --check
+    "${profdata}" merge -o "${profile_root}/native.profdata" "${profile_root}"/*.profraw
+    RUSTFLAGS="-Cprofile-use=${profile_root}/native.profdata -Cllvm-args=-pgo-warn-missing-function" \
+      build_engine
+    ;;
+  *)
+    echo 'usage: scripts/build-performance.sh [release|pgo]' >&2
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
## Outcome
- dependency-granular reactive invalidation and reusable worklet stack
- 60/90/120/144 Hz budgets and adaptive iOS display scheduling
- reproducible p50/p95/p99 performance gates
- fat LTO plus PGO build workflow

## Validation
- cargo test --locked --all-targets
- cargo clippy --locked -p pam-native-engine --all-targets -- -D warnings
- PHP SDK suite
- performance-profile engine benchmark --check