### PR TITLE
fix: recover Android installs during cold boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.10 - 2026-08-26
+
+- Makes Android boot-cold installs resilient to partially initialized package/storage services with a bounded recovery window and automatic non-streaming ADB fallback.
+- Recognizes the Android 36 `PackageManagerInternal.freeStorage` startup race without hiding permanent installation failures.
+
 ## 1.0.9 - 2026-08-25
 
 - Require Android's storage manager to return mounted-volume state before APK

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.9"
+version = "1.0.10"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.9"
+version = "1.0.10"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -30,9 +30,10 @@ const PLUGIN_MANIFEST_MAX_BYTES: u64 = 1024 * 1024;
 const RUNTIME_LOCK_VERSION: u32 = 1;
 const MAX_ANDROID_RUNTIME_ARCHIVE_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_CHECKSUM_BYTES: u64 = 4 * 1024;
-const ADB_INSTALL_ATTEMPTS: usize = 4;
+const ADB_INSTALL_ATTEMPTS: usize = 12;
 const ADB_INSTALL_SERVICE_POLLS: usize = 60;
 const ADB_INSTALL_SERVICE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const ADB_INSTALL_RECOVERY_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BuildMode {
@@ -6812,8 +6813,16 @@ fn install_apk(apk: &Path) -> Result<(), String> {
     let apk = apk.to_string_lossy();
     wait_for_android_install_services()?;
     for attempt in 1..=ADB_INSTALL_ATTEMPTS {
-        let output = Command::new("adb")
-            .args(["install", "-r", apk.as_ref()])
+        let mut command = Command::new("adb");
+        command.arg("install");
+        if attempt > 1 {
+            // A booting PackageInstaller may expose its binder before its storage
+            // collaborators exist. The non-streaming transport avoids that broken
+            // write-session path while Android finishes bringing services online.
+            command.arg("--no-streaming");
+        }
+        let output = command
+            .args(["-r", apk.as_ref()])
             .output()
             .map_err(|error| format!("cannot start adb install: {error}"))?;
         std::io::stdout()
@@ -6840,11 +6849,12 @@ fn install_apk(apk: &Path) -> Result<(), String> {
         }
 
         eprintln!(
-            "pam-native: transient adb package-service failure; waiting for Android to recover before install ({}/{})",
+            "pam-native: transient adb install-service failure; waiting for Android to recover before non-streaming retry ({}/{})",
             attempt + 1,
             ADB_INSTALL_ATTEMPTS
         );
         wait_for_android_install_services()?;
+        std::thread::sleep(ADB_INSTALL_RECOVERY_INTERVAL);
     }
     unreachable!("bounded adb install loop always returns")
 }
@@ -6971,7 +6981,9 @@ fn transient_adb_install_failure(diagnostic: &str) -> bool {
     let storage_startup_failure = diagnostic.contains("installlocationutils")
         && diagnostic.contains("storagemanager.getvolumes()")
         && diagnostic.contains("null object reference");
-    known_service_failure || storage_startup_failure
+    let package_storage_startup_failure = diagnostic.contains("packagemanagerinternal.freestorage")
+        && diagnostic.contains("null object reference");
+    known_service_failure || storage_startup_failure || package_storage_startup_failure
 }
 
 fn debug_application_id(project: &Project) -> String {
@@ -8228,6 +8240,9 @@ mod tests {
         ));
         assert!(transient_adb_install_failure(
             "java.lang.NullPointerException: StorageManager.getVolumes() on a null object reference at InstallLocationUtils.resolveInstallVolume"
+        ));
+        assert!(transient_adb_install_failure(
+            "java.lang.NullPointerException: PackageManagerInternal.freeStorage(java.lang.String, long, int) on a null object reference"
         ));
         assert!(!transient_adb_install_failure(
             "java.lang.NullPointerException: unrelated application exception"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.9';
+    public const string SDK_VERSION = '1.0.10';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.9',
-    'The runtime SDK contract must match the stable 1.0.9 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.10',
+    'The runtime SDK contract must match the stable 1.0.10 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Prepares v1.0.10. Android 36 can expose package/storage binders before PackageManagerInternal is initialized. The CLI now classifies that exact startup race, uses a bounded 12-attempt recovery window, and falls back to non-streaming ADB install after the first transient failure. Permanent install failures remain fail-closed. Full Rust workspace (110 tests), PHP SDK tests, formatting, and diff validation pass locally.