### PR TITLE
release: prepare PAM Native 1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.18 - 2026-09-05
+
+- Measure variable fonts using their requested weight and update automatic layout when weight or accessibility scale changes.
+- Preserve exact Android font weights and fractional glyph advances to prevent text clipping.
+- Load packaged iOS font assets with their requested OpenType weight through CoreText.
+- Measure wrapped row children against their allocated width so text height grows with its lines.
+
 ## 1.0.17 - 2026-09-04
 
 - Add exact project-relative `.pamignore` exclusions for mobile bundles.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.17"
+version = "1.0.18"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.17"
+version = "1.0.18"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.17';
+    public const string SDK_VERSION = '1.0.18';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6309,8 +6309,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.17',
-    'The runtime SDK contract must match the stable 1.0.17 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.18',
+    'The runtime SDK contract must match the stable 1.0.18 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Prepare PAM Native 1.0.18 with the font measurement and wrapped-row fixes merged in #111. Update workspace/SDK versions and changelog; external dependencies remain unchanged.

The fix passed Rust/PHP, Android and iOS CI before merge. The 69 engine tests passed again after the version bump. The release tag will trigger the existing full certification and artifact publication workflow.
