### PR TITLE
fix: wait for Android activity registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.11 - 2026-08-26
+
+- Waits for Android to register a successfully installed activity before launching it, covering the final package-manager cold-boot race with bounded retries.
+- Keeps permission, manifest and other permanent launch failures fail-closed instead of retrying them.
+
 ## 1.0.10 - 2026-08-26
 
 - Makes Android boot-cold installs resilient to partially initialized package/storage services with a bounded recovery window and automatic non-streaming ADB fallback.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.10"
+version = "1.0.11"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.10"
+version = "1.0.11"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -34,6 +34,8 @@ const ADB_INSTALL_ATTEMPTS: usize = 12;
 const ADB_INSTALL_SERVICE_POLLS: usize = 60;
 const ADB_INSTALL_SERVICE_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const ADB_INSTALL_RECOVERY_INTERVAL: Duration = Duration::from_secs(5);
+const ADB_LAUNCH_ATTEMPTS: usize = 60;
+const ADB_LAUNCH_RETRY_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BuildMode {
@@ -6794,19 +6796,52 @@ fn install_and_launch(project: &Project, apk: &Path, mode: BuildMode) -> Result<
         BuildMode::Debug => debug_application_id(project),
         BuildMode::Release => project.manifest.application_id.clone(),
     };
-    command_status(
-        "adb",
-        &[
-            "shell",
-            "am",
-            "start",
-            "-W",
-            "-n",
-            &format!("{application_id}/dev.pam.nativeapp.PamActivity"),
-        ],
-    )?;
+    launch_android_activity(&application_id)?;
     println!("Started {application_id}");
     Ok(())
+}
+
+fn launch_android_activity(application_id: &str) -> Result<(), String> {
+    let component = format!("{application_id}/dev.pam.nativeapp.PamActivity");
+    let mut last_diagnostic = String::new();
+    for attempt in 1..=ADB_LAUNCH_ATTEMPTS {
+        let output = Command::new("adb")
+            .args(["shell", "am", "start", "-W", "-n", &component])
+            .output()
+            .map_err(|error| format!("cannot start adb activity launch: {error}"))?;
+        std::io::stdout()
+            .write_all(&output.stdout)
+            .map_err(|error| format!("cannot write adb output: {error}"))?;
+        std::io::stderr()
+            .write_all(&output.stderr)
+            .map_err(|error| format!("cannot write adb error output: {error}"))?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        last_diagnostic = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if attempt == ADB_LAUNCH_ATTEMPTS || !transient_adb_launch_failure(&last_diagnostic) {
+            return Err(format!(
+                "adb activity launch failed with status {}: {}",
+                output.status,
+                last_diagnostic.trim()
+            ));
+        }
+        eprintln!(
+            "pam-native: Android accepted the install but has not registered the activity yet; waiting before launch ({}/{})",
+            attempt + 1,
+            ADB_LAUNCH_ATTEMPTS
+        );
+        std::thread::sleep(ADB_LAUNCH_RETRY_INTERVAL);
+    }
+    Err(format!(
+        "Android activity did not become visible: {}",
+        last_diagnostic.trim()
+    ))
 }
 
 fn install_apk(apk: &Path) -> Result<(), String> {
@@ -6984,6 +7019,18 @@ fn transient_adb_install_failure(diagnostic: &str) -> bool {
     let package_storage_startup_failure = diagnostic.contains("packagemanagerinternal.freestorage")
         && diagnostic.contains("null object reference");
     known_service_failure || storage_startup_failure || package_storage_startup_failure
+}
+
+fn transient_adb_launch_failure(diagnostic: &str) -> bool {
+    let diagnostic = diagnostic.to_ascii_lowercase();
+    (diagnostic.contains("error type 3")
+        && diagnostic.contains("activity class")
+        && diagnostic.contains("does not exist"))
+        || diagnostic.contains("unable to resolve intent")
+        || diagnostic.contains("failure calling service activity")
+        || diagnostic.contains("can't find service: activity")
+        || diagnostic.contains("device offline")
+        || diagnostic.contains("broken pipe")
 }
 
 fn debug_application_id(project: &Project) -> String {
@@ -8252,6 +8299,22 @@ mod tests {
         ));
         assert!(!transient_adb_install_failure(
             "Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"
+        ));
+    }
+
+    #[test]
+    fn retries_only_transient_adb_activity_registration_failures() {
+        assert!(transient_adb_launch_failure(
+            "Error type 3: Activity class {dev.pam.app/dev.pam.nativeapp.PamActivity} does not exist."
+        ));
+        assert!(transient_adb_launch_failure(
+            "Error: Activity not started, unable to resolve Intent"
+        ));
+        assert!(transient_adb_launch_failure(
+            "cmd: Failure calling service activity: Broken pipe (32)"
+        ));
+        assert!(!transient_adb_launch_failure(
+            "java.lang.SecurityException: Permission Denial"
         ));
     }
 

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.10';
+    public const string SDK_VERSION = '1.0.11';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.10',
-    'The runtime SDK contract must match the stable 1.0.10 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.11',
+    'The runtime SDK contract must match the stable 1.0.11 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Prepares v1.0.11. After a successful cold-boot non-streaming install, Android 36 may return before PackageManager has registered the Activity. PAM Native now retries only the known transient activity-resolution/service failures for a bounded 120-second window; permission and other permanent launch failures remain fail-closed. Full Rust workspace (111 tests), PHP SDK, formatting, and diff checks pass locally.