### PR TITLE
fix(release): include Nitro in ecosystem publishing

### DIFF
--- a/.github/workflows/publish-ecosystem.yml
+++ b/.github/workflows/publish-ecosystem.yml
@@ -38,7 +38,7 @@ jobs:
             pam-native-widgets pam-native-firebase pam-native-laravel-sync
             pam-native-sync-laravel
             pam-native-camera pam-native-media-editor pam-native-canvas
-            pam-native-gpu pam-native-3d pam-native-image
+            pam-native-gpu pam-native-3d pam-native-image pam-native-nitro
           )
           if [[ "${SELECTED_PACKAGE}" != all ]]; then
             valid=false


### PR DESCRIPTION
## Summary
- include the already-official Nitro package in the central Packagist refresh allowlist
- make `package=all` cover the complete official ecosystem

## Validation
- workflow YAML parsed successfully