### PR TITLE
fix(vscode): PHP intelligence and highlighting for PAM components

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,30 @@
+# PAM Native for VS Code
+
+PAM single-file components contain real PHP. Open `.pam` and `.pam.php` as
+PHP so Intelephense can index classes, imports, inherited methods and types.
+The extension pack includes Intelephense. PAM contributes template navigation,
+completion and formatting alongside the PHP server. Existing workspace
+associations to `pam` take precedence; change them to `php` to enable PHP tooling.
+
+```json
+{
+  "files.associations": { "*.pam": "php", "*.pam.php": "php" },
+  "intelephense.files.associations": ["*.php", "*.phtml", "*.pam"]
+}
+```
+
+The PAM language server runs with `pam exec`, using the runtime's PHP version
+instead of the host interpreter. Set `pam.languageServer.runtime` for a custom
+PAM executable. An explicit `pam.languageServer.path` remains an executable
+override. PHP keywords, braces, open/close delimiters, CSS and template expressions
+use their embedded grammars.
+
+## Verification
+
+`node --check extension.js` checks extension syntax. `php-editor.test.js` is a
+VS Code extension-host integration test for an SDK-equipped sample workspace with
+`src/Components/PrimaryButton.pam` (extends Component and calls emit). Launch VS Code
+with this directory as `--extensionDevelopmentPath`, the test file as
+`--extensionTestsPath`, and the sample app as the workspace. Intelephense must be
+installed. It checks PHP language identity, SDK class definition, inherited method
+definition and PHP hover. The test does not claim universal PHP language coverage.

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -6,12 +6,12 @@ const fs = require("fs");
 const path = require("path");
 
 class PamLanguageClient {
-    constructor(cwd, executable, diagnostics) {
+    constructor(cwd, executable, diagnostics, args = []) {
         this.nextId = 1;
         this.pending = new Map();
         this.buffer = Buffer.alloc(0);
         this.diagnostics = diagnostics;
-        this.process = cp.spawn(executable, [], {cwd, stdio: ["pipe", "pipe", "pipe"]});
+        this.process = cp.spawn(executable, args, {cwd, stdio: ["pipe", "pipe", "pipe"]});
         this.process.stdout.on("data", chunk => this.consume(chunk));
         this.process.stderr.setEncoding("utf8").on("data", message => {
             if (message.trim()) console.error(`[pam-native] ${message.trim()}`);
@@ -90,6 +90,21 @@ class PamLanguageClient {
     close(document) { this.notify("textDocument/didClose", {textDocument: {uri: document.uri.toString()}}); }
 }
 
+function isPam(document) {
+    return document.languageId === "pam" || /\.pam(?:\.php)?$/.test(document.uri.path);
+}
+
+function isPhpPosition(document, position) {
+    const prefix = document.getText(new vscode.Range(new vscode.Position(0, 0), position));
+    return prefix.lastIndexOf("<?php") > prefix.lastIndexOf("?>");
+}
+
+const pamSelector = [
+    {language: "pam"},
+    {language: "php", pattern: "**/*.pam"},
+    {language: "php", pattern: "**/*.pam.php"},
+];
+
 async function activate(context) {
     const workspace = vscode.workspace.workspaceFolders?.[0];
     const activeDocument = vscode.window.activeTextEditor?.document;
@@ -99,19 +114,23 @@ async function activate(context) {
     const projectExecutable = process.platform === "win32"
         ? path.join(cwd, "vendor", "bin", "pam-native-language-server.bat")
         : path.join(cwd, "vendor", "bin", "pam-native-language-server");
+    if (!configured && !fs.existsSync(projectExecutable) && !vscode.workspace.textDocuments.some(isPam)) return;
     const executable = configured || (fs.existsSync(projectExecutable) ? projectExecutable : "pam-native-language-server");
     const diagnostics = vscode.languages.createDiagnosticCollection("pam-native");
-    const client = new PamLanguageClient(cwd, executable, diagnostics);
+    const runtime = vscode.workspace.getConfiguration("pam").get("languageServer.runtime", "pam");
+    const client = configured
+        ? new PamLanguageClient(cwd, executable, diagnostics)
+        : new PamLanguageClient(cwd, runtime, diagnostics, ["exec", executable]);
     await client.request("initialize", {processId: process.pid, rootUri: workspace?.uri.toString() ?? null, capabilities: {}});
     client.notify("initialized", {});
 
-    for (const document of vscode.workspace.textDocuments.filter(document => document.languageId === "pam")) client.open(document);
+    for (const document of vscode.workspace.textDocuments.filter(document => isPam(document))) client.open(document);
     context.subscriptions.push(
         diagnostics,
-        vscode.workspace.onDidOpenTextDocument(document => { if (document.languageId === "pam") client.open(document); }),
-        vscode.workspace.onDidChangeTextDocument(event => { if (event.document.languageId === "pam") client.change(event.document); }),
-        vscode.workspace.onDidCloseTextDocument(document => { if (document.languageId === "pam") client.close(document); }),
-        vscode.languages.registerDocumentFormattingEditProvider("pam", {
+        vscode.workspace.onDidOpenTextDocument(document => { if (isPam(document)) client.open(document); }),
+        vscode.workspace.onDidChangeTextDocument(event => { if (isPam(event.document)) client.change(event.document); }),
+        vscode.workspace.onDidCloseTextDocument(document => { if (isPam(document)) client.close(document); }),
+        vscode.languages.registerDocumentFormattingEditProvider(pamSelector, {
             async provideDocumentFormattingEdits(document, options) {
                 const edits = await client.request("textDocument/formatting", {textDocument: {uri: document.uri.toString()}, options});
                 return edits.map(edit => vscode.TextEdit.replace(
@@ -120,19 +139,22 @@ async function activate(context) {
                 ));
             },
         }),
-        vscode.languages.registerCompletionItemProvider("pam", {
+        vscode.languages.registerCompletionItemProvider(pamSelector, {
             async provideCompletionItems(document, position) {
+                if (document.languageId === "php" && isPhpPosition(document, position)) return null;
                 return client.request("textDocument/completion", {textDocument: {uri: document.uri.toString()}, position});
             },
         }, "<", ":", "@"),
-        vscode.languages.registerHoverProvider("pam", {
+        vscode.languages.registerHoverProvider(pamSelector, {
             async provideHover(document, position) {
+                if (document.languageId === "php" && isPhpPosition(document, position)) return null;
                 const hover = await client.request("textDocument/hover", {textDocument: {uri: document.uri.toString()}, position});
                 return hover ? new vscode.Hover(new vscode.MarkdownString(hover.contents.value)) : null;
             },
         }),
-        vscode.languages.registerDefinitionProvider("pam", {
+        vscode.languages.registerDefinitionProvider(pamSelector, {
             async provideDefinition(document, position) {
+                if (document.languageId === "php" && isPhpPosition(document, position)) return null;
                 const definition = await client.request("textDocument/definition", {textDocument: {uri: document.uri.toString()}, position});
                 if (!definition) return null;
                 return new vscode.Location(

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,11 +1,44 @@
 {
-    "comments": {"blockComment": ["<!--", "-->"]},
-    "brackets": [["<", ">"], ["{", "}"], ["[", "]"], ["(", ")"]],
+    "comments": {
+        "blockComment": [
+            "<!--",
+            "-->"
+        ]
+    },
+    "brackets": [
+        [
+            "{",
+            "}"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ]
+    ],
     "autoClosingPairs": [
-        {"open": "{", "close": "}"},
-        {"open": "[", "close": "]"},
-        {"open": "(", "close": ")"},
-        {"open": "\"", "close": "\""},
-        {"open": "'", "close": "'"}
+        {
+            "open": "{",
+            "close": "}"
+        },
+        {
+            "open": "[",
+            "close": "]"
+        },
+        {
+            "open": "(",
+            "close": ")"
+        },
+        {
+            "open": "\"",
+            "close": "\""
+        },
+        {
+            "open": "'",
+            "close": "'"
+        }
     ]
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4,26 +4,61 @@
     "description": "Language support for PAM Native components.",
     "version": "0.1.0",
     "publisher": "pushin",
-    "engines": {"vscode": "^1.95.0"},
-    "categories": ["Programming Languages", "Formatters"],
-    "activationEvents": ["onLanguage:pam"],
+    "engines": {
+        "vscode": "^1.95.0"
+    },
+    "categories": [
+        "Programming Languages",
+        "Formatters"
+    ],
+    "activationEvents": [
+        "onLanguage:pam",
+        "onLanguage:php"
+    ],
     "main": "./extension.js",
     "contributes": {
-        "languages": [{
-            "id": "pam",
-            "aliases": ["PAM Native", "pam"],
-            "extensions": [".pam", ".pam.php"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "pam",
-            "scopeName": "source.pam",
-            "path": "./syntaxes/pam.tmLanguage.json"
-        }],
+        "languages": [
+            {
+                "id": "pam",
+                "aliases": [
+                    "PAM Native",
+                    "pam"
+                ],
+                "extensions": [
+                    ".pam",
+                    ".pam.php"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "pam",
+                "scopeName": "source.pam",
+                "path": "./syntaxes/pam.tmLanguage.json",
+                "embeddedLanguages": {
+                    "source.php": "php",
+                    "source.css": "css",
+                    "text.html.pam": "html",
+                    "source.pam-expression": "php"
+                }
+            },
+            {
+                "scopeName": "pam.php.embedded",
+                "path": "./syntaxes/pam-php.injection.json",
+                "injectTo": [
+                    "text.html.php"
+                ]
+            }
+        ],
         "configurationDefaults": {
             "[pam]": {
                 "editor.defaultFormatter": "pushin.pam-native",
                 "editor.formatOnSave": true
+            },
+            "files.associations": {
+                "*.pam": "php",
+                "*.pam.php": "php"
             }
         },
         "configuration": {
@@ -33,10 +68,20 @@
                     "type": "string",
                     "default": "",
                     "description": "Optional absolute path to pam-native-language-server. The project vendor/bin and PATH are used by default."
+                },
+                "pam.languageServer.runtime": {
+                    "type": "string",
+                    "default": "pam",
+                    "description": "PAM runtime executable used to run the language server with the project PHP version."
                 }
             }
         }
     },
-    "scripts": {"test": "node --check extension.js && node test.js"},
-    "license": "Apache-2.0"
+    "scripts": {
+        "test": "node --check extension.js && node test.js"
+    },
+    "license": "Apache-2.0",
+    "extensionPack": [
+        "bmewburn.vscode-intelephense-client"
+    ]
 }

--- a/editors/vscode/php-editor.test.js
+++ b/editors/vscode/php-editor.test.js
@@ -1,0 +1,25 @@
+const vscode = require('vscode');
+const fs = require('fs');
+const assert = require('assert');
+exports.run = async () => {
+ const doc = await vscode.workspace.openTextDocument(vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, 'src/Components/PrimaryButton.pam'));
+ await vscode.window.showTextDocument(doc);
+ assert.equal(doc.languageId, 'php');
+ const lines = doc.getText().split('\n');
+ const line = lines.findIndex(x => x.includes('extends Component'));
+ const pos = new vscode.Position(line, lines[line].lastIndexOf('Component')+2);
+ let defs=[];
+ for(let i=0;i<45;i++) {
+  defs=await vscode.commands.executeCommand('vscode.executeDefinitionProvider',doc.uri,pos)||[];
+  if(defs.some(x=>(x.uri||x.targetUri).path.endsWith('/Component.php')))break;
+  await new Promise(r=>setTimeout(r,1000));
+ }
+ assert(defs.some(x=>(x.uri||x.targetUri).path.endsWith('/Component.php')), 'Ctrl+click Component must resolve SDK PHP');
+ const memberLine=lines.findIndex(x=>x.includes("$this->emit"));
+ const memberPos=new vscode.Position(memberLine,lines[memberLine].indexOf('emit')+1);
+ const members=await vscode.commands.executeCommand('vscode.executeDefinitionProvider',doc.uri,memberPos)||[];
+ assert(members.length>0,'Inherited PHP method definition must resolve');
+ const hover=await vscode.commands.executeCommand('vscode.executeHoverProvider',doc.uri,memberPos);
+ assert(hover?.length,'PHP hover must resolve');
+ console.log(JSON.stringify({phpLanguage:true,classDefinition:defs.length,methodDefinition:members.length,hover:hover.length}));
+};

--- a/editors/vscode/syntaxes/pam-php.injection.json
+++ b/editors/vscode/syntaxes/pam-php.injection.json
@@ -1,0 +1,12 @@
+{
+    "scopeName": "pam.php.embedded",
+    "injectionSelector": "L:text.html.php - source.php - source.css",
+    "patterns": [
+        {
+            "include": "source.pam#template"
+        },
+        {
+            "include": "source.pam#style"
+        }
+    ]
+}

--- a/editors/vscode/syntaxes/pam.tmLanguage.json
+++ b/editors/vscode/syntaxes/pam.tmLanguage.json
@@ -3,32 +3,89 @@
     "name": "PAM Native",
     "scopeName": "source.pam",
     "patterns": [
-        {"include": "#php"},
-        {"include": "#style"},
-        {"include": "#template"}
+        {
+            "include": "#php"
+        },
+        {
+            "include": "#style"
+        },
+        {
+            "include": "#template"
+        }
     ],
     "repository": {
         "php": {
             "begin": "<\\?php",
             "end": "\\?>",
-            "beginCaptures": {"0": {"name": "punctuation.section.embedded.begin.php"}},
-            "endCaptures": {"0": {"name": "punctuation.section.embedded.end.php"}},
-            "contentName": "source.php"
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.php"
+                }
+            },
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.php"
+                }
+            },
+            "contentName": "source.php",
+            "patterns": [
+                {
+                    "include": "source.php"
+                }
+            ]
         },
         "style": {
             "begin": "(<style)(\\s+scoped)?(>)",
             "end": "</style>",
-            "contentName": "source.css"
+            "contentName": "source.css",
+            "patterns": [
+                {
+                    "include": "source.css"
+                }
+            ],
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.tag.style.html"
+                },
+                "2": {
+                    "name": "entity.other.attribute-name.html"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.end.html"
+                }
+            },
+            "endCaptures": {
+                "0": {
+                    "name": "entity.name.tag.style.html"
+                }
+            }
         },
         "template": {
             "begin": "<template(?:\\s+language=\\\"2\\\")?>",
             "end": "</template>",
             "contentName": "text.html.pam",
             "patterns": [
-                {"match": "\\b(p-if|p-else-if|p-else|p-for|p-key|p-index|recipe|variant:[A-Za-z][A-Za-z0-9_-]*)\\b", "name": "keyword.control.pam"},
-                {"match": "(@[A-Za-z][A-Za-z0-9:-]*|:[A-Za-z][A-Za-z0-9:-]*|bind:[A-Za-z][A-Za-z0-9:-]*)", "name": "entity.other.attribute-name.pam"},
-                {"begin": "\\{\\{", "end": "\\}\\}", "contentName": "source.pam-expression"},
-                {"include": "text.html.basic"}
+                {
+                    "match": "\\b(p-if|p-else-if|p-else|p-for|p-key|p-index|recipe|variant:[A-Za-z][A-Za-z0-9_-]*)\\b",
+                    "name": "keyword.control.pam"
+                },
+                {
+                    "match": "(@[A-Za-z][A-Za-z0-9:-]*|:[A-Za-z][A-Za-z0-9:-]*|bind:[A-Za-z][A-Za-z0-9:-]*)",
+                    "name": "entity.other.attribute-name.pam"
+                },
+                {
+                    "begin": "\\{\\{",
+                    "end": "\\}\\}",
+                    "contentName": "source.pam-expression",
+                    "patterns": [
+                        {
+                            "include": "source.php"
+                        }
+                    ]
+                },
+                {
+                    "include": "text.html.basic"
+                }
             ]
         }
     }


### PR DESCRIPTION
PAM components were highlighted as a custom language without access to PHP language intelligence, and the custom bracket list treated PHP delimiters and member arrows as unmatched angle brackets. The extension now defaults `.pam` and `.pam.php` to PHP, recommends Intelephense through its extension pack, and retains PAM template providers for these files.

PHP blocks delegate completion, hover and definitions to the PHP provider. Embedded PHP/CSS grammars and template injection retain highlighting. The PAM language server starts through `pam exec` to use the application's PHP runtime instead of an incompatible host PHP.

Validation: real VS Code extension-host test with Intelephense 1.18.5 resolved Component to the SDK, resolved inherited emit(), and returned PHP hover for a `.pam` component. TextMate tokenization checked PHP keywords, native tags, interpolation, CSS properties and hex colors. JavaScript syntax checks passed. Includes a reusable sample-workspace integration test and setup documentation. No claim of universal PHP feature coverage or Marketplace publication.
