### PR TITLE
ci: allow rerunning immutable tag releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,6 +21,11 @@ pam release --platform ios
 pam release --platform all
 ```
 
+The repository release workflow also supports a manual rerun against an
+existing immutable `v*` tag. Select that tag as the workflow ref; the workflow
+then builds and attests the exact tagged tree. This recovery path never moves a
+tag and never accepts an arbitrary version input.
+
 The command runs Native doctor and plugin certification before validating
 signing and producing checksummed release artifacts. It never creates signing
 credentials or uploads to a store. CI/store adapters consume the resulting


### PR DESCRIPTION
Adds workflow_dispatch to the existing release workflow so an immutable v* tag can be selected as the ref and rerun through the same gates. No arbitrary version input and no tag movement. Workflow YAML and release contract tests pass.