### PR TITLE
release: prepare PAM Native 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.6 - 2026-08-25
+
+- Recover automatically from bounded transient Android package-service and ADB
+  transport failures while preserving immediate failure for real APK errors.
+- Keep clean first-run builds deterministic even on slow software-emulated CI
+  devices without hiding invalid signatures, storage failures or bad packages.
+
 ## 1.0.5 - 2026-08-25
 
 - Resolve the versioned PAM install root from the public launcher before clean

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.5"
+version = "1.0.6"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.5"
+version = "1.0.6"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -30,6 +30,7 @@ const PLUGIN_MANIFEST_MAX_BYTES: u64 = 1024 * 1024;
 const RUNTIME_LOCK_VERSION: u32 = 1;
 const MAX_ANDROID_RUNTIME_ARCHIVE_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_CHECKSUM_BYTES: u64 = 4 * 1024;
+const ADB_INSTALL_ATTEMPTS: usize = 4;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BuildMode {
@@ -6785,7 +6786,7 @@ fn connected_abi() -> Result<AndroidAbi, String> {
 }
 
 fn install_and_launch(project: &Project, apk: &Path, mode: BuildMode) -> Result<(), String> {
-    command_status("adb", &["install", "-r", apk.to_string_lossy().as_ref()])?;
+    install_apk(apk)?;
     let application_id = match mode {
         BuildMode::Debug => debug_application_id(project),
         BuildMode::Release => project.manifest.application_id.clone(),
@@ -6803,6 +6804,64 @@ fn install_and_launch(project: &Project, apk: &Path, mode: BuildMode) -> Result<
     )?;
     println!("Started {application_id}");
     Ok(())
+}
+
+fn install_apk(apk: &Path) -> Result<(), String> {
+    let apk = apk.to_string_lossy();
+    for attempt in 1..=ADB_INSTALL_ATTEMPTS {
+        let output = Command::new("adb")
+            .args(["install", "-r", apk.as_ref()])
+            .output()
+            .map_err(|error| format!("cannot start adb install: {error}"))?;
+        std::io::stdout()
+            .write_all(&output.stdout)
+            .map_err(|error| format!("cannot write adb output: {error}"))?;
+        std::io::stderr()
+            .write_all(&output.stderr)
+            .map_err(|error| format!("cannot write adb error output: {error}"))?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let diagnostic = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if attempt == ADB_INSTALL_ATTEMPTS || !transient_adb_install_failure(&diagnostic) {
+            return Err(format!(
+                "adb install failed with status {}: {}",
+                output.status,
+                diagnostic.trim()
+            ));
+        }
+
+        eprintln!(
+            "pam-native: transient adb package-service failure; retrying install ({}/{})",
+            attempt + 1,
+            ADB_INSTALL_ATTEMPTS
+        );
+        std::thread::sleep(Duration::from_secs(attempt as u64 * 2));
+        let _ = Command::new("adb")
+            .args(["shell", "getprop", "sys.boot_completed"])
+            .output();
+    }
+    unreachable!("bounded adb install loop always returns")
+}
+
+fn transient_adb_install_failure(diagnostic: &str) -> bool {
+    let diagnostic = diagnostic.to_ascii_lowercase();
+    [
+        "broken pipe",
+        "connection reset",
+        "device offline",
+        "protocol fault",
+        "failure calling service package",
+        "can't find service: package",
+        "cannot connect to daemon",
+    ]
+    .iter()
+    .any(|message| diagnostic.contains(message))
 }
 
 fn debug_application_id(project: &Project) -> String {
@@ -8043,6 +8102,23 @@ mod tests {
             "https://mirror.example/pam/v2.0.10"
         );
         assert!(!android_runtime_release_base(None).contains(env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn retries_only_transient_adb_package_service_failures() {
+        assert!(transient_adb_install_failure(
+            "cmd: Failure calling service package: Broken pipe (32)"
+        ));
+        assert!(transient_adb_install_failure("error: device offline"));
+        assert!(transient_adb_install_failure(
+            "adb: failed to install app.apk: can't find service: package"
+        ));
+        assert!(!transient_adb_install_failure(
+            "Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]"
+        ));
+        assert!(!transient_adb_install_failure(
+            "Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"
+        ));
     }
 
     #[test]

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.5';
+    public const string SDK_VERSION = '1.0.6';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.5',
-    'The runtime SDK contract must match the stable 1.0.5 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.6',
+    'The runtime SDK contract must match the stable 1.0.6 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
## Summary
- retry only bounded, classified transient ADB transport/package-service install failures
- preserve immediate failure for invalid signatures, incompatible updates and storage errors
- probe device boot state between attempts and retain complete ADB diagnostics
- promote Rust and PHP SDK surfaces to 1.0.6

## Validation
- classifier regression covers the exact CI `Broken pipe (32)` failure and fail-fast cases
- `cargo test --workspace --locked` (109 tests)
- deterministic ZIP and release workflow suites
- PHP SDK test suite