### PR TITLE
Align source versions with PAM Native 1.0.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.17 - 2026-09-04
+
+- Add exact project-relative `.pamignore` exclusions for mobile bundles.
+- Restore PHP language tooling and embedded template/CSS highlighting for PAM components in VS Code.
+- Publish editor package 0.1.1 with PHP definition/hover regression coverage.
+
+
 ## 1.0.16 - 2026-08-26
 
 - Passes the short immutable release tag to every reusable certification

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.16"
+version = "1.0.17"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.16"
+version = "1.0.17"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "pam-native",
     "displayName": "PAM Native",
     "description": "Language support for PAM Native components.",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "pushin",
     "engines": {
         "vscode": "^1.95.0"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.16';
+    public const string SDK_VERSION = '1.0.17';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.16',
-    'The runtime SDK contract must match the stable 1.0.16 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.17',
+    'The runtime SDK contract must match the stable 1.0.17 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Aligns the source version markers with the published PAM Native 1.0.17 release and editor 0.1.1. The release includes PHP-aware editor support and project bundle exclusions through `.pamignore`.

Validation: release run 33933603337 passed all platform, ecosystem, accessibility and clean-starter gates; Composer publication run 33936032903 passed. Local release preparation passed 115 Rust tests and PHP/editor checks. The CLI release checksum was verified and the consuming app passed 21 tests after the published SDK update.
