### PR TITLE
fix: remove Native build intermediates on exit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
           python3 -m json.tool packages/native/resources/pam-native-ui-ir.schema.json >/dev/null
           node --check editors/vscode/extension.js
           node editors/vscode/test.js
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh
 
   android:
     name: Android renderer build and unit contracts
@@ -132,6 +135,9 @@ jobs:
           path: dist/pam-native-android-prerequisites.tar.gz
           if-no-files-found: error
           retention-days: 1
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh
 
   android-instrumented:
     name: Android API ${{ matrix.api-level }} renderer contracts
@@ -182,6 +188,9 @@ jobs:
             android/app/build/outputs/androidTest-results/connected/
           if-no-files-found: warn
           retention-days: 7
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh
 
   ios:
     name: Swift and UIKit contracts
@@ -221,6 +230,9 @@ jobs:
           SWIFT_COMPILATION_MODE=wholemodule
           DEAD_CODE_STRIPPING=YES
           build
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh
 
   accessibility-evidence:
     name: Cross-platform accessibility evidence
@@ -267,3 +279,6 @@ jobs:
           path: evidence/pam-native-accessibility-evidence.json
           if-no-files-found: error
           retention-days: 30
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         run: >-
           xcodebuild
           -scheme PamNative
+          -derivedDataPath '${{ github.workspace }}/.build/DerivedData'
           -configuration Release
           -destination 'generic/platform=iOS Simulator'
           CODE_SIGNING_ALLOWED=NO
@@ -95,6 +96,9 @@ jobs:
           path: dist/pam-native-ios-*
           if-no-files-found: error
           retention-days: 7
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh
 
   android:
     name: Package Android renderer and plugin API
@@ -205,6 +209,9 @@ jobs:
           path: dist/pam-native-android-*
           if-no-files-found: error
           retention-days: 7
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh
 
   php-sdk:
     name: Package PHP SDK
@@ -263,6 +270,9 @@ jobs:
           path: dist/pam-native-php-*
           if-no-files-found: error
           retention-days: 7
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh
 
   native-cli:
     name: Package Native CLI (${{ matrix.platform }})
@@ -314,6 +324,10 @@ jobs:
           path: dist/pam-native-cli-*
           if-no-files-found: error
           retention-days: 7
+      - name: Remove regenerable build artifacts
+        if: always()
+        shell: bash
+        run: scripts/cleanup-build-artifacts.sh
 
   community-first-run:
     name: Create and run every clean community starter
@@ -382,6 +396,9 @@ jobs:
           profile: pixel_6
           disable-animations: true
           script: pam-cli/scripts/community-experience-gate.sh all
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh
 
   publish:
     name: Publish GitHub release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.14 - 2026-08-26
+
+- Makes post-build cleanup mandatory for Android and iOS development, build,
+  run and packaging flows while preserving only declared final deliverables in
+  `dist`.
+- Cleans the actual project-local Gradle home, Android build outputs, iOS
+  DerivedData and temporary export workspace after successful and failed
+  operations.
+
 ## 1.0.13 - 2026-08-26
 
 - Recognizes Android's explicit `Too early to start activity` response as cold-boot readiness and continues the existing bounded launch retry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.13"
