### PR TITLE
feat: ship PAM Native Visual DOM 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           cargo run --locked --profile performance -p pam-native-engine --example benchmark -- --check
           php packages/native/tests/run.php
           php packages/native/tests/performance.php
+          php packages/native/tests/visual_dom_performance.php
           php packages/native/tests/navigation_performance.php
           php packages/native/tests/fuzz.php
           phpstan analyse --configuration=packages/native/phpstan-singularity.neon --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.0.15 - 2026-08-26
+
+- Adds the typed Visual DOM with indexed selectors, stable element handles,
+  structural mutations, atomic rollback, observations, native motion, focus,
+  asynchronous measurement and diagnostic snapshots.
+- Connects declarative `id`, `class`, and `data-*` metadata to the same retained
+  document while preserving the existing CSS compiler and test identifiers.
+- Uses Visual DOM identities in incremental binary patches so sibling insertion
+  preserves mounted Android and iOS views.
+- Adds a mandatory 5,001-node performance gate for document indexing, 4,000
+  indexed queries and 5,000 batched mutations.
+
 ## 1.0.14 - 2026-08-26
 
 - Makes post-build cleanup mandatory for Android and iOS development, build,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.14"
+version = "1.0.15"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.14"
+version = "1.0.15"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ accessibility diagnostics, Composer-extensible tags and a full editor-neutral
 LSP. Attributes such as `#[Prop]` and `#[Action]` remain the canonical PHP API.
 Read the [UI Language 2 guide](docs/ui-language-2.md).
 
+Need precise imperative control without introducing a browser runtime? The
+[Visual DOM](docs/visual-dom.md) adds indexed selectors, atomic tree mutations,
+events, native animation and asynchronous layout observation directly on the
+same retained PHP → Rust → Android/UIKit pipeline.
+
 ## Native where it matters
 
 - Real Android Views and UIKit controls

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ short end-to-end recipes.
 | --- | --- |
 | Product-quality Android gallery and source tour | [Visual showcase](showcase.md) |
 | Components, props, state, lifecycle, effects, slots, context and refs | [Component runtime](component-runtime.md) |
+| Typed retained UI queries, transactions, events, animation and measurement | [Visual DOM](visual-dom.md) |
 | Global store, transactions, persistence, sync, undo and optimistic state | [Pam Store](store.md) |
 | Files, direct gallery, camera, notifications, SQLite, WebView, media, animation and device APIs | [Capability cookbook](examples.md) |
 | Permissions, push, observation and lifecycle recovery | [Production capabilities](production-capabilities.md) |

--- a/docs/performance-offensive.md
+++ b/docs/performance-offensive.md
@@ -41,3 +41,17 @@ suites retain frame-time, startup, memory, and long-run budgets.
 Profile a release-like binary and optimize only measured hot paths. Compare the
 same device, build type, fixture, thermal state, and sample count. A change is
 accepted only when functional tests remain green and its p99 does not regress.
+
+## Visual DOM budget
+
+```bash
+php packages/native/tests/visual_dom_performance.php
+```
+
+CI builds a 5,001-node retained document, executes 4,000 indexed selectors and
+applies 5,000 property/class changes through one transaction. Default ceilings
+are 500 ms for indexing, 500 ms for queries and 5,000 ms for the mutation batch;
+override them with `PAM_DOM_INDEX_MS`, `PAM_DOM_QUERY_MS` and
+`PAM_DOM_MUTATION_MS` only during investigation. The benchmark prints measured
+latencies and peak memory as JSON so release evidence can retain the exact
+machine result.

--- a/docs/visual-dom.md
+++ b/docs/visual-dom.md
@@ -1,0 +1,146 @@
+# Visual DOM
+
+PAM Native's Visual DOM is a typed retained-tree API for manipulating real
+Android and iOS UI from PHP. It is deliberately not a browser emulator: it
+adds element lookup, structural mutations, events and measurements to the
+existing PAM Native element tree while navigation, storage and networking stay
+in their existing subsystems.
+
+## Start here
+
+```php
+<?php
+
+use Pam\Native\App;
+use Pam\Native\Dom\Document;
+use Pam\Native\UI\Button;
+use Pam\Native\UI\Text;
+use Pam\Native\UI\View;
+
+$document = App::document(
+    View::make(
+        Text::make('Loki')->id('title')->class('heading'),
+        Button::make('Play')->id('play')->class('primary')->data('media-id', '42'),
+    )->id('screen')->class('detail-screen'),
+);
+
+$document->id('play')->on(\Pam\Native\EventKind::Press, function () use ($document): void {
+    $document->transaction(function (Document $dom): void {
+        $dom->id('title')->text('Playing');
+        $dom->all('.primary')->addClass('active')->style('opacity', 0.92);
+    });
+});
+
+App::run($document);
+```
+
+`transaction()` coalesces all changes into one render request and one native
+mutation batch. If its callback throws, PAM restores the exact immutable tree
+and selector indexes before rethrowing the error.
+
+## Declarative syntax
+
+Normal template attributes populate the same document metadata:
+
+```xml
+<View id="movie" class="card featured" data-media-id="42">
+    <Text id="movie-title">{{ $movie->title }}</Text>
+    <Button class="action" @press="play">Play</Button>
+</View>
+```
+
+`class` continues to drive the native CSS compiler and also becomes queryable.
+`id` maps to the platform test identifier, so a single stable name works for
+DOM lookup and UI automation. `data-*` is bounded PHP metadata and adds no
+platform reflection overhead.
+
+## Query API
+
+```php
+$title = $document->getElementById('movie-title'); // nullable
+$title = $document->id('movie-title');             // throws if absent
+$play = $document->querySelector('#movie > .action');
+$cards = $document->querySelectorAll('View.card[data-media-id="42"]');
+
+$play?->parent();
+$play?->children();
+$play?->previousSibling();
+$play?->nextSibling();
+$play?->closest('.card');
+$play?->matches('.action');
+$play?->contains($title);
+```
+
+Supported selectors are intentionally bounded and indexable: element type,
+`#id`, `.class`, `[data-name]`, `[data-name="value"]`, descendant and direct
+child (`>`) combinators. Unsupported browser selectors are rejected instead of
+silently becoming an expensive scan. Compiled selectors are cached; right-most
+ids, classes and types use document indexes.
+
+## Mutations
+
+```php
+$card = $document->id('movie');
+$card->append(Text::make('New'));
+$card->prepend(Text::make('First'));
+$card->replaceChildren(Text::make('Empty'));
+$card->before(View::make());
+$card->after(View::make());
+$card->replaceWith(View::make());
+$card->remove();
+
+$card->classList()->add('selected');
+$card->classList()->remove('loading');
+$card->classList()->toggle('expanded');
+$card->data('state', 'ready')->removeData('stale');
+$card->text('Updated');
+$card->style()->set('opacity', 0.8);
+$card->style()->set(\Pam\Native\PropKey::Width, 320.0);
+```
+
+Handles keep a stable document identity. Calling a read or mutation method on
+a detached handle fails clearly; `connected()` supports optional work. Inserted
+subtrees receive fresh identities, preventing accidental aliasing.
+
+## Events, animation and observation
+
+```php
+$button
+    ->on(\Pam\Native\EventKind::Press, $play)
+    ->animate(\Pam\Native\MotionPreset::ScaleIn, 180)
+    ->pauseAnimation()
+    ->resumeAnimation();
+
+$subscription = $document->observe(
+    fn (\Pam\Native\Dom\MutationRecord $record) => logChange($record->version),
+    '.card',
+);
+
+$button->observeResize(function (array $frame) use ($button): void {
+    inspect($button->measure()); // x, y, width, height from the UI thread
+});
+$button->observeIntersection($visibilityChanged);
+$subscription->disconnect();
+```
+
+`measure()` returns the latest native resize observation, so it never blocks
+PHP with a synchronous bridge round-trip. Focus uses the existing native
+autofocus property; blur delegates to the existing keyboard authority. Resize,
+intersection and animation frames remain native-driven.
+
+## Performance contract
+
+- DOM identities feed `TreeEncoder`, preserving mounted native views when
+  siblings move or are inserted.
+- Elements remain immutable; only changed ancestor paths are cloned.
+- A transaction schedules one render and emits one coalesced mutation record.
+- The existing binary protocol, Rust diff/layout engine and bounded Android/iOS
+  UI-thread mutation queues remain the only rendering pipeline.
+- No selector evaluation, PHP callback or bridge message runs per animation
+  frame.
+- Limits are explicit: 100,000 native nodes, 512-byte selectors, 16 selector
+  compounds, 128-byte ids/classes and 4 KiB data values.
+
+Use native virtualized lists for feeds instead of materializing thousands of
+off-screen DOM children. Visual DOM is a precision tool, not a replacement for
+component state, signals or recycler-backed lists.

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -94,6 +94,13 @@ binding, conditional blocks, loops, utility classes and user-defined theme
 tokens. The fluent PHP element API and custom Kotlin views remain available as
 escape hatches, so the template/class convention is optional.
 
