### PR TITLE
fix: pass short tags to release certification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,28 +43,28 @@ jobs:
     needs: release-ref
     uses: ./.github/workflows/ci.yml
     with:
-      checkout_ref: ${{ inputs.release_tag || github.ref }}
+      checkout_ref: ${{ inputs.release_tag || github.ref_name }}
 
   ecosystem-compatibility:
     name: Certify the complete PAM Native ecosystem
     needs: release-ref
     uses: push-in/pam/.github/workflows/ecosystem-compatibility.yml@main
     with:
-      native_ref: ${{ inputs.release_tag || github.ref }}
+      native_ref: ${{ inputs.release_tag || github.ref_name }}
 
   ecosystem-android:
     name: Certify official Android plugins
     needs: release-ref
     uses: ./.github/workflows/ecosystem-android.yml
     with:
-      checkout_ref: ${{ inputs.release_tag || github.ref }}
+      checkout_ref: ${{ inputs.release_tag || github.ref_name }}
 
   ecosystem-ios:
     name: Certify official iOS plugins
     needs: release-ref
     uses: ./.github/workflows/ecosystem-ios.yml
     with:
-      checkout_ref: ${{ inputs.release_tag || github.ref }}
+      checkout_ref: ${{ inputs.release_tag || github.ref_name }}
 
   ios:
     name: Package iOS renderer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.16 - 2026-08-26
+
+- Passes the short immutable release tag to every reusable certification
+  workflow, preventing `refs/tags/*` from being interpreted as a Composer
+  semantic version during ecosystem candidate resolution.
+- Adds a release-workflow regression contract that rejects full Git refs at
+  reusable workflow boundaries.
+
 ## 1.0.15 - 2026-08-26
 
 - Adds the typed Visual DOM with indexed selectors, stable element handles,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.15"
+version = "1.0.16"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.15"
+version = "1.0.16"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.15';
+    public const string SDK_VERSION = '1.0.16';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.15',
-    'The runtime SDK contract must match the stable 1.0.15 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.16',
+    'The runtime SDK contract must match the stable 1.0.16 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,

--- a/scripts/test-release-workflows.php
+++ b/scripts/test-release-workflows.php
@@ -88,7 +88,7 @@ requireFragments($release, 'release.yml', [
     "  source-contracts:\n",
     "    uses: ./.github/workflows/ci.yml\n",
     "  ecosystem-android:\n",
-    "      native_ref: \${{ inputs.release_tag || github.ref }}\n",
+    "      native_ref: \${{ inputs.release_tag || github.ref_name }}\n",
     "    uses: ./.github/workflows/ecosystem-android.yml\n",
     "  ecosystem-ios:\n",
     "    uses: ./.github/workflows/ecosystem-ios.yml\n",
@@ -120,6 +120,9 @@ requireFragments($release, 'release.yml', [
     "            --created-epoch \"$(git log -1 --format=%ct)\" \\\n",
     "        uses: actions/attest-sbom@v4\n",
 ]);
+if (str_contains($release, 'inputs.release_tag || github.ref }}')) {
+    fail('release.yml must pass a short immutable tag, never refs/tags/*, to reusable workflows');
+}
 requireFragments($composerPackage, 'composer-package.yml', [
     "  ecosystem-compatibility:\n",
     "      native_ref: \${{ inputs.release_tag }}\n",


### PR DESCRIPTION
## Root cause

The v1.0.15 release correctly stopped before publication because the tag-push path passed `github.ref` (`refs/tags/v1.0.15`) to the reusable ecosystem workflow. Composer candidate setup expects a semantic version or short tag and rejected the full Git ref in every affected package matrix.

## Fix

- pass `inputs.release_tag || github.ref_name` to every reusable source/ecosystem workflow
- add a regression contract rejecting `github.ref` at these boundaries
- prepare immutable v1.0.16; v1.0.15 remains an unpublished failed release tag and is not moved

## Evidence

- `cargo metadata --locked --no-deps`
- `php scripts/test-release-workflows.php`
- `php packages/native/tests/run.php`
- Visual DOM 5,001-node performance gate
- `git diff --check`
