### PR TITLE
release: prepare Native 1.0.2 community gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.2 - 2026-08-25
+
+- Keep the checked-out PAM candidate outside the Native Cargo workspace during
+  the mandatory clean-starter release gate.
+- Restore the end-to-end `pam init --template mobile` plus `pam dev` journey in
+  release certification without weakening workspace isolation.
+
 ## 1.0.1 - 2026-08-25
 
 - Refresh the immutable Android ecosystem lock to the independently versioned

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.1"
+version = "1.0.2"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,10 @@ members = [
     "crates/pam-native-engine",
     "crates/pam-native-protocol",
 ]
+exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.1';
+    public const string SDK_VERSION = '1.0.2';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.1',
-    'The runtime SDK contract must match the stable 1.0.1 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.2',
+    'The runtime SDK contract must match the stable 1.0.2 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Excludes the checked-out PAM candidate from the Native Cargo workspace so the mandatory clean `pam init --template mobile` and `pam dev` release gate can build the candidate runtime. Bumps the runtime and PHP SDK to 1.0.2. The nested checkout path was reproduced locally and accepted by Cargo metadata.