### PR TITLE
fix: wait for Android system providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.8 - 2026-08-25
+
+- Require both Android's package service and global settings provider to be
+  operational before APK installation, closing the gap between a superficial
+  emulator boot and a usable Package Installer.
+- Recover from the bounded Android startup state where system providers are
+  still being installed without retrying permanent application failures.
+
 ## 1.0.7 - 2026-08-25
 
 - Wait for Android's package manager service, not only `sys.boot_completed`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.7"
+version = "1.0.8"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.7"
+version = "1.0.8"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -31,8 +31,8 @@ const RUNTIME_LOCK_VERSION: u32 = 1;
 const MAX_ANDROID_RUNTIME_ARCHIVE_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_CHECKSUM_BYTES: u64 = 4 * 1024;
 const ADB_INSTALL_ATTEMPTS: usize = 4;
-const ADB_PACKAGE_SERVICE_POLLS: usize = 60;
-const ADB_PACKAGE_SERVICE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const ADB_INSTALL_SERVICE_POLLS: usize = 60;
+const ADB_INSTALL_SERVICE_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BuildMode {
@@ -6810,7 +6810,7 @@ fn install_and_launch(project: &Project, apk: &Path, mode: BuildMode) -> Result<
 
 fn install_apk(apk: &Path) -> Result<(), String> {
     let apk = apk.to_string_lossy();
-    wait_for_adb_package_service()?;
+    wait_for_android_install_services()?;
     for attempt in 1..=ADB_INSTALL_ATTEMPTS {
         let output = Command::new("adb")
             .args(["install", "-r", apk.as_ref()])
@@ -6844,14 +6844,14 @@ fn install_apk(apk: &Path) -> Result<(), String> {
             attempt + 1,
             ADB_INSTALL_ATTEMPTS
         );
-        wait_for_adb_package_service()?;
+        wait_for_android_install_services()?;
     }
     unreachable!("bounded adb install loop always returns")
 }
 
-fn wait_for_adb_package_service() -> Result<(), String> {
+fn wait_for_android_install_services() -> Result<(), String> {
     let mut last_diagnostic = String::new();
-    for poll in 1..=ADB_PACKAGE_SERVICE_POLLS {
+    for poll in 1..=ADB_INSTALL_SERVICE_POLLS {
         match Command::new("adb")
             .args(["shell", "service", "check", "package"])
             .output()
@@ -6860,21 +6860,47 @@ fn wait_for_adb_package_service() -> Result<(), String> {
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 if adb_package_service_ready(output.status.success(), &stdout, &stderr) {
-                    return Ok(());
+                    match Command::new("adb")
+                        .args(["shell", "settings", "get", "global", "device_provisioned"])
+                        .output()
+                    {
+                        Ok(settings) => {
+                            let settings_stdout = String::from_utf8_lossy(&settings.stdout);
+                            let settings_stderr = String::from_utf8_lossy(&settings.stderr);
+                            if adb_settings_provider_ready(
+                                settings.status.success(),
+                                &settings_stdout,
+                                &settings_stderr,
+                            ) {
+                                return Ok(());
+                            }
+                            last_diagnostic = format!(
+                                "package service ready; settings provider response: {}\n{}",
+                                settings_stdout.trim(),
+                                settings_stderr.trim()
+                            );
+                        }
+                        Err(error) => {
+                            last_diagnostic = format!(
+                                "package service ready; cannot query settings provider: {error}"
+                            );
+                        }
+                    }
+                } else {
+                    last_diagnostic = format!("{}\n{}", stdout.trim(), stderr.trim());
                 }
-                last_diagnostic = format!("{}\n{}", stdout.trim(), stderr.trim());
             }
             Err(error) => last_diagnostic = error.to_string(),
         }
 
-        if poll < ADB_PACKAGE_SERVICE_POLLS {
-            std::thread::sleep(ADB_PACKAGE_SERVICE_POLL_INTERVAL);
+        if poll < ADB_INSTALL_SERVICE_POLLS {
+            std::thread::sleep(ADB_INSTALL_SERVICE_POLL_INTERVAL);
         }
     }
 
     Err(format!(
-        "Android package service did not become ready within {} seconds; last adb response: {}",
-        ADB_PACKAGE_SERVICE_POLLS * ADB_PACKAGE_SERVICE_POLL_INTERVAL.as_secs() as usize,
+        "Android package and settings services did not become ready within {} seconds; last adb response: {}",
+        ADB_INSTALL_SERVICE_POLLS * ADB_INSTALL_SERVICE_POLL_INTERVAL.as_secs() as usize,
         last_diagnostic.trim()
     ))
 }
@@ -6888,6 +6914,13 @@ fn adb_package_service_ready(status_success: bool, stdout: &str, stderr: &str) -
         .contains("service package: found")
 }
 
+fn adb_settings_provider_ready(status_success: bool, stdout: &str, stderr: &str) -> bool {
+    if !status_success || !stderr.trim().is_empty() {
+        return false;
+    }
+    matches!(stdout.trim(), "0" | "1")
+}
+
 fn transient_adb_install_failure(diagnostic: &str) -> bool {
     let diagnostic = diagnostic.to_ascii_lowercase();
     [
@@ -6897,6 +6930,8 @@ fn transient_adb_install_failure(diagnostic: &str) -> bool {
         "protocol fault",
         "failure calling service package",
         "can't find service: package",
+        "cannot access system provider",
+        "before system providers are installed",
         "cannot connect to daemon",
     ]
     .iter()
@@ -8152,6 +8187,9 @@ mod tests {
         assert!(transient_adb_install_failure(
             "adb: failed to install app.apk: can't find service: package"
         ));
+        assert!(transient_adb_install_failure(
+            "java.lang.IllegalStateException: Cannot access system provider: 'settings' before system providers are installed!"
+        ));
         assert!(!transient_adb_install_failure(
             "Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]"
         ));
@@ -8177,6 +8215,14 @@ mod tests {
             "Service package: found\n",
             "error: device offline"
         ));
+        assert!(adb_settings_provider_ready(true, "1\n", ""));
+        assert!(adb_settings_provider_ready(true, "0\n", ""));
+        assert!(!adb_settings_provider_ready(
+            false,
+            "",
+            "java.lang.IllegalStateException: Cannot access system provider: settings"
+        ));
+        assert!(!adb_settings_provider_ready(true, "null\n", ""));
     }
 
     #[test]

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.7';
+    public const string SDK_VERSION = '1.0.8';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.7',
-    'The runtime SDK contract must match the stable 1.0.7 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.8',
+    'The runtime SDK contract must match the stable 1.0.8 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
## Root cause
The v1.0.7 gate proved that Android can expose the package binder service before the global settings provider is usable. APK installation then fails while the emulator is still installing system providers.

## Fix
- require both package service and global settings provider readiness
- recognize the exact system-provider initialization exception as transient
- keep the 120-second bound, four install attempts, and permanent-error fail-fast behavior
- promote the immutable candidate to v1.0.8

## Evidence
- 31 CLI tests with package/settings readiness and exact exception regression
- 67 engine tests
- 12 protocol tests
- PHP SDK, deterministic archive, locked metadata and release workflow contracts