+For targeted imperative UI work, wrap any root with `App::document(...)` and
+use the typed [Visual DOM](../../docs/visual-dom.md): indexed `#id`, `.class`,
+type and `data-*` selectors; atomic structural mutations; `classList`; typed
+styles and events; native animation; resize/intersection observation; and
+incremental patches with stable native identities. It extends the existing
+element pipeline and does not duplicate navigation, storage or networking.
+
 Complex controls can expose localized TalkBack and VoiceOver alternatives to
 gesture-only interaction. Bind up to eight `{name, label}` entries through
 `:accessibilityActions` and handle `on:accessibilityAction`, or use

--- a/packages/native/src/App.php
+++ b/packages/native/src/App.php
@@ -7,6 +7,7 @@ namespace Pam\Native;
 use Closure;
 use Pam\Native\Internal\PamPhpRegistry;
 use Pam\Native\Internal\Runtime;
+use Pam\Native\Dom\Document;
 use Pam\Native\Plugin\PluginManager;
 use Pam\Native\Navigation\TabNavigator;
 use Throwable;
@@ -32,6 +33,15 @@ final class App
 
             throw $error;
         }
+    }
+
+    /**
+     * Creates a retained, queryable visual document that can be passed directly
+     * to App::run(). The document remains the mutation handle for its lifetime.
+     */
+    public static function document(Renderable $root): Document
+    {
+        return Document::from($root);
     }
 
     public static function views(string $path, ?string $cachePath = null): void

--- a/packages/native/src/Dom/ClassList.php
+++ b/packages/native/src/Dom/ClassList.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Dom;
+
+final class ClassList
+{
+    public function __construct(private readonly Element $element)
+    {
+    }
+
+    public function add(string ...$classes): Element
+    {
+        return $this->element->setClasses([...$this->element->classes(), ...$classes]);
+    }
+
+    public function remove(string ...$classes): Element
+    {
+        return $this->element->setClasses(array_values(array_filter(
+            $this->element->classes(),
+            static fn (string $class): bool => !in_array($class, $classes, true),
+        )));
+    }
+
+    public function toggle(string $class, ?bool $force = null): Element
+    {
+        $contains = $this->contains($class);
+        $enabled = $force ?? !$contains;
+
+        return $enabled ? $this->add($class) : $this->remove($class);
+    }
+
+    public function replace(string $old, string $new): Element
+    {
+        return $this->remove($old)->classList()->add($new);
+    }
+
+    public function contains(string $class): bool
+    {
+        return in_array($class, $this->element->classes(), true);
+    }
+}

