### PR TITLE
fix: honor Android early-launch readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.13 - 2026-08-26
+
+- Recognizes Android's explicit `Too early to start activity` response as cold-boot readiness and continues the existing bounded launch retry.
+
 ## 1.0.12 - 2026-08-26
 
 - Covers Android 36's late `PackageManagerInternal.isSameApp` initialization during cold-boot activity launch.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.12"
+version = "1.0.13"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.12"
+version = "1.0.13"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -7033,6 +7033,7 @@ fn transient_adb_launch_failure(diagnostic: &str) -> bool {
         || diagnostic.contains("can't find service: activity")
         || diagnostic.contains("device offline")
         || diagnostic.contains("broken pipe")
+        || diagnostic.contains("too early to start activity")
         || package_manager_startup_failure
 }
 
@@ -8318,6 +8319,9 @@ mod tests {
         ));
         assert!(transient_adb_launch_failure(
             "java.lang.NullPointerException: PackageManagerInternal.isSameApp(java.lang.String, int, int) on a null object reference"
+        ));
+        assert!(transient_adb_launch_failure(
+            "java.lang.IllegalStateException: Too early to start activity."
         ));
         assert!(!transient_adb_launch_failure(
             "java.lang.SecurityException: Permission Denial"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.12';
+    public const string SDK_VERSION = '1.0.13';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.12',
-    'The runtime SDK contract must match the stable 1.0.12 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.13',
+    'The runtime SDK contract must match the stable 1.0.13 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Prepares v1.0.13. Android 36 explicitly reports `IllegalStateException: Too early to start activity` while system services finish cold boot. PAM Native now treats that exact message as transient inside the existing bounded launch window; permanent launch errors remain fail-closed. The prior clean-room proved the core mobile app launch and screenshot before this signature appeared on native-ui. Full Rust workspace (111 tests), PHP SDK, formatting, and diff checks pass locally.