### PR TITLE
fix: wait for Android storage readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.9 - 2026-08-25
+
+- Require Android's storage manager to return mounted-volume state before APK
+  installation, in addition to the package and settings readiness probes.
+- Recover only from the exact Package Installer startup signature involving
+  `InstallLocationUtils` and a null `StorageManager`, while unrelated null
+  pointer failures remain fail-fast.
+
 ## 1.0.8 - 2026-08-25
 
 - Require both Android's package service and global settings provider to be

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.8"
+version = "1.0.9"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.8"
+version = "1.0.9"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -6872,13 +6872,41 @@ fn wait_for_android_install_services() -> Result<(), String> {
                                 &settings_stdout,
                                 &settings_stderr,
                             ) {
-                                return Ok(());
+                                match Command::new("adb")
+                                    .args(["shell", "sm", "list-volumes", "all"])
+                                    .output()
+                                {
+                                    Ok(storage) => {
+                                        let storage_stdout =
+                                            String::from_utf8_lossy(&storage.stdout);
+                                        let storage_stderr =
+                                            String::from_utf8_lossy(&storage.stderr);
+                                        if adb_storage_manager_ready(
+                                            storage.status.success(),
+                                            &storage_stdout,
+                                            &storage_stderr,
+                                        ) {
+                                            return Ok(());
+                                        }
+                                        last_diagnostic = format!(
+                                            "package and settings ready; storage manager response: {}\n{}",
+                                            storage_stdout.trim(),
+                                            storage_stderr.trim()
+                                        );
+                                    }
+                                    Err(error) => {
+                                        last_diagnostic = format!(
+                                            "package and settings ready; cannot query storage manager: {error}"
+                                        );
+                                    }
+                                }
+                            } else {
+                                last_diagnostic = format!(
+                                    "package service ready; settings provider response: {}\n{}",
+                                    settings_stdout.trim(),
+                                    settings_stderr.trim()
+                                );
                             }
-                            last_diagnostic = format!(
-                                "package service ready; settings provider response: {}\n{}",
-                                settings_stdout.trim(),
-                                settings_stderr.trim()
-                            );
                         }
                         Err(error) => {
                             last_diagnostic = format!(
@@ -6899,7 +6927,7 @@ fn wait_for_android_install_services() -> Result<(), String> {
     }
 
     Err(format!(
-        "Android package and settings services did not become ready within {} seconds; last adb response: {}",
+        "Android package, settings and storage services did not become ready within {} seconds; last adb response: {}",
         ADB_INSTALL_SERVICE_POLLS * ADB_INSTALL_SERVICE_POLL_INTERVAL.as_secs() as usize,
         last_diagnostic.trim()
     ))
@@ -6921,9 +6949,13 @@ fn adb_settings_provider_ready(status_success: bool, stdout: &str, stderr: &str)
     matches!(stdout.trim(), "0" | "1")
 }
 
+fn adb_storage_manager_ready(status_success: bool, stdout: &str, stderr: &str) -> bool {
+    status_success && stderr.trim().is_empty() && !stdout.trim().is_empty()
+}
+
 fn transient_adb_install_failure(diagnostic: &str) -> bool {
     let diagnostic = diagnostic.to_ascii_lowercase();
-    [
+    let known_service_failure = [
         "broken pipe",
         "connection reset",
         "device offline",
@@ -6935,7 +6967,11 @@ fn transient_adb_install_failure(diagnostic: &str) -> bool {
         "cannot connect to daemon",
     ]
     .iter()
-    .any(|message| diagnostic.contains(message))
+    .any(|message| diagnostic.contains(message));
+    let storage_startup_failure = diagnostic.contains("installlocationutils")
+        && diagnostic.contains("storagemanager.getvolumes()")
+        && diagnostic.contains("null object reference");
+    known_service_failure || storage_startup_failure
 }
 
 fn debug_application_id(project: &Project) -> String {
@@ -8190,6 +8226,12 @@ mod tests {
         assert!(transient_adb_install_failure(
             "java.lang.IllegalStateException: Cannot access system provider: 'settings' before system providers are installed!"
         ));
+        assert!(transient_adb_install_failure(
+            "java.lang.NullPointerException: StorageManager.getVolumes() on a null object reference at InstallLocationUtils.resolveInstallVolume"
+        ));
+        assert!(!transient_adb_install_failure(
+            "java.lang.NullPointerException: unrelated application exception"
+        ));
         assert!(!transient_adb_install_failure(
             "Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]"
         ));
@@ -8223,6 +8265,17 @@ mod tests {
             "java.lang.IllegalStateException: Cannot access system provider: settings"
         ));
         assert!(!adb_settings_provider_ready(true, "null\n", ""));
+        assert!(adb_storage_manager_ready(
+            true,
+            "private mounted null\nemulated;0 mounted null\n",
+            ""
+        ));
+        assert!(!adb_storage_manager_ready(true, "", ""));
+        assert!(!adb_storage_manager_ready(
+            false,
+            "",
+            "java.lang.NullPointerException"
+        ));
     }
 
     #[test]

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.8';
+    public const string SDK_VERSION = '1.0.9';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.8',
-    'The runtime SDK contract must match the stable 1.0.8 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.9',
+    'The runtime SDK contract must match the stable 1.0.9 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
## Root cause
The v1.0.8 clean-room proved that Package Manager and Settings can be ready while StorageManager is still null inside InstallLocationUtils.

## Fix
- require mounted-volume output from Android storage manager before installing
- retry only the exact InstallLocationUtils plus StorageManager.getVolumes startup signature
- preserve bounded recovery and permanent APK fail-fast behavior
- promote the immutable candidate to v1.0.9

## Evidence
31 CLI, 67 engine and 12 protocol tests; exact storage startup and unrelated NPE regressions; PHP SDK; deterministic archive; release workflow contracts; locked Cargo metadata.