--- a/packages/native/src/Dom/Document.php
+++ b/packages/native/src/Dom/Document.php
@@ -1,0 +1,453 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Dom;
+
+use Closure;
+use InvalidArgumentException;
+use LogicException;
+use Pam\Native\Element as NativeElement;
+use Pam\Native\Internal\Runtime;
+use Pam\Native\Renderable;
+use Throwable;
+
+final class Document implements Renderable
+{
+    private NativeElement $root;
+    private int $nextIdentity = 1;
+    private int $transactionDepth = 0;
+    private bool $dirty = false;
+    private int $mutationVersion = 0;
+    private int $nextObserver = 1;
+    /** @var array<string, true> */
+    private array $touched = [];
+    /** @var array<int, array{selector: ?string, callback: Closure}> */
+    private array $observers = [];
+    /** @var array<string, array{x: float, y: float, width: float, height: float}> */
+    private array $measurements = [];
+
+    /** @var array<string, NativeElement> */
+    private array $nodes = [];
+    /** @var array<string, ?string> */
+    private array $parents = [];
+    /** @var array<string, list<string>> */
+    private array $children = [];
+    /** @var array<string, string> */
+    private array $ids = [];
+    /** @var array<string, list<string>> */
+    private array $classes = [];
+    /** @var array<string, list<string>> */
+    private array $kinds = [];
+    /** @var array<string, array<string, list<string>>> */
+    private array $dataValues = [];
+    /** @var array<string, Selector> */
+    private array $selectorCache = [];
+
+    private function __construct(Renderable $root)
+    {
+        $this->root = $this->normalize($root->toElement(), false);
+        $this->reindex();
+    }
+
+    public static function from(Renderable $root): self
+    {
+        return new self($root);
+    }
+
+    public function toElement(): NativeElement
+    {
+        return $this->root;
+    }
+
+    public function root(): Element
+    {
+        return new Element($this, $this->root->domIdentity() ?? throw new LogicException('DOM root has no identity.'));
+    }
+
+    public function getElementById(string $id): ?Element
+    {
+        $identity = $this->ids[$id] ?? null;
+
+        return $identity === null ? null : new Element($this, $identity);
+    }
+
+    public function id(string $id): Element
+    {
+        return $this->getElementById($id) ?? throw new LogicException("DOM element #{$id} was not found.");
+    }
+
+    public function querySelector(string $selector): ?Element
+    {
+        return $this->querySelectorAll($selector)->first();
+    }
+
+    public function querySelectorAll(string $selector): ElementCollection
+    {
+        $compiled = $this->selector($selector);
+        $candidates = $this->candidateIdentities($selector);
+        $matches = [];
+        foreach ($candidates as $identity) {
+            $element = $this->nodes[$identity] ?? null;
+            if ($element !== null && $compiled->matches($element, $this->parentElement(...))) {
+                $matches[] = $identity;
+            }
+        }
+
+        return new ElementCollection($this, $matches);
+    }
+
+    public function all(string $selector): ElementCollection
+    {
+        return $this->querySelectorAll($selector);
+    }
+
+    public function snapshot(): DocumentSnapshot
+    {
+        return new DocumentSnapshot(
+            rootIdentity: $this->root->domIdentity() ?? throw new LogicException('DOM root has no identity.'),
+            nodeCount: count($this->nodes),
+            idCount: count($this->ids),
+            classCount: count($this->classes),
+            cachedSelectorCount: count($this->selectorCache),
+            mutationVersion: $this->mutationVersion,
+            transactionDepth: $this->transactionDepth,
+        );
+    }
+
+    public function transaction(Closure $operation): mixed
+    {
+        $snapshot = $this->root;
+        $wasDirty = $this->dirty;
+        $previousTouched = $this->touched;
+        $this->transactionDepth++;
+        try {
+            return $operation($this);
+        } catch (Throwable $error) {
+            $this->root = $snapshot;
+            $this->dirty = $wasDirty;
+            $this->touched = $previousTouched;
+            $this->reindex();
+
+            throw $error;
+        } finally {
+            $this->transactionDepth--;
+            if ($this->transactionDepth === 0 && $this->dirty) {
+                $this->commitChanges();
+            }
+        }
+    }
+
+    public function update(Closure $operation): mixed
+    {
+        return $this->transaction($operation);
+    }
+
+    /** @param Closure(MutationRecord): void $callback */
+    public function observe(Closure $callback, ?string $selector = null): MutationObserver
+    {
+        if ($selector !== null) {
+            $this->selector($selector);
+        }
+        $id = $this->nextObserver++;
+        $this->observers[$id] = ['selector' => $selector, 'callback' => $callback];
+
+        return new MutationObserver($this, $id);
+    }
+
+    /** @internal */
+    public function disconnectObserver(int $id): void
+    {
+        unset($this->observers[$id]);
+    }
+
+    /** @param array{x: float, y: float, width: float, height: float} $measurement */
+    public function recordMeasurement(string $identity, array $measurement): void
+    {
+        $this->measurements[$identity] = $measurement;
+    }
+
+    /** @return array{x: float, y: float, width: float, height: float}|null */
+    public function measurement(string $identity): ?array
+    {
+        return $this->measurements[$identity] ?? null;
+    }
+
+    public function native(string $identity): ?NativeElement
+    {
+        return $this->nodes[$identity] ?? null;
+    }
+
+    public function parentIdentity(string $identity): ?string
+    {
+        return $this->parents[$identity] ?? null;
+    }
+
+    /** @return list<string> */
+    public function childIdentities(string $identity): array
+    {
+        return $this->children[$identity] ?? [];
+    }
+
+    public function sibling(string $identity, int $offset): ?Element
+    {
+        $parent = $this->parentIdentity($identity);
+        if ($parent === null) {
+            return null;
+        }
+        $siblings = $this->childIdentities($parent);
+        $index = array_search($identity, $siblings, true);
+        $candidate = $index === false ? null : ($siblings[$index + $offset] ?? null);
+
+        return $candidate === null ? null : new Element($this, $candidate);
+    }
+
+    public function contains(string $ancestor, string $candidate): bool
+    {
+        $cursor = $candidate;
+        while (($cursor = $this->parentIdentity($cursor)) !== null) {
+            if ($cursor === $ancestor) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function matches(string $identity, string $selector): bool
+    {
+        $element = $this->nodes[$identity] ?? null;
+
+        return $element !== null && $this->selector($selector)->matches($element, $this->parentElement(...));
+    }
+
+    /** @param Closure(NativeElement): NativeElement $operation */
+    public function replace(string $identity, Closure $operation): void
+    {
+        if (!isset($this->nodes[$identity])) {
+            throw new LogicException("DOM node {$identity} is detached.");
+        }
+        $this->root = $this->transform($this->root, $identity, $operation);
+        $this->changed($identity);
+    }
+
+    /** @param list<string> $identities @param Closure(NativeElement): NativeElement $operation */
+    public function replaceMany(array $identities, Closure $operation): void
+    {
+        $targets = array_fill_keys($identities, true);
+        if ($targets === []) {
+            return;
+        }
+        $this->root = $this->transformMany($this->root, $targets, $operation);
+        $this->reindex();
+        $this->dirty = true;
+        foreach ($targets as $identity => $_) {
+            $this->touched[$identity] = true;
+        }
+        if ($this->transactionDepth === 0) {
+            $this->commitChanges();
+        }
+    }
+
+    /** @param list<Renderable> $children */
+    public function insert(string $parent, array $children, ?int $index): void
+    {
+        $normalized = array_map(fn (Renderable $child): NativeElement => $this->normalize($child->toElement(), true), $children);
+        $this->replace($parent, static function (NativeElement $element) use ($normalized, $index): NativeElement {
+            $existing = $element->children();
+            $position = $index === null ? count($existing) : max(0, min(count($existing), $index));
+            array_splice($existing, $position, 0, $normalized);
+
+            return $element->domWithChildren($existing);
+        });
+    }
+
+    /** @param list<Renderable> $children */
+    public function replaceChildren(string $parent, array $children): void
+    {
+        $normalized = array_map(fn (Renderable $child): NativeElement => $this->normalize($child->toElement(), true), $children);
+        $this->replace($parent, static fn (NativeElement $element): NativeElement => $element->domWithChildren($normalized));
+    }
+
+    /** @param list<Renderable> $siblings */
+    public function insertSibling(string $identity, array $siblings, bool $after): void
+    {
+        $parent = $this->parentIdentity($identity) ?? throw new LogicException('The DOM root cannot have siblings.');
+        $children = $this->childIdentities($parent);
+        $index = array_search($identity, $children, true);
+        if ($index === false) {
+            throw new LogicException("DOM node {$identity} is detached.");
+        }
+        $this->insert($parent, $siblings, $index + ($after ? 1 : 0));
+    }
+
+    public function replaceWith(string $identity, Renderable $replacement): void
+    {
+        $parent = $this->parentIdentity($identity) ?? throw new LogicException('The DOM root cannot be replaced through replaceWith().');
+        $siblings = $this->childIdentities($parent);
+        $index = array_search($identity, $siblings, true);
+        $this->transaction(function () use ($identity, $parent, $replacement, $index): void {
+            $this->remove($identity);
+            $this->insert($parent, [$replacement], is_int($index) ? $index : null);
+        });
+    }
+
+    public function remove(string $identity): void
+    {
+        $parent = $this->parentIdentity($identity) ?? throw new LogicException('The DOM root cannot be removed.');
+        $this->replace($parent, static fn (NativeElement $element): NativeElement => $element->domWithChildren(array_values(array_filter(
+            $element->children(),
+            static fn (NativeElement $child): bool => $child->domIdentity() !== $identity,
+        ))));
+    }
+
+    private function changed(string $identity): void
+    {
+        $this->reindex();
+        $this->dirty = true;
+        $this->touched[$identity] = true;
+        if ($this->transactionDepth === 0) {
+            $this->commitChanges();
+        }
+    }
+
+    private function commitChanges(): void
+    {
+        $this->dirty = false;
+        $identities = array_keys($this->touched);
+        $this->touched = [];
+        $record = new MutationRecord(++$this->mutationVersion, $identities);
+        foreach ($this->observers as $observer) {
+            $selector = $observer['selector'];
+            if ($selector !== null && !array_any(
+                $identities,
+                fn (string $identity): bool => isset($this->nodes[$identity]) && $this->matches($identity, $selector),
+            )) {
+                continue;
+            }
+            try {
+                ($observer['callback'])($record);
+            } catch (Throwable $error) {
+                Runtime::reportError($error);
+            }
+        }
+        Runtime::requestRender();
+    }
+
+    private function normalize(NativeElement $element, bool $fresh): NativeElement
+    {
+        $identity = !$fresh && $element->domIdentity() !== null
+            ? $element->domIdentity()
+            : 'n'.$this->nextIdentity++;
+        $children = array_map(fn (NativeElement $child): NativeElement => $this->normalize($child, $fresh), $element->children());
+
+        return $element->domWithIdentity($identity)->domWithChildren($children);
+    }
+
+    /** @param Closure(NativeElement): NativeElement $operation */
+    private function transform(NativeElement $element, string $identity, Closure $operation): NativeElement
+    {
+        if ($element->domIdentity() === $identity) {
+            return $operation($element);
+        }
+        $changed = false;
+        $children = [];
+        foreach ($element->children() as $child) {
+            $next = $this->transform($child, $identity, $operation);
+            $changed = $changed || $next !== $child;
+            $children[] = $next;
+        }
+
+        return $changed ? $element->domWithChildren($children) : $element;
+    }
+
+    /** @param array<string, true> $targets @param Closure(NativeElement): NativeElement $operation */
+    private function transformMany(NativeElement $element, array $targets, Closure $operation): NativeElement
+    {
+        $current = isset($targets[$element->domIdentity() ?? '']) ? $operation($element) : $element;
+        $changed = $current !== $element;
+        $children = [];
+        foreach ($current->children() as $child) {
+            $next = $this->transformMany($child, $targets, $operation);
+            $changed = $changed || $next !== $child;
+            $children[] = $next;
+        }
+
+        return $changed ? $current->domWithChildren($children) : $current;
+    }
+
+    private function reindex(): void
+    {
+        $this->nodes = $this->parents = $this->children = $this->ids = $this->classes = $this->kinds = $this->dataValues = [];
+        $this->indexNode($this->root, null);
+    }
+
+    private function indexNode(NativeElement $element, ?string $parent): void
+    {
+        $identity = $element->domIdentity() ?? throw new LogicException('DOM node is missing its identity.');
+        if (isset($this->nodes[$identity])) {
+            throw new LogicException("Duplicate DOM identity {$identity}.");
+        }
+        $this->nodes[$identity] = $element;
+        $this->parents[$identity] = $parent;
+        $this->kinds[strtolower($element->kind()->name)][] = $identity;
+        if (($id = $element->domId()) !== null) {
+            if (isset($this->ids[$id])) {
+                throw new LogicException("Duplicate DOM id {$id}.");
+            }
+            $this->ids[$id] = $identity;
+        }
+        foreach ($element->domClasses() as $class) {
+            $this->classes[$class][] = $identity;
+        }
+        foreach ($element->domDataset() as $name => $value) {
+            $this->dataValues[$name][$value][] = $identity;
+        }
+        foreach ($element->children() as $child) {
+            $childIdentity = $child->domIdentity() ?? throw new LogicException('DOM child is missing its identity.');
+            $this->children[$identity][] = $childIdentity;
+            $this->indexNode($child, $identity);
+        }
+        $this->children[$identity] ??= [];
+    }
+
+    private function selector(string $source): Selector
+    {
+        if (count($this->selectorCache) >= 256 && !isset($this->selectorCache[$source])) {
+            array_shift($this->selectorCache);
+        }
+
+        return $this->selectorCache[$source] ??= Selector::compile($source);
+    }
+
+    /** @return list<string> */
+    private function candidateIdentities(string $selector): array
+    {
+        // Only index the right-most compound.  An id/class/type on an ancestor
+        // constrains the relationship, not the nodes that can be returned.
+        preg_match('/(?:^|[ >])([^ >]+)\s*$/', trim($selector), $rightmost);
+        $compound = $rightmost[1] ?? '';
+        if (preg_match('/\[data-([a-z][a-z0-9-]{0,63})=(?:"([^"]*)"|\'([^\']*)\'|([^\]]+))\]/', $compound, $data) === 1) {
+            $value = $data[2] !== '' ? $data[2] : ($data[3] !== '' ? $data[3] : trim($data[4] ?? ''));
+            return $this->dataValues[$data[1]][$value] ?? [];
+        }
+        if (preg_match('/#([A-Za-z][A-Za-z0-9_.:-]{0,127})(?![A-Za-z0-9_.:-])/', $compound, $id) === 1) {
+            return isset($this->ids[$id[1]]) ? [$this->ids[$id[1]]] : [];
+        }
+        if (preg_match('/\.([A-Za-z_][A-Za-z0-9_-]{0,127})(?![A-Za-z0-9_-])/', $compound, $class) === 1) {
+            return $this->classes[$class[1]] ?? [];
+        }
+        if (preg_match('/^([A-Za-z][A-Za-z0-9-]*)(?=[.#\[]|$)/', $compound, $kind) === 1) {
+            return $this->kinds[strtolower($kind[1])] ?? [];
+        }
+
+        return array_keys($this->nodes);
+    }
+
+    private function parentElement(string $identity): ?NativeElement
+    {
+        $parent = $this->parents[$identity] ?? null;
+
+        return $parent === null ? null : ($this->nodes[$parent] ?? null);
+    }
+}

--- a/packages/native/src/Dom/Document.php
+++ b/packages/native/src/Dom/Document.php
@@ -46,7 +46,9 @@ final class Document implements Renderable
 
     private function __construct(Renderable $root)
     {
-        $this->root = $this->normalize($root->toElement(), false);
+        // A Document owns its identity namespace. Importing a tree from another
+        // document must never preserve handles that could collide on insertion.
+        $this->root = $this->normalize($root->toElement(), true);
         $this->reindex();
     }
 

--- a/packages/native/src/Dom/DocumentSnapshot.php
+++ b/packages/native/src/Dom/DocumentSnapshot.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Dom;
+
+final readonly class DocumentSnapshot
+{
+    public function __construct(
+        public string $rootIdentity,
+        public int $nodeCount,
+        public int $idCount,
+        public int $classCount,
+        public int $cachedSelectorCount,
+        public int $mutationVersion,
+        public int $transactionDepth,
+    ) {
+    }
+}

--- a/packages/native/src/Dom/Element.php
+++ b/packages/native/src/Dom/Element.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Dom;
+
+use Closure;
+use LogicException;
+use Pam\Native\AnimationEasing;
+use Pam\Native\AnimationPlayState;
+use Pam\Native\Element as NativeElement;
+use Pam\Native\EventKind;
+use Pam\Native\Internal\BinaryValue;
+use Pam\Native\MotionPreset;
+use Pam\Native\PropKey;
+use Pam\Native\Renderable;
+use Pam\Native\System\Keyboard;
+
+final class Element
+{
+    public function __construct(
+        private readonly Document $document,
+        private readonly string $identity,
+    ) {
+    }
+
+    public function identity(): string
+    {
+        return $this->identity;
+    }
+
+    public function connected(): bool
+    {
+        return $this->document->native($this->identity) !== null;
+    }
+
+    public function id(): ?string
+    {
+        return $this->required()->domId();
+    }
+
+    /** @return list<string> */
+    public function classes(): array
+    {
+        return $this->required()->domClasses();
+    }
+
+    /** @return array<string, string> */
+    public function dataset(): array
+    {
+        return $this->required()->domDataset();
+    }
+
+    public function parent(): ?self
+    {
+        $identity = $this->document->parentIdentity($this->identity);
+
+        return $identity === null ? null : new self($this->document, $identity);
+    }
+
+    public function children(): ElementCollection
+    {
+        return new ElementCollection($this->document, $this->document->childIdentities($this->identity));
+    }
+
+    public function firstChild(): ?self
+    {
+        return $this->children()->first();
+    }
+
+    public function lastChild(): ?self
+    {
+        return $this->children()->last();
+    }
+
+    public function nextSibling(): ?self
+    {
+        return $this->document->sibling($this->identity, 1);
+    }
+
+    public function previousSibling(): ?self
+    {
+        return $this->document->sibling($this->identity, -1);
+    }
+
+    public function contains(self $candidate): bool
+    {
+        return $this->document->contains($this->identity, $candidate->identity);
+    }
+
+    public function matches(string $selector): bool
+    {
+        return $this->document->matches($this->identity, $selector);
+    }
+
+    public function closest(string $selector): ?self
+    {
+        $cursor = $this;
+        while ($cursor !== null) {
+            if ($cursor->matches($selector)) {
+                return $cursor;
+            }
+            $cursor = $cursor->parent();
+        }
+
+        return null;
+    }
+
+    public function classList(): ClassList
+    {
+        return new ClassList($this);
+    }
+
+    public function style(): StyleDeclaration
+    {
+        return new StyleDeclaration($this);
+    }
+
+    public function prop(
+        PropKey $key,
+        string|int|float|bool|BinaryValue $value,
+    ): self {
+        $this->document->replace($this->identity, static fn (NativeElement $element): NativeElement => $element->domWithProperty($key, $value));
+
+        return $this;
+    }
+
+    public function property(PropKey $key): string|int|float|bool|BinaryValue|null
+    {
+        return $this->required()->properties()[$key->value] ?? null;
+    }
+
+    public function removeProp(PropKey $key): self
+    {
+        $this->document->replace($this->identity, static fn (NativeElement $element): NativeElement => $element->domWithoutProperty($key));
+
+        return $this;
+    }
+
+    public function text(string $text): self
+    {
+        return $this->prop(PropKey::Text, $text);
+    }
+
+    public function data(string $name, string $value): self
+    {
+        $this->document->replace($this->identity, static fn (NativeElement $element): NativeElement => $element->data($name, $value));
+
+        return $this;
+    }
+
+    public function removeData(string $name): self
+    {
+        $this->document->replace($this->identity, static fn (NativeElement $element): NativeElement => $element->domWithoutData($name));
+
+        return $this;
+    }
+
+    /** @param list<string> $classes */
+    public function setClasses(array $classes): self
+    {
+        $tokens = [];
+        foreach ($classes as $class) {
+            foreach (preg_split('/\s+/', trim($class), -1, PREG_SPLIT_NO_EMPTY) ?: [] as $token) {
+                if (!in_array($token, $tokens, true)) {
+                    $tokens[] = $token;
+                }
+            }
+        }
+        $this->document->replace($this->identity, static fn (NativeElement $element): NativeElement => $element->domWithClasses($tokens));
+
+        return $this;
+    }
+
+    public function on(EventKind $event, Closure $handler): self
+    {
+        $this->document->replace($this->identity, static fn (NativeElement $element): NativeElement => $element->domWithEvent($event, $handler));
+
+        return $this;
+    }
+
+    public function append(Renderable ...$children): self
+    {
+        $this->document->insert($this->identity, $children, null);
+
+        return $this;
+    }
+
+    public function prepend(Renderable ...$children): self
+    {
+        $this->document->insert($this->identity, $children, 0);
+
+        return $this;
+    }
+
+    public function replaceChildren(Renderable ...$children): self
+    {
+        $this->document->replaceChildren($this->identity, $children);
+
+        return $this;
+    }
+
+    public function before(Renderable ...$siblings): self
+    {
+        $this->document->insertSibling($this->identity, $siblings, false);
+
+        return $this;
+    }
+
+    public function after(Renderable ...$siblings): self
+    {
+        $this->document->insertSibling($this->identity, $siblings, true);
+
+        return $this;
+    }
+
+    public function replaceWith(Renderable $replacement): void
+    {
+        $this->document->replaceWith($this->identity, $replacement);
+    }
+
+    public function remove(): void
+    {
+        $this->document->remove($this->identity);
+    }
+
+    public function animate(
+        MotionPreset $preset,
+        int $durationMs = 240,
+        AnimationEasing $easing = AnimationEasing::EaseOut,
+    ): self {
+        $this->document->replace($this->identity, static fn (NativeElement $element): NativeElement => $element->motion($preset, $durationMs, $easing));
+
+        return $this;
+    }
+
+    public function pauseAnimation(): self
+    {
+        return $this->prop(PropKey::AnimationPlayState, AnimationPlayState::Paused->value);
+    }
+
+    public function resumeAnimation(): self
+    {
+        return $this->prop(PropKey::AnimationPlayState, AnimationPlayState::Running->value);
+    }
+
+    public function cancelAnimation(): self
+    {
+        return $this->prop(PropKey::AnimationPlayState, AnimationPlayState::Stopped->value);
+    }
+
+    public function focus(): self
+    {
+        return $this->prop(PropKey::AutoFocus, true);
+    }
+
+    public function blur(): self
+    {
+        Keyboard::dismiss();
+
+        return $this;
+    }
+
+    /**
+     * Returns the last UI-thread resize measurement. Call observeResize() first;
+     * no synchronous bridge round-trip is performed.
+     *
+     * @return array{x: float, y: float, width: float, height: float}|null
+     */
+    public function measure(): ?array
+    {
+        return $this->document->measurement($this->identity);
+    }
+
+    /** @param Closure(array{x: float, y: float, width: float, height: float}): void $handler */
+    public function observeResize(Closure $handler): self
+    {
+        $identity = $this->identity;
+        $document = $this->document;
+
+        return $this->on(EventKind::Resize, static function (mixed $payload) use ($identity, $document, $handler): void {
+            if (!is_array($payload)) {
+                return;
+            }
+            $measurement = [
+                'x' => (float) ($payload['x'] ?? 0.0),
+                'y' => (float) ($payload['y'] ?? 0.0),
+                'width' => (float) ($payload['width'] ?? 0.0),
+                'height' => (float) ($payload['height'] ?? 0.0),
+            ];
+            $document->recordMeasurement($identity, $measurement);
+            $handler($measurement);
+        });
+    }
+
+    /** @param Closure(mixed): void $handler */
+    public function observeIntersection(Closure $handler): self
+    {
+        return $this->on(EventKind::Intersect, $handler);
+    }
+
+    private function required(): NativeElement
+    {
+        return $this->document->native($this->identity)
+            ?? throw new LogicException("DOM node {$this->identity} is detached.");
+    }
+}

--- a/packages/native/src/Dom/Element.php
+++ b/packages/native/src/Dom/Element.php
@@ -85,7 +85,8 @@ final class Element
 
     public function contains(self $candidate): bool
     {
-        return $this->document->contains($this->identity, $candidate->identity);
+        return $this->document === $candidate->document
+            && $this->document->contains($this->identity, $candidate->identity);
     }
 
     public function matches(string $selector): bool

--- a/packages/native/src/Dom/ElementCollection.php
+++ b/packages/native/src/Dom/ElementCollection.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Dom;
+
+use Closure;
+use Countable;
+use IteratorAggregate;
+use Pam\Native\AnimationEasing;
+use Pam\Native\EventKind;
+use Pam\Native\Internal\BinaryValue;
+use Pam\Native\MotionPreset;
+use Pam\Native\PropKey;
+use Pam\Native\Element as NativeElement;
+use Traversable;
+
+/** @implements IteratorAggregate<int, Element> */
+final readonly class ElementCollection implements Countable, IteratorAggregate
+{
+    /** @param list<string> $identities */
+    public function __construct(
+        private Document $document,
+        private array $identities,
+    ) {
+    }
+
+    public function count(): int
+    {
+        return count($this->identities);
+    }
+
+    public function first(): ?Element
+    {
+        return isset($this->identities[0]) ? new Element($this->document, $this->identities[0]) : null;
+    }
+
+    public function last(): ?Element
+    {
+        $identity = $this->identities[array_key_last($this->identities)] ?? null;
+
+        return $identity === null ? null : new Element($this->document, $identity);
+    }
+
+    public function getIterator(): Traversable
+    {
+        foreach ($this->identities as $identity) {
+            yield new Element($this->document, $identity);
+        }
+    }
+
+    /** @return list<Element> */
+    public function toArray(): array
+    {
+        return iterator_to_array($this->getIterator(), false);
+    }
+
+    /** @param Closure(Element, int): mixed $operation */
+    public function each(Closure $operation): self
+    {
+        foreach ($this as $index => $element) {
+            $operation($element, $index);
+        }
+
+        return $this;
+    }
+
+    /** @param Closure(Element, int): bool $predicate */
+    public function filter(Closure $predicate): self
+    {
+        $identities = [];
+        foreach ($this as $index => $element) {
+            if ($predicate($element, $index)) {
+                $identities[] = $element->identity();
+            }
+        }
+
+        return new self($this->document, $identities);
+    }
+
+    public function addClass(string ...$classes): self
+    {
+        $this->document->replaceMany($this->identities, static fn (NativeElement $element): NativeElement => $element->class(...$classes));
+
+        return $this;
+    }
+
+    public function removeClass(string ...$classes): self
+    {
+        $this->document->replaceMany($this->identities, static fn (NativeElement $element): NativeElement => $element->domWithClasses(array_values(array_filter(
+            $element->domClasses(),
+            static fn (string $class): bool => !in_array($class, $classes, true),
+        ))));
+
+        return $this;
+    }
+
+    public function style(string|PropKey $property, string|int|float|bool|BinaryValue $value): self
+    {
+        $key = StyleDeclaration::resolve($property);
+        $this->document->replaceMany($this->identities, static fn (NativeElement $element): NativeElement => $element->domWithProperty($key, $value));
+
+        return $this;
+    }
+
+    public function on(EventKind $event, Closure $handler): self
+    {
+        $this->document->replaceMany($this->identities, static fn (NativeElement $element): NativeElement => $element->domWithEvent($event, $handler));
+
+        return $this;
+    }
+
+    public function animate(MotionPreset $preset, int $durationMs = 240, AnimationEasing $easing = AnimationEasing::EaseOut): self
+    {
+        $this->document->replaceMany($this->identities, static fn (NativeElement $element): NativeElement => $element->motion($preset, $durationMs, $easing));
+
+        return $this;
+    }
+
+    public function remove(): void
+    {
+        $this->document->transaction(function (): void {
+            foreach (array_reverse($this->identities) as $identity) {
+                if ($this->document->native($identity) !== null) {
+                    (new Element($this->document, $identity))->remove();
+                }
+            }
+        });
+    }
+
+    /** @param Closure(Element): mixed $operation */
+    private function batch(Closure $operation): self
+    {
+        $this->document->transaction(function () use ($operation): void {
+            foreach ($this as $element) {
+                $operation($element);
+            }
+        });
+
+        return $this;
+    }
+}

--- a/packages/native/src/Dom/MutationObserver.php
+++ b/packages/native/src/Dom/MutationObserver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Dom;
+
+final class MutationObserver
+{
+    private bool $connected = true;
+
+    /** @internal */
+    public function __construct(
+        private readonly Document $document,
+        private readonly int $id,
+    ) {
+    }
+
+    public function connected(): bool
+    {
+        return $this->connected;
+    }
+
+    public function disconnect(): void
+    {
+        if (!$this->connected) {
+            return;
+        }
+        $this->connected = false;
+        $this->document->disconnectObserver($this->id);
+    }
+
+    public function __destruct()
+    {
+        $this->disconnect();
+    }
+}

--- a/packages/native/src/Dom/MutationRecord.php
+++ b/packages/native/src/Dom/MutationRecord.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Dom;
+
+final readonly class MutationRecord
+{
+    /** @param list<string> $identities */
+    public function __construct(
+        public int $version,
+        public array $identities,
+    ) {
+    }
+}

--- a/packages/native/src/Dom/Selector.php
+++ b/packages/native/src/Dom/Selector.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Dom;
+
+use InvalidArgumentException;
+use Pam\Native\Element as NativeElement;
+
+final readonly class Selector
+{
+    /** @param non-empty-list<array{compound: string, combinator: ?string}> $parts */
+    private function __construct(private array $parts)
+    {
+    }
+
+    public static function compile(string $source): self
+    {
+        $source = trim($source);
+        if ($source === '' || strlen($source) > 512) {
+            throw new InvalidArgumentException('DOM selectors must contain between 1 and 512 bytes.');
+        }
+        if (str_contains($source, ',') || preg_match('/[+~:*()]/', $source) === 1) {
+            throw new InvalidArgumentException('DOM selectors support type, id, class, data attributes, child, and descendant combinators.');
+        }
+
+        preg_match_all('/(?:\[[^\]]+\]|[^\s>])+|>/', $source, $matches);
+        $tokens = $matches[0] ?? [];
+        $parts = [];
+        $nextCombinator = null;
+        foreach ($tokens as $token) {
+            if ($token === '>') {
+                if ($parts === [] || $nextCombinator !== null) {
+                    throw new InvalidArgumentException("Invalid DOM selector {$source}.");
+                }
+                $nextCombinator = '>';
+                continue;
+            }
+            $parts[] = ['compound' => $token, 'combinator' => $parts === [] ? null : ($nextCombinator ?? ' ')];
+            $nextCombinator = null;
+        }
+        if ($parts === [] || $nextCombinator !== null || count($parts) > 16) {
+            throw new InvalidArgumentException("Invalid or excessively complex DOM selector {$source}.");
+        }
+
+        return new self($parts);
+    }
+
+    /** @param callable(string): ?NativeElement $parent */
+    public function matches(NativeElement $element, callable $parent): bool
+    {
+        return $this->matchesAt(count($this->parts) - 1, $element, $parent);
+    }
+
+    /** @param callable(string): ?NativeElement $parent */
+    private function matchesAt(int $index, NativeElement $element, callable $parent): bool
+    {
+        if (!$this->matchesCompound($this->parts[$index]['compound'], $element)) {
+            return false;
+        }
+        if ($index === 0) {
+            return true;
+        }
+
+        $identity = $element->domIdentity();
+        $ancestor = $identity === null ? null : $parent($identity);
+        if ($this->parts[$index]['combinator'] === '>') {
+            return $ancestor !== null && $this->matchesAt($index - 1, $ancestor, $parent);
+        }
+        while ($ancestor !== null) {
+            if ($this->matchesAt($index - 1, $ancestor, $parent)) {
+                return true;
+            }
+            $identity = $ancestor->domIdentity();
+            $ancestor = $identity === null ? null : $parent($identity);
+        }
+
+        return false;
+    }
+
+    private function matchesCompound(string $compound, NativeElement $element): bool
+    {
+        preg_match('/^[A-Za-z][A-Za-z0-9-]*/', $compound, $tagMatch);
+        $tag = $tagMatch[0] ?? null;
+        if ($tag !== null && strcasecmp($tag, $element->kind()->name) !== 0) {
+            return false;
+        }
+        if (preg_match('/#([A-Za-z][A-Za-z0-9_.:-]{0,127})/', $compound, $id) === 1 && $element->domId() !== $id[1]) {
+            return false;
+        }
+        preg_match_all('/\.([A-Za-z_][A-Za-z0-9_-]{0,127})/', $compound, $classes);
+        foreach ($classes[1] ?? [] as $class) {
+            if (!in_array($class, $element->domClasses(), true)) {
+                return false;
+            }
+        }
+        preg_match_all('/\[data-([a-z][a-z0-9-]{0,63})(?:=(?:"([^"]*)"|\'([^\']*)\'|([^\]]+)))?\]/', $compound, $data, PREG_SET_ORDER);
+        foreach ($data as $attribute) {
+            $name = $attribute[1];
+            $dataset = $element->domDataset();
+            if (!array_key_exists($name, $dataset)) {
+                return false;
+            }
+            $hasExpectedValue = str_contains($attribute[0], '=');
+            $expected = $attribute[2] !== '' ? $attribute[2] : ($attribute[3] !== '' ? $attribute[3] : trim($attribute[4] ?? ''));
+            if ($hasExpectedValue && $dataset[$name] !== $expected) {
+                return false;
+            }
+        }
+
+        $consumed = preg_replace([
+            '/^[A-Za-z][A-Za-z0-9-]*/',
+            '/#[A-Za-z][A-Za-z0-9_.:-]{0,127}/',
+            '/\.[A-Za-z_][A-Za-z0-9_-]{0,127}/',
+            '/\[data-[^\]]+\]/',
+        ], '', $compound);
+        if ($consumed !== '') {
+            throw new InvalidArgumentException("Unsupported DOM selector compound {$compound}.");
+        }
+
+        return true;
+    }
+}

--- a/packages/native/src/Dom/StyleDeclaration.php
+++ b/packages/native/src/Dom/StyleDeclaration.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pam\Native\Dom;
+
+use InvalidArgumentException;
+use Pam\Native\Internal\BinaryValue;
+use Pam\Native\PropKey;
+
+final class StyleDeclaration
+{
+    /** @var array<string, PropKey> */
+    private const PROPERTIES = [
+        'width' => PropKey::Width,
+        'height' => PropKey::Height,
+        'opacity' => PropKey::Opacity,
+        'background-color' => PropKey::BackgroundColor,
+        'color' => PropKey::TextColor,
+        'font-size' => PropKey::FontSize,
+        'font-weight' => PropKey::FontWeight,
+        'border-radius' => PropKey::BorderRadius,
+        'border-width' => PropKey::BorderWidth,
+        'border-color' => PropKey::BorderColor,
+        'padding' => PropKey::Padding,
+        'margin' => PropKey::Margin,
+        'gap' => PropKey::Gap,
+        'translate-x' => PropKey::TranslationX,
+        'translate-y' => PropKey::TranslationY,
+        'scale-x' => PropKey::ScaleX,
+        'scale-y' => PropKey::ScaleY,
+        'rotation' => PropKey::Rotation,
+        'z-index' => PropKey::ZIndex,
+    ];
+
+    public function __construct(private readonly Element $element)
+    {
+    }
+
+    public function set(
+        string|PropKey $property,
+        string|int|float|bool|BinaryValue $value,
+    ): Element {
+        $key = self::resolve($property);
+        $this->validate($key, $value);
+
+        return $this->element->prop($key, $value);
+    }
+
+    public function remove(string|PropKey $property): Element
+    {
+        return $this->element->removeProp(self::resolve($property));
+    }
+
+    public function get(string|PropKey $property): string|int|float|bool|BinaryValue|null
+    {
+        return $this->element->property(self::resolve($property));
+    }
+
+    public static function resolve(string|PropKey $property): PropKey
+    {
+        if ($property instanceof PropKey) {
+            return $property;
+        }
+        $key = self::PROPERTIES[strtolower(trim($property))] ?? null;
+        if ($key === null) {
+            throw new InvalidArgumentException("Unknown or non-styleable DOM property {$property}; use a typed PropKey for advanced properties.");
+        }
+
+        return $key;
+    }
+
+    private function validate(PropKey $key, string|int|float|bool|BinaryValue $value): void
+    {
+        if (in_array($key, [PropKey::Opacity, PropKey::ScaleX, PropKey::ScaleY], true)
+            && is_float($value) && !is_finite($value)) {
+            throw new InvalidArgumentException('DOM style values must be finite.');
+        }
+        if ($key === PropKey::Opacity && is_numeric($value) && ((float) $value < 0.0 || (float) $value > 1.0)) {
+            throw new InvalidArgumentException('DOM opacity must be between zero and one.');
+        }
+    }
+}

--- a/packages/native/src/Element.php
+++ b/packages/native/src/Element.php
@@ -22,6 +22,16 @@ abstract class Element implements Renderable
 
     private ?string $elementKey = null;
 
+    private ?string $domIdentity = null;
+
+    private ?string $domId = null;
+
+    /** @var list<string> */
+    private array $domClasses = [];
+
+    /** @var array<string, string> */
+    private array $domDataset = [];
+
     final protected function __construct(private readonly NodeKind $kind)
     {
     }
@@ -34,6 +44,50 @@ abstract class Element implements Renderable
 
         $copy = clone $this;
         $copy->elementKey = $key;
+
+        return $copy;
+    }
+
+    final public function id(string $id): static
+    {
+        if (preg_match('/^[A-Za-z][A-Za-z0-9_.:-]{0,127}$/D', $id) !== 1) {
+            throw new InvalidArgumentException('DOM ids must use a bounded portable identifier.');
+        }
+
+        $copy = clone $this;
+        $copy->domId = $id;
+
+        return $copy->testId($id);
+    }
+
+    final public function class(string ...$classes): static
+    {
+        $copy = clone $this;
+        foreach ($classes as $class) {
+            foreach (preg_split('/\s+/', trim($class), -1, PREG_SPLIT_NO_EMPTY) ?: [] as $token) {
+                if (preg_match('/^[A-Za-z_][A-Za-z0-9_-]{0,127}$/D', $token) !== 1) {
+                    throw new InvalidArgumentException("Invalid DOM class token {$token}.");
+                }
+                if (!in_array($token, $copy->domClasses, true)) {
+                    $copy->domClasses[] = $token;
+                }
+            }
+        }
+
+        return $copy;
+    }
+
+    final public function data(string $name, string $value): static
+    {
+        if (preg_match('/^[a-z][a-z0-9-]{0,63}$/D', $name) !== 1) {
+            throw new InvalidArgumentException('DOM data names must use lowercase kebab-case.');
+        }
+        if (strlen($value) > 4_096 || preg_match('//u', $value) !== 1) {
+            throw new InvalidArgumentException('DOM data values must be valid UTF-8 up to 4 KiB.');
+        }
+
+        $copy = clone $this;
+        $copy->domDataset[$name] = $value;
 
         return $copy;
     }
@@ -256,6 +310,87 @@ abstract class Element implements Renderable
     final public function elementKey(): ?string
     {
         return $this->elementKey;
+    }
+
+    final public function domIdentity(): ?string
+    {
+        return $this->domIdentity;
+    }
+
+    final public function domId(): ?string
+    {
+        return $this->domId;
+    }
+
+    /** @return list<string> */
+    final public function domClasses(): array
+    {
+        return $this->domClasses;
+    }
+
+    /** @return array<string, string> */
+    final public function domDataset(): array
+    {
+        return $this->domDataset;
+    }
+
+    /** @internal Visual DOM retained-tree operation. */
+    final public function domWithIdentity(string $identity): static
+    {
+        if (preg_match('/^n[1-9][0-9]{0,18}$/D', $identity) !== 1) {
+            throw new InvalidArgumentException('DOM identities must be positive bounded handles.');
+        }
+        $copy = clone $this;
+        $copy->domIdentity = $identity;
+
+        return $copy;
+    }
+
+    /** @internal Visual DOM retained-tree operation. @param list<Element> $children */
+    final public function domWithChildren(array $children): static
+    {
+        return $this->withChildren($children);
+    }
+
+    /** @internal Visual DOM retained-tree operation. */
+    final public function domWithProperty(
+        PropKey $key,
+        string|int|float|bool|BinaryValue $value,
+    ): static {
+        return $this->withProperty($key, $value);
+    }
+
+    /** @internal Visual DOM retained-tree operation. */
+    final public function domWithoutProperty(PropKey $key): static
+    {
+        $copy = clone $this;
+        unset($copy->properties[$key->value]);
+
+        return $copy;
+    }
+
+    /** @internal Visual DOM retained-tree operation. */
+    final public function domWithEvent(EventKind $kind, Closure $handler): static
+    {
+        return $this->withEvent($kind, $handler);
+    }
+
+    /** @internal Visual DOM retained-tree operation. @param list<string> $classes */
+    final public function domWithClasses(array $classes): static
+    {
+        $copy = clone $this;
+        $copy->domClasses = [];
+
+        return $copy->class(...$classes);
+    }
+
+    /** @internal Visual DOM retained-tree operation. */
+    final public function domWithoutData(string $name): static
+    {
+        $copy = clone $this;
+        unset($copy->domDataset[$name]);
+
+        return $copy;
     }
 
     /**

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -1376,6 +1376,7 @@ final class TemplateRenderer
 
         if ($resolvedClass !== null) {
             $element = self::classes($element, $resolvedClass, $data);
+            $element = $element->class($resolvedClass);
         }
 
         $element = self::attributes($element, $values);
@@ -1633,6 +1634,19 @@ final class TemplateRenderer
      */
     private static function attributes(Element $element, array $attributes): Element
     {
+        if (isset($attributes['id'])) {
+            $element = $element->id(self::stringValue($attributes['id'], 'DOM id'));
+        }
+
+        foreach ($attributes as $name => $value) {
+            if (str_starts_with($name, 'data-')) {
+                $element = $element->data(
+                    substr($name, 5),
+                    self::stringValue($value, "DOM {$name}"),
+                );
+            }
+        }
+
         if (isset($attributes['key'])) {
             $element = $element->key(self::stringValue($attributes['key'], 'Element key'));
         }

--- a/packages/native/src/Internal/TreeEncoder.php
+++ b/packages/native/src/Internal/TreeEncoder.php
@@ -232,7 +232,10 @@ final class TreeEncoder
             $this->encodeNode($child, $childId, $id, $childIndex, $childPath);
         }
 
-        if ($path === 'root' || ($element->elementKey() !== null && $element->children() !== [])) {
+        if (
+            $path === 'root'
+            || (($element->domIdentity() !== null || $element->elementKey() !== null) && $element->children() !== [])
+        ) {
             $this->cacheCandidates[] = new SubtreeCacheCandidate(
                 element: $element,
                 path: $path,
@@ -392,14 +395,17 @@ final class TreeEncoder
 
     private function pathSegment(Element $element, int $index): string
     {
-        return $element->elementKey() !== null
+        return $element->domIdentity() !== null
+            ? 'dom:'.$element->domIdentity()
+            : ($element->elementKey() !== null
             ? 'key:'.$element->elementKey()
-            : $element->kind()->value.':'.$index;
+            : $element->kind()->value.':'.$index);
     }
 
     private function nodeId(string $path, Element $element): int
     {
-        $identity = $path.'|'.$element->kind()->value;
+        $identity = ($element->domIdentity() === null ? $path : 'dom:'.$element->domIdentity())
+            .'|'.$element->kind()->value;
         $id = $this->identityIds[$identity]
             ??= (int) hexdec(substr(hash('xxh3', $identity), 0, 15));
 

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.14';
+    public const string SDK_VERSION = '1.0.15';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -7157,5 +7157,6 @@ require __DIR__.'/language2.php';
 require __DIR__.'/style_conformance.php';
 require __DIR__.'/singularity.php';
 require __DIR__.'/signals.php';
+require __DIR__.'/visual_dom.php';
 
 echo "Pam Native PHP SDK tests passed.\n";

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.14',
-    'The runtime SDK contract must match the stable 1.0.14 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.15',
+    'The runtime SDK contract must match the stable 1.0.15 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,

--- a/packages/native/tests/visual_dom.php
+++ b/packages/native/tests/visual_dom.php
@@ -30,6 +30,8 @@ $document = App::document(
 $assert($document instanceof Document, 'App::document must create a visual document.');
 $assert($document->root()->id() === 'app', 'The visual document must expose its root.');
 $assert($document->id('profile-name')->closest('.card')?->id() === 'profile', 'closest() must traverse visual ancestors.');
+$otherDocument = Document::from(View::make(Text::make('Other')->id('other')));
+$assert(!$document->root()->contains($otherDocument->id('other')), 'contains() must not alias handles from another document.');
 $assert($document->querySelector('View.card > Text.primary')?->id() === 'profile-name', 'Child selectors must match the right-most result.');
 $assert($document->querySelector('.card Button.action[data-state="idle"]') !== null, 'Compound descendant selectors must match data attributes.');
 $assert(count($document->all('.label')) === 2, 'Class indexes must return every matching element.');
@@ -75,6 +77,10 @@ try {
     $assert($error->getMessage() === 'rollback fixture', 'Transactions must rethrow their original error.');
 }
 $assert($document->querySelector('#rollback') === null && $document->toElement() === $snapshot, 'Failed transactions must restore the exact immutable tree.');
+
+$imported = Document::from($document->toElement());
+$imported->root()->append(Text::make('Imported')->id('imported-child'));
+$assert($imported->id('imported-child')->connected(), 'Imported documents must allocate a collision-free identity namespace.');
 
 $invalidSelectorRejected = false;
 try {

--- a/packages/native/tests/visual_dom.php
+++ b/packages/native/tests/visual_dom.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use Pam\Native\App;
+use Pam\Native\Dom\Document;
+use Pam\Native\Dom\MutationRecord;
+use Pam\Native\MotionPreset;
+use Pam\Native\PropKey;
+use Pam\Native\Internal\TemplateCompiler;
+use Pam\Native\Internal\TemplateRenderer;
+use Pam\Native\Internal\TreeEncoder;
+use Pam\Native\TemplateRegistry;
+use Pam\Native\UI\Button;
+use Pam\Native\UI\Text;
+use Pam\Native\UI\View;
+
+/** @var Closure(bool, string): void $assert */
+
+$document = App::document(
+    View::make(
+        View::make(
+            Text::make('Ada')->id('profile-name')->class('label', 'primary')->data('role', 'title'),
+            Button::make('Follow')->class('action')->data('state', 'idle'),
+        )->id('profile')->class('card'),
+        Text::make('Footer')->class('label'),
+    )->id('app')->class('screen'),
+);
+
+$assert($document instanceof Document, 'App::document must create a visual document.');
+$assert($document->root()->id() === 'app', 'The visual document must expose its root.');
+$assert($document->id('profile-name')->closest('.card')?->id() === 'profile', 'closest() must traverse visual ancestors.');
+$assert($document->querySelector('View.card > Text.primary')?->id() === 'profile-name', 'Child selectors must match the right-most result.');
+$assert($document->querySelector('.card Button.action[data-state="idle"]') !== null, 'Compound descendant selectors must match data attributes.');
+$assert(count($document->all('.label')) === 2, 'Class indexes must return every matching element.');
+$assert($document->snapshot()->nodeCount === 5, 'DevTools snapshots must expose bounded document metrics.');
+$assert(count($document->all('.label')->filter(static fn ($element, $index): bool => $index === 0)) === 1, 'Collections must support typed filtering.');
+
+$observed = [];
+$observer = $document->observe(static function (MutationRecord $record) use (&$observed): void {
+    $observed[] = $record;
+});
+$document->transaction(static function (Document $dom): void {
+    $dom->all('.label')->addClass('visible')->style('opacity', 0.8);
+    $dom->id('profile-name')->text('Grace')->data('role', 'heading');
+    $dom->id('profile')->append(Text::make('New')->id('new-child')->class('label'));
+});
+$assert(count($observed) === 1 && $observed[0]->version === 1, 'A transaction must emit one coalesced mutation record.');
+
+$assert(count($document->all('.visible')) === 2, 'Collection mutations must be applied atomically.');
+$assert($document->id('profile-name')->dataset()['role'] === 'heading', 'Dataset mutations must update selector indexes.');
+$assert($document->id('profile-name')->matches('[data-role="heading"]'), 'Mutated data must be queryable immediately.');
+$assert($document->id('new-child')->parent()?->id() === 'profile', 'append() must preserve parent relationships.');
+$assert($document->id('profile-name')->style()->get(PropKey::Opacity) === 0.8, 'Typed styles must remain readable.');
+
+$document->id('new-child')->before(Text::make('Before')->id('before-child'));
+$document->id('new-child')->after(Text::make('After')->id('after-child'));
+$assert($document->id('before-child')->nextSibling()?->id() === 'new-child', 'before() must preserve sibling order.');
+$assert($document->id('after-child')->previousSibling()?->id() === 'new-child', 'after() must preserve sibling order.');
+
+$document->id('new-child')->classList()->toggle('selected');
+$document->id('new-child')->classList()->replace('selected', 'active');
+$assert($document->id('new-child')->matches('.active'), 'classList mutations must update class indexes.');
+$document->id('new-child')->animate(MotionPreset::FadeIn)->pauseAnimation()->resumeAnimation();
+$document->id('new-child')->observeResize(static function (array $measurement): void {})->observeIntersection(static function (mixed $entry): void {});
+$assert($document->id('new-child')->measure() === null, 'measure() must avoid a synchronous bridge round-trip before native layout reports.');
+
+$snapshot = $document->toElement();
+try {
+    $document->transaction(static function (Document $dom): void {
+        $dom->id('profile')->append(Text::make('Rollback')->id('rollback'));
+        throw new RuntimeException('rollback fixture');
+    });
+} catch (RuntimeException $error) {
+    $assert($error->getMessage() === 'rollback fixture', 'Transactions must rethrow their original error.');
+}
+$assert($document->querySelector('#rollback') === null && $document->toElement() === $snapshot, 'Failed transactions must restore the exact immutable tree.');
+
+$invalidSelectorRejected = false;
+try {
+    $document->all('#before-child, #after-child');
+} catch (InvalidArgumentException) {
+    $invalidSelectorRejected = true;
+}
+$assert($invalidSelectorRejected, 'Unsupported selector syntax must fail loudly.');
+$observer->disconnect();
+
+TemplateRegistry::styleResolver(static fn (string $class): array => []);
+$templateElement = TemplateRenderer::render(
+    TemplateCompiler::compile('<View id="template-root" class="shell featured" data-screen="home"><Text id="headline">Hello</Text></View>'),
+    null,
+    [],
+);
+TemplateRegistry::reset();
+$templateDocument = Document::from($templateElement);
+$assert(
+    $templateDocument->id('template-root')->matches('.shell.featured[data-screen="home"]')
+        && $templateDocument->id('headline')->parent()?->id() === 'template-root',
+    'Declarative id, class, and data-* attributes must feed the visual DOM.',
+);
+
+$encoder = new TreeEncoder();
+$encoder->encode($document->toElement());
+$document->id('profile')->prepend(Text::make('Stable')->id('stable-child'));
+$domPatch = $encoder->encode($document->toElement());
+$assert(
+    $domPatch['frame'] !== null && str_starts_with($domPatch['frame'], 'PNP1'),
+    'Visual DOM mutations must cross the existing Rust/native pipeline as incremental patches.',
+);

--- a/packages/native/tests/visual_dom_performance.php
+++ b/packages/native/tests/visual_dom_performance.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Pam\Native\Dom\Document;
+use Pam\Native\UI\Text;
+use Pam\Native\UI\View;
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'Pam\\Native\\';
+    if (str_starts_with($class, $prefix)) {
+        $path = __DIR__.'/../src/'.str_replace('\\', '/', substr($class, strlen($prefix))).'.php';
+        if (is_file($path)) {
+            require $path;
+        }
+    }
+});
+
+$rows = [];
+for ($index = 0; $index < 5_000; $index++) {
+    $rows[] = Text::make("Row {$index}")
+        ->id("row-{$index}")
+        ->class('row', $index % 2 === 0 ? 'even' : 'odd')
+        ->data('index', (string) $index);
+}
+
+$started = hrtime(true);
+$document = Document::from(View::make(...$rows)->id('benchmark'));
+$indexMs = (hrtime(true) - $started) / 1_000_000;
+
+$started = hrtime(true);
+for ($iteration = 0; $iteration < 2_000; $iteration++) {
+    $document->querySelector('#row-'.($iteration % 5_000));
+    $document->querySelector('.odd[data-index="'.(($iteration * 2 + 1) % 5_000).'"]');
+}
+$queryMs = (hrtime(true) - $started) / 1_000_000;
+
+$started = hrtime(true);
+$document->transaction(static function (Document $dom): void {
+    $dom->all('.even')->addClass('selected')->style('opacity', 0.95);
+});
+$mutationMs = (hrtime(true) - $started) / 1_000_000;
+
+$indexBudget = (float) (getenv('PAM_DOM_INDEX_MS') ?: 500);
+$queryBudget = (float) (getenv('PAM_DOM_QUERY_MS') ?: 500);
+$mutationBudget = (float) (getenv('PAM_DOM_MUTATION_MS') ?: 5_000);
+
+fwrite(STDOUT, json_encode([
+    'nodes' => 5_001,
+    'indexedQueries' => 4_000,
+    'batchedMutations' => 5_000,
+    'indexMs' => round($indexMs, 3),
+    'queryMs' => round($queryMs, 3),
+    'mutationMs' => round($mutationMs, 3),
+    'peakMemoryMiB' => round(memory_get_peak_usage(true) / 1_048_576, 2),
+], JSON_THROW_ON_ERROR).PHP_EOL);
+
+if ($indexMs > $indexBudget || $queryMs > $queryBudget || $mutationMs > $mutationBudget) {
+    fwrite(STDERR, 'Visual DOM performance budget exceeded.'.PHP_EOL);
+    exit(1);
+}


### PR DESCRIPTION
## Outcome

Adds a typed, retained Visual DOM facade on the existing PAM Native element, binary patch, Rust layout and platform renderer pipeline.

## Included

- indexed type, id, class and `data-*` selectors with bounded combinators and cache
- stable Document/Element handles and declarative `id`, `class`, `data-*` integration
- atomic transactions with exact rollback and coalesced mutation observation
- append/prepend/before/after/replace/remove, classList, dataset, typed styles and events
- native motion controls, focus, resize/intersection observation and async measurement cache
- stable DOM identities in TreeEncoder so structural edits preserve mounted platform views
- document snapshots for DevTools and collection bulk transforms
- full functional tests, PHPStan level-9 coverage and a mandatory 5,001-node performance gate
- complete Visual DOM and performance documentation

## Local evidence

- `php packages/native/tests/run.php`
- `phpstan analyse --configuration=packages/native/phpstan-singularity.neon --no-progress`
- `php packages/native/tests/visual_dom_performance.php`
  - 5,001 nodes
  - 4,000 indexed queries: ~15 ms
  - 5,000 batched mutations: ~16 ms
  - peak memory: 16 MiB
- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets` (112 tests)
- `cargo clippy --locked --all-targets -- -D warnings`
- `git diff --check`

Build intermediates will be removed by the mandatory cleanup contract after certification.
