### PR TITLE
fix: survive late Android package-manager startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.12 - 2026-08-26
+
+- Covers Android 36's late `PackageManagerInternal.isSameApp` initialization during cold-boot activity launch.
+- Extends the bounded activity-registration recovery window to four minutes for slow emulators and first-run devices.
+
 ## 1.0.11 - 2026-08-26
 
 - Waits for Android to register a successfully installed activity before launching it, covering the final package-manager cold-boot race with bounded retries.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.11"
+version = "1.0.12"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.11"
+version = "1.0.12"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -34,7 +34,7 @@ const ADB_INSTALL_ATTEMPTS: usize = 12;
 const ADB_INSTALL_SERVICE_POLLS: usize = 60;
 const ADB_INSTALL_SERVICE_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const ADB_INSTALL_RECOVERY_INTERVAL: Duration = Duration::from_secs(5);
-const ADB_LAUNCH_ATTEMPTS: usize = 60;
+const ADB_LAUNCH_ATTEMPTS: usize = 120;
 const ADB_LAUNCH_RETRY_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -7023,6 +7023,8 @@ fn transient_adb_install_failure(diagnostic: &str) -> bool {
 
 fn transient_adb_launch_failure(diagnostic: &str) -> bool {
     let diagnostic = diagnostic.to_ascii_lowercase();
+    let package_manager_startup_failure = diagnostic.contains("packagemanagerinternal.issameapp")
+        && diagnostic.contains("null object reference");
     (diagnostic.contains("error type 3")
         && diagnostic.contains("activity class")
         && diagnostic.contains("does not exist"))
@@ -7031,6 +7033,7 @@ fn transient_adb_launch_failure(diagnostic: &str) -> bool {
         || diagnostic.contains("can't find service: activity")
         || diagnostic.contains("device offline")
         || diagnostic.contains("broken pipe")
+        || package_manager_startup_failure
 }
 
 fn debug_application_id(project: &Project) -> String {
@@ -8312,6 +8315,9 @@ mod tests {
         ));
         assert!(transient_adb_launch_failure(
             "cmd: Failure calling service activity: Broken pipe (32)"
+        ));
+        assert!(transient_adb_launch_failure(
+            "java.lang.NullPointerException: PackageManagerInternal.isSameApp(java.lang.String, int, int) on a null object reference"
         ));
         assert!(!transient_adb_launch_failure(
             "java.lang.SecurityException: Permission Denial"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.11';
+    public const string SDK_VERSION = '1.0.12';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.11',
-    'The runtime SDK contract must match the stable 1.0.11 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.12',
+    'The runtime SDK contract must match the stable 1.0.12 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Prepares v1.0.12. Android 36 may transition from unresolved Activity to a PackageManagerInternal.isSameApp null startup race after a successful install. PAM Native now recognizes that exact transient signature and allows a bounded four-minute activity-registration window while still failing permanent permission/manifest errors immediately. Full Rust workspace (111 tests), PHP SDK, formatting, and diff checks pass locally.