+version = "1.0.14"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.13"
+version = "1.0.14"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ pam dev
 ```
 
 The **[PAM documentation](https://push-in.github.io/pam-docs/native/overview/)** covers prerequisites, production setup, and the complete workflow. PAM projects keep normal manifests and lockfiles; product features stay in the package that owns them.
+
+Every build follows the mandatory [build hygiene contract](docs/build-hygiene.md):
+final APK/AAB/IPA/app deliverables are preserved in `dist`, while regenerable
+Gradle, Cargo and Xcode intermediates are removed when the command exits.
 <!-- pam:product-page:end -->
 
 PAM Native lets PHP developers ship native mobile applications without adding

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -778,9 +778,12 @@ pub fn run(arguments: Vec<OsString>) -> Result<u8, String> {
             if options.abis == default_abis() {
                 options.abis = vec![connected_abi()?];
             }
-            let apk = build(options)?;
-            install_and_launch(&apk.project, &apk.path, apk.mode)?;
-            Ok(0)
+            let project_root = options.project.clone();
+            with_android_build_cleanup(&project_root, || {
+                let apk = build_intermediate(options)?;
+                install_and_launch(&apk.project, &apk.path, apk.mode)?;
+                Ok(0)
+            })
         }
         "dev" => {
             let mut options = parse_options(arguments, false)?;
@@ -3654,7 +3657,7 @@ fn replace_ios_placeholders(path: &Path, replacements: &[(&str, &str)]) -> Resul
     write_atomic(path, contents.as_bytes())
 }
 
-fn build_ios(project_path: PathBuf, release: bool) -> Result<PathBuf, String> {
+fn build_ios_intermediate(project_path: PathBuf, release: bool) -> Result<PathBuf, String> {
     if !cfg!(target_os = "macos") {
         return Err("iOS builds require macOS with Xcode".to_owned());
     }
@@ -3693,6 +3696,29 @@ fn build_ios(project_path: PathBuf, release: bool) -> Result<PathBuf, String> {
     Ok(app)
 }
 
+fn build_ios(project_path: PathBuf, release: bool) -> Result<PathBuf, String> {
+    let project = load_project(&project_path)?;
+    with_ios_build_cleanup(&project.root, || {
+        let app = build_ios_intermediate(project.root.clone(), release)?;
+        let output = project.root.join("dist");
+        fs::create_dir_all(&output)
+            .map_err(|error| format!("cannot create {}: {error}", output.display()))?;
+        let destination = output.join(format!(
+            "{}-{}-ios-{}.app",
+            android_artifact_stem(&project),
+            project.manifest.version_name,
+            if release { "release" } else { "debug" }
+        ));
+        if destination.exists() {
+            fs::remove_dir_all(&destination)
+                .map_err(|error| format!("cannot replace {}: {error}", destination.display()))?;
+        }
+        copy_tree(&app, &destination, &[])?;
+        println!("Preserved {}", destination.display());
+        Ok(destination)
+    })
+}
+
 fn booted_ios_simulator() -> Result<String, String> {
     let output = Command::new("xcrun")
         .args(["simctl", "list", "devices", "booted", "--json"])
@@ -3717,10 +3743,12 @@ fn booted_ios_simulator() -> Result<String, String> {
 
 fn run_ios(project_path: PathBuf) -> Result<u8, String> {
     let project = load_project(&project_path)?;
-    let simulator = booted_ios_simulator()?;
-    let app = build_ios(project.root.clone(), false)?;
-    install_and_launch_ios(&project, &simulator, &app)?;
-    Ok(0)
+    with_ios_build_cleanup(&project.root, || {
+        let simulator = booted_ios_simulator()?;
+        let app = build_ios_intermediate(project.root.clone(), false)?;
+        install_and_launch_ios(&project, &simulator, &app)?;
+        Ok(0)
+    })
 }
 
 fn install_and_launch_ios(project: &Project, simulator: &str, app: &Path) -> Result<(), String> {
@@ -3743,6 +3771,11 @@ fn install_and_launch_ios(project: &Project, simulator: &str, app: &Path) -> Res
 
 fn dev_ios(project_path: PathBuf) -> Result<u8, String> {
     let project = load_project(&project_path)?;
+    let root = project.root.clone();
+    with_ios_build_cleanup(&root, || dev_ios_intermediate(project))
+}
+
+fn dev_ios_intermediate(project: Project) -> Result<u8, String> {
     crate::dev_event::emit(
         crate::dev_event::EventCode::SessionStarting,
         crate::dev_event::SurfaceCode::Ios,
@@ -3751,7 +3784,7 @@ fn dev_ios(project_path: PathBuf) -> Result<u8, String> {
     );
     clean_ios_dev_artifacts(&project.root)?;
     let simulator = booted_ios_simulator()?;
-    let app = build_ios(project.root.clone(), false)?;
+    let app = build_ios_intermediate(project.root.clone(), false)?;
     install_and_launch_ios(&project, &simulator, &app)?;
     println!(
         "Pam Native iOS hot reload listening on 127.0.0.1:{DEFAULT_PORT}. Press Ctrl+C to stop."
@@ -3842,12 +3875,32 @@ fn clean_android_dev_artifacts(project_path: &Path) -> Result<(), String> {
     let paths = [
         generated.join("app/build"),
         generated.join("build"),
-        generated.join("gradle-home/caches"),
-        generated.join("gradle-home/daemon"),
-        generated.join("gradle-home/native"),
-        generated.join("gradle-home/workers"),
+        project.root.join(".pam-native/gradle-home/caches"),
+        project.root.join(".pam-native/gradle-home/daemon"),
+        project.root.join(".pam-native/gradle-home/native"),
+        project.root.join(".pam-native/gradle-home/notifications"),
+        project.root.join(".pam-native/gradle-home/workers"),
     ];
     clean_dev_paths(&project.root, &paths)
+}
+
+fn with_android_build_cleanup<T>(
+    project_path: &Path,
+    operation: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    let outcome = operation();
+    let cleanup = clean_android_dev_artifacts(project_path);
+    match (outcome, cleanup) {
+        (Err(error), Err(cleanup_error)) => {
+            eprintln!(
+                "PAM Native could not complete mandatory Android build cleanup: {cleanup_error}"
+            );
+            Err(error)
+        }
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Ok(value), Ok(())) => Ok(value),
+    }
 }
 
 fn clean_ios_dev_artifacts(project_root: &Path) -> Result<(), String> {
@@ -3855,9 +3908,27 @@ fn clean_ios_dev_artifacts(project_root: &Path) -> Result<(), String> {
         project_root,
         &[
             project_root.join(".pam-native/ios/App/DerivedData"),
+            project_root.join(".pam-native/ios/App/build"),
             project_root.join(".pam-native/ios/HotReloadBundle"),
         ],
     )
+}
+
+fn with_ios_build_cleanup<T>(
+    project_root: &Path,
+    operation: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    let outcome = operation();
+    let cleanup = clean_ios_dev_artifacts(project_root);
+    match (outcome, cleanup) {
+        (Err(error), Err(cleanup_error)) => {
+            eprintln!("PAM Native could not complete mandatory iOS build cleanup: {cleanup_error}");
+            Err(error)
+        }
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Ok(value), Ok(())) => Ok(value),
+    }
 }
 
 fn clean_dev_paths(project_root: &Path, paths: &[PathBuf]) -> Result<(), String> {
@@ -4065,6 +4136,11 @@ fn signing_status_ios(project_path: PathBuf) -> Result<u8, String> {
 }
 
 fn package_ios(project_path: PathBuf) -> Result<u8, String> {
+    let project = load_project(&project_path)?;
+    with_ios_build_cleanup(&project.root, || package_ios_intermediate(project_path))
+}
+
+fn package_ios_intermediate(project_path: PathBuf) -> Result<u8, String> {
     if !cfg!(target_os = "macos") {
         return Err("iOS packaging requires macOS with Xcode".to_owned());
     }
@@ -5837,7 +5913,7 @@ struct BuiltApk {
     mode: BuildMode,
 }
 
-fn build(options: MobileOptions) -> Result<BuiltApk, String> {
+fn build_intermediate(options: MobileOptions) -> Result<BuiltApk, String> {
     repair_android(&options.project)?;
     let project = load_project(&options.project)?;
     let native_home = native_home()?;
@@ -5895,10 +5971,57 @@ fn build(options: MobileOptions) -> Result<BuiltApk, String> {
     })
 }
 
+fn android_artifact_stem(project: &Project) -> String {
+    project
+        .manifest
+        .name
+        .to_ascii_lowercase()
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned()
+}
+
+fn persist_built_apk(mut built: BuiltApk) -> Result<BuiltApk, String> {
+    let output = built.project.root.join("dist");
+    fs::create_dir_all(&output)
+        .map_err(|error| format!("cannot create {}: {error}", output.display()))?;
+    let destination = output.join(format!(
+        "{}-{}-android-{}.apk",
+        android_artifact_stem(&built.project),
+        built.project.manifest.version_name,
+        built.mode.directory()
+    ));
+    fs::copy(&built.path, &destination)
+        .map_err(|error| format!("cannot copy {}: {error}", destination.display()))?;
+    write_artifact_checksum(&destination)?;
+    built.path = destination;
+    Ok(built)
+}
+
+fn build(options: MobileOptions) -> Result<BuiltApk, String> {
+    let project_root = options.project.clone();
+    with_android_build_cleanup(&project_root, || {
+        persist_built_apk(build_intermediate(options)?)
+    })
+}
+
 fn package_android(options: MobileOptions) -> Result<u8, String> {
+    let project_root = options.project.clone();
+    with_android_build_cleanup(&project_root, || package_android_intermediate(options))
+}
+
+fn package_android_intermediate(options: MobileOptions) -> Result<u8, String> {
     let signing_project = load_project(&options.project)?;
     validate_android_signing(&signing_project)?;
-    let built = build(options)?;
+    let built = build_intermediate(options)?;
     let workspace = built.project.root.join(".pam-native/android");
     let gradlew = workspace.join("gradlew");
     let status = Command::new(&gradlew)
@@ -5920,32 +6043,17 @@ fn package_android(options: MobileOptions) -> Result<u8, String> {
     let output = built.project.root.join("dist");
     fs::create_dir_all(&output)
         .map_err(|error| format!("cannot create {}: {error}", output.display()))?;
-    let name = built
-        .project
-        .manifest
-        .name
-        .to_ascii_lowercase()
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() {
-                character
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>();
+    let name = android_artifact_stem(&built.project);
     let destination = output.join(format!(
         "{}-{}-android.aab",
-        name.trim_matches('-'),
-        built.project.manifest.version_name
+        name, built.project.manifest.version_name
     ));
     fs::copy(&source, &destination)
         .map_err(|error| format!("cannot copy {}: {error}", destination.display()))?;
     write_artifact_checksum(&destination)?;
     let apk_destination = output.join(format!(
         "{}-{}-android.apk",
-        name.trim_matches('-'),
-        built.project.manifest.version_name
+        name, built.project.manifest.version_name
     ));
     fs::copy(&built.path, &apk_destination)
         .map_err(|error| format!("cannot copy {}: {error}", apk_destination.display()))?;
@@ -7069,7 +7177,12 @@ fn command_status(command: &str, arguments: &[&str]) -> Result<(), String> {
 }
 
 fn dev(options: MobileOptions) -> Result<u8, String> {
-    let apk = build(options)?;
+    let project_root = options.project.clone();
+    with_android_build_cleanup(&project_root, || dev_intermediate(options))
+}
+
+fn dev_intermediate(options: MobileOptions) -> Result<u8, String> {
+    let apk = build_intermediate(options)?;
     crate::dev_event::emit(
         crate::dev_event::EventCode::SessionStarting,
         crate::dev_event::SurfaceCode::Android,
@@ -8400,15 +8513,18 @@ mod tests {
         ));
         let application_build = root.join(".pam-native/android/app/build/outputs");
         let root_build = root.join(".pam-native/android/build");
-        let gradle_cache = root.join(".pam-native/android/gradle-home/caches/modules");
+        let gradle_cache = root.join(".pam-native/gradle-home/caches/modules");
+        let gradle_daemon = root.join(".pam-native/gradle-home/daemon/8.0");
         let source = root.join(".pam-native/android/app/src/main/AndroidManifest.xml");
         fs::create_dir_all(&application_build).expect("application build");
         fs::create_dir_all(&root_build).expect("root build");
         fs::create_dir_all(&gradle_cache).expect("Gradle cache");
+        fs::create_dir_all(&gradle_daemon).expect("Gradle daemon");
         fs::create_dir_all(source.parent().expect("source parent")).expect("sources");
         fs::write(application_build.join("app.apk"), [0_u8; 32]).expect("APK");
         fs::write(root_build.join("artifact.bin"), [0_u8; 32]).expect("build output");
         fs::write(gradle_cache.join("module.bin"), [0_u8; 32]).expect("cache");
+        fs::write(gradle_daemon.join("daemon.bin"), [0_u8; 32]).expect("daemon");
         fs::write(&source, "<manifest />\n").expect("manifest");
         fs::write(
             root.join("pam-native.json"),
@@ -8423,9 +8539,53 @@ mod tests {
 
         assert!(!root.join(".pam-native/android/app/build").exists());
         assert!(!root.join(".pam-native/android/build").exists());
-        assert!(!root.join(".pam-native/android/gradle-home/caches").exists());
+        assert!(!root.join(".pam-native/gradle-home/caches").exists());
+        assert!(!root.join(".pam-native/gradle-home/daemon").exists());
         assert!(source.is_file());
         assert!(root.join(".pam-native/android/app/src").is_dir());
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn android_build_cleanup_preserves_only_the_dist_artifact() {
+        let root = std::env::temp_dir().join(format!(
+            "pam-android-build-clean-{}",
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let intermediate =
+            root.join(".pam-native/android/app/build/outputs/apk/debug/app-debug.apk");
+        fs::create_dir_all(intermediate.parent().expect("APK parent")).expect("APK output");
+        fs::write(&intermediate, b"apk").expect("APK");
+        fs::write(
+            root.join("pam-native.json"),
+            r#"{"version":1,"applicationId":"dev.pam.cleanup","name":"Cleanup App","entry":"index.php","versionName":"1.2.3"}"#,
+        )
+        .expect("manifest");
+        fs::write(root.join("index.php"), "<?php\n").expect("entry");
+        fs::create_dir_all(root.join("vendor")).expect("vendor");
+        fs::write(root.join("vendor/autoload.php"), "<?php\n").expect("autoload");
+        let project = load_project(&root).expect("project");
+
+        let built = with_android_build_cleanup(&root, || {
+            persist_built_apk(BuiltApk {
+                project,
+                path: intermediate,
+                mode: BuildMode::Debug,
+            })
+        })
+        .expect("persist and clean");
+
+        assert_eq!(
+            built.path,
+            root.join("dist/cleanup-app-1.2.3-android-debug.apk")
+        );
+        assert!(built.path.is_file());
+        assert!(built.path.with_extension("apk.sha256").is_file());
+        assert!(!root.join(".pam-native/android/app/build").exists());
+        assert!(root.join("index.php").is_file());
         fs::remove_dir_all(root).expect("cleanup");
     }
 
@@ -8439,16 +8599,20 @@ mod tests {
                 .as_nanos()
         ));
         let derived_data = root.join(".pam-native/ios/App/DerivedData/Build/Products");
+        let package_build = root.join(".pam-native/ios/App/build/export/App.ipa");
         let source = root.join(".pam-native/ios/App/Sources/AppDelegate.swift");
         let hot_reload = root.join(".pam-native/ios/HotReloadBundle/index.php");
         let neighboring_artifact = root.join("artifacts/release-evidence.json");
         fs::create_dir_all(&derived_data).expect("derived data");
+        fs::create_dir_all(package_build.parent().expect("package build parent"))
+            .expect("package build");
         fs::create_dir_all(source.parent().expect("source parent")).expect("sources");
         fs::create_dir_all(hot_reload.parent().expect("hot reload parent"))
             .expect("hot reload bundle");
         fs::create_dir_all(neighboring_artifact.parent().expect("artifact parent"))
             .expect("artifacts");
         fs::write(derived_data.join("application.bin"), [0_u8; 32]).expect("build output");
+        fs::write(&package_build, [0_u8; 32]).expect("package output");
         fs::write(&source, "// generated host source\n").expect("source");
         fs::write(&hot_reload, "<?php\n").expect("hot reload entry");
         fs::write(&neighboring_artifact, "{}\n").expect("evidence");
@@ -8456,6 +8620,7 @@ mod tests {
         clean_ios_dev_artifacts(&root).expect("clean iOS artifacts");
 
         assert!(!root.join(".pam-native/ios/App/DerivedData").exists());
+        assert!(!root.join(".pam-native/ios/App/build").exists());
         assert!(!root.join(".pam-native/ios/HotReloadBundle").exists());
         assert!(source.is_file());
         assert!(neighboring_artifact.is_file());

--- a/docs/build-hygiene.md
+++ b/docs/build-hygiene.md
@@ -20,4 +20,6 @@ preserves that original error and also reports the cleanup failure.
 
 Official packages and contributors must follow the same invariant. A workflow
 that builds native code without an unconditional cleanup step is not eligible
-to publish a release.
+to publish a release. Repository workflows use
+`scripts/cleanup-build-artifacts.sh` from an `if: always()` final step after
+required artifacts have been uploaded.

--- a/docs/build-hygiene.md
+++ b/docs/build-hygiene.md
@@ -1,0 +1,23 @@
+# Mandatory build hygiene
+
+PAM Native builds leave only declared deliverables behind. Regenerable build
+trees and project-local tool caches are not release artifacts and must be
+removed after every local, CI and release build, including failed builds.
+
+## Command contract
+
+| Command | Retained | Removed on exit |
+| --- | --- | --- |
+| `pam mobile build` | Checksummed APK or simulator `.app` in `dist` | Android `app/build`, root build, project Gradle caches/daemons; iOS `DerivedData` |
+| `pam mobile package` | Checksummed APK/AAB or IPA and release metadata in `dist` | Gradle/Xcode intermediates and export workspaces |
+| `pam dev` / `pam mobile dev` | Source, dependencies and explicit evidence | All regenerable session build outputs when the session exits |
+| CI/release | Uploaded final release assets and bounded evidence | Runner build trees in an unconditional final step |
+
+Cleanup is fail-closed and project-scoped. It never removes source, `vendor`,
+application data, credentials, screenshots, release evidence or `dist`. A
+cleanup failure fails a successful build; when the build itself failed, PAM
+preserves that original error and also reports the cleanup failure.
+
+Official packages and contributors must follow the same invariant. A workflow
+that builds native code without an unconditional cleanup step is not eligible
+to publish a release.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -28,6 +28,10 @@ credentials or uploads to a store. CI/store adapters consume the resulting
 
 ## Release gate
 
+Build hygiene is mandatory for every gate. Final deliverables must be copied to
+`dist` or uploaded before an unconditional cleanup removes all regenerable
+Gradle, Cargo and Xcode outputs. See [Mandatory build hygiene](build-hygiene.md).
+
 1. Run PHP SDK tests and lint.
 2. Run the Rust workspace tests.
 3. Compile Android unit and instrumented-test sources.

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.13';
+    public const string SDK_VERSION = '1.0.14';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.13',
-    'The runtime SDK contract must match the stable 1.0.13 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.14',
+    'The runtime SDK contract must match the stable 1.0.14 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,

--- a/scripts/cleanup-build-artifacts.sh
+++ b/scripts/cleanup-build-artifacts.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=${1:-.}
+root=$(cd "${root}" && pwd -P)
+
+paths=(
+  target
+  android/.gradle
+  android/build
+  android/app/build
+  android/macrobenchmark/build
+  android/plugin-api/build
+  ios/.build
+  .pam-native/android/app/build
+  .pam-native/android/build
+  .pam-native/gradle-home/caches
+  .pam-native/gradle-home/daemon
+  .pam-native/gradle-home/native
+  .pam-native/gradle-home/notifications
+  .pam-native/gradle-home/workers
+  .pam-native/ios/App/DerivedData
+  .pam-native/ios/App/build
+  .pam-native/ios/HotReloadBundle
+  examples/showcase/vendor
+)
+
+for relative in "${paths[@]}"; do
+  path=${root}/${relative}
+  [[ ${path} == "${root}/"* ]] || {
+    printf 'refusing cleanup outside %s: %s\n' "${root}" "${path}" >&2
+    exit 1
+  }
+  if [[ -e ${path} || -L ${path} ]]; then
+    [[ ! -L ${path} ]] || {
+      printf 'refusing symlinked build artifact: %s\n' "${path}" >&2
+      exit 1
+    }
+    find "${path}" -depth -delete
+    printf 'cleaned %s\n' "${relative}"
+  fi
+done

--- a/scripts/cleanup-build-artifacts.sh
+++ b/scripts/cleanup-build-artifacts.sh
@@ -5,6 +5,7 @@ root=${1:-.}
 root=$(cd "${root}" && pwd -P)
 
 paths=(
+  .build
   target
   android/.gradle
   android/build
@@ -23,6 +24,7 @@ paths=(
   .pam-native/ios/App/build
   .pam-native/ios/HotReloadBundle
   examples/showcase/vendor
+  pam-cli/target
 )
 
 for relative in "${paths[@]}"; do


### PR DESCRIPTION
## Summary\n- preserve Android APK/AAB and iOS app/IPA deliverables in dist before cleanup\n- clean actual project-local Gradle caches/daemons, Android build trees, DerivedData and iOS export workspaces\n- run cleanup after successful and failed build, run, dev and package operations\n- add a mandatory repository-wide build hygiene contract\n\n## Validation\n- Rust workspace: 112 tests passed\n- PHP SDK tests passed\n- Clippy all targets with warnings denied passed\n- regression test proves dist APK/checksum survive while app/build is removed\n- generated Cargo targets removed after validation\n\nRelease remains blocked on CI and clean-room gates.