### PR TITLE
fix: wait for Android package service recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.7 - 2026-08-25
+
+- Wait for Android's package manager service, not only `sys.boot_completed`,
+  before installing an APK and after a transient package-service restart.
+- Keep the recovery bounded and preserve fail-fast behavior for permanent APK
+  installation errors.
+
 ## 1.0.6 - 2026-08-25
 
 - Recover automatically from bounded transient Android package-service and ADB

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.6"
+version = "1.0.7"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -31,6 +31,8 @@ const RUNTIME_LOCK_VERSION: u32 = 1;
 const MAX_ANDROID_RUNTIME_ARCHIVE_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_CHECKSUM_BYTES: u64 = 4 * 1024;
 const ADB_INSTALL_ATTEMPTS: usize = 4;
+const ADB_PACKAGE_SERVICE_POLLS: usize = 60;
+const ADB_PACKAGE_SERVICE_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BuildMode {
@@ -6808,6 +6810,7 @@ fn install_and_launch(project: &Project, apk: &Path, mode: BuildMode) -> Result<
 
 fn install_apk(apk: &Path) -> Result<(), String> {
     let apk = apk.to_string_lossy();
+    wait_for_adb_package_service()?;
     for attempt in 1..=ADB_INSTALL_ATTEMPTS {
         let output = Command::new("adb")
             .args(["install", "-r", apk.as_ref()])
@@ -6837,16 +6840,52 @@ fn install_apk(apk: &Path) -> Result<(), String> {
         }
 
         eprintln!(
-            "pam-native: transient adb package-service failure; retrying install ({}/{})",
+            "pam-native: transient adb package-service failure; waiting for Android to recover before install ({}/{})",
             attempt + 1,
             ADB_INSTALL_ATTEMPTS
         );
-        std::thread::sleep(Duration::from_secs(attempt as u64 * 2));
-        let _ = Command::new("adb")
-            .args(["shell", "getprop", "sys.boot_completed"])
-            .output();
+        wait_for_adb_package_service()?;
     }
     unreachable!("bounded adb install loop always returns")
+}
+
+fn wait_for_adb_package_service() -> Result<(), String> {
+    let mut last_diagnostic = String::new();
+    for poll in 1..=ADB_PACKAGE_SERVICE_POLLS {
+        match Command::new("adb")
+            .args(["shell", "service", "check", "package"])
+            .output()
+        {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                if adb_package_service_ready(output.status.success(), &stdout, &stderr) {
+                    return Ok(());
+                }
+                last_diagnostic = format!("{}\n{}", stdout.trim(), stderr.trim());
+            }
+            Err(error) => last_diagnostic = error.to_string(),
+        }
+
+        if poll < ADB_PACKAGE_SERVICE_POLLS {
+            std::thread::sleep(ADB_PACKAGE_SERVICE_POLL_INTERVAL);
+        }
+    }
+
+    Err(format!(
+        "Android package service did not become ready within {} seconds; last adb response: {}",
+        ADB_PACKAGE_SERVICE_POLLS * ADB_PACKAGE_SERVICE_POLL_INTERVAL.as_secs() as usize,
+        last_diagnostic.trim()
+    ))
+}
+
+fn adb_package_service_ready(status_success: bool, stdout: &str, stderr: &str) -> bool {
+    if !status_success {
+        return false;
+    }
+    format!("{stdout}\n{stderr}")
+        .to_ascii_lowercase()
+        .contains("service package: found")
 }
 
 fn transient_adb_install_failure(diagnostic: &str) -> bool {
@@ -8118,6 +8157,25 @@ mod tests {
         ));
         assert!(!transient_adb_install_failure(
             "Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"
+        ));
+    }
+
+    #[test]
+    fn waits_for_the_android_package_service_instead_of_boot_completed_only() {
+        assert!(adb_package_service_ready(
+            true,
+            "Service package: found\n",
+            ""
+        ));
+        assert!(!adb_package_service_ready(
+            true,
+            "Service package: not found\n",
+            ""
+        ));
+        assert!(!adb_package_service_ready(
+            false,
+            "Service package: found\n",
+            "error: device offline"
         ));
     }
 

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.6';
+    public const string SDK_VERSION = '1.0.7';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.6',
-    'The runtime SDK contract must match the stable 1.0.6 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.7',
+    'The runtime SDK contract must match the stable 1.0.7 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
## Root cause
The v1.0.6 clean-room emulator reported sys.boot_completed, but Android package manager died during the first streamed install. The previous bounded retries happened before the package service recovered.

## Fix
- gate every install on Android service check package readiness
- wait up to 120 seconds for package-manager recovery after transient failures
- retain four bounded install attempts and fail fast for permanent APK errors
- promote the immutable retry candidate to 1.0.7

## Evidence
- 31 CLI tests, including exact package-service readiness parsing
- 67 engine tests
- 12 protocol tests
- PHP SDK suite
- deterministic ZIP tests
- release workflow contract tests
- locked Cargo metadata