### PR TITLE
ci: bind ecosystem evidence to exact Native tags

### DIFF
--- a/.github/workflows/composer-package.yml
+++ b/.github/workflows/composer-package.yml
@@ -28,6 +28,8 @@ jobs:
   ecosystem-compatibility:
     name: Certify the complete PAM Native ecosystem
     uses: push-in/pam/.github/workflows/ecosystem-compatibility.yml@main
+    with:
+      native_ref: ${{ inputs.release_tag }}
 
   validate:
     name: Validate PHP SDK release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
     name: Certify the complete PAM Native ecosystem
     needs: release-ref
     uses: push-in/pam/.github/workflows/ecosystem-compatibility.yml@main
+    with:
+      native_ref: ${{ inputs.release_tag || github.ref }}
 
   ecosystem-android:
     name: Certify official Android plugins

--- a/scripts/test-release-workflows.php
+++ b/scripts/test-release-workflows.php
@@ -60,6 +60,7 @@ $ci = workflow($root, 'ci.yml');
 $android = workflow($root, 'ecosystem-android.yml');
 $ios = workflow($root, 'ecosystem-ios.yml');
 $release = workflow($root, 'release.yml');
+$composerPackage = workflow($root, 'composer-package.yml');
 $androidBuild = file_get_contents("{$root}/android/build.gradle.kts");
 if ($androidBuild === false) {
     fail('cannot read android/build.gradle.kts');
@@ -87,6 +88,7 @@ requireFragments($release, 'release.yml', [
     "  source-contracts:\n",
     "    uses: ./.github/workflows/ci.yml\n",
     "  ecosystem-android:\n",
+    "      native_ref: \${{ inputs.release_tag || github.ref }}\n",
     "    uses: ./.github/workflows/ecosystem-android.yml\n",
     "  ecosystem-ios:\n",
     "    uses: ./.github/workflows/ecosystem-ios.yml\n",
@@ -117,6 +119,10 @@ requireFragments($release, 'release.yml', [
     "            sha256sum \"\${artifact}\" > \"\${artifact}.sha256\"\n",
     "            --created-epoch \"$(git log -1 --format=%ct)\" \\\n",
     "        uses: actions/attest-sbom@v4\n",
+]);
+requireFragments($composerPackage, 'composer-package.yml', [
+    "  ecosystem-compatibility:\n",
+    "      native_ref: \${{ inputs.release_tag }}\n",
 ]);
 if (substr_count($release, 'cmp "dist/${artifact}" "${RUNNER_TEMP}/${artifact}"') !== 3) {
     fail('release.yml must verify iOS, Android renderer, and PHP SDK archives byte for byte');


### PR DESCRIPTION
## Summary
- pass the immutable Native release tag to the reusable ecosystem certification
- bind Composer publication certification to the dispatched tag
- enforce both contracts in the release workflow test

## Verification
- `php -l scripts/test-release-workflows.php`
- `php scripts/test-release-workflows.php`
- `git diff --check`

This closes the evidence gap where manually dispatched v1.0.14 certification recorded a null Native candidate commit.