### PR TITLE
ci: clean Composer release builds

### DIFF
--- a/.github/workflows/composer-package.yml
+++ b/.github/workflows/composer-package.yml
@@ -49,6 +49,9 @@ jobs:
           scripts/composer-package.sh validate-tag "${RELEASE_TAG}"
           split_sha=$(scripts/composer-package.sh split "${RELEASE_TAG}")
           scripts/composer-package.sh verify-split "${split_sha}"
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh
 
   publish:
     name: Validate and publish PHP SDK
@@ -154,3 +157,6 @@ jobs:
               --data "${payload}" \
               "https://packagist.org/api/create-package?username=${encoded_username}&apiToken=${encoded_token}"
           fi
+      - name: Remove regenerable build artifacts
+        if: always()
+        run: scripts/cleanup-build-artifacts.sh


### PR DESCRIPTION
Makes mandatory build hygiene universal in the Composer validation and Packagist publication workflow. Cleanup runs with `if: always()` on both success and failure, preserving published outputs while removing regenerable workspace artifacts.