### PR TITLE
fix: recover from notification permission failures

### DIFF
--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -196,6 +196,17 @@ IncomingShares::listen($openComposer);
 `BackgroundTasks::end()`.
 
 `Notifications` requests permission and schedules/cancels local notifications.
+Permission denial reaches the normal callback with `false`. Unexpected native
+failures can be handled separately without invoking the global error handler:
+
+```php
+Notifications::requestPermission(
+    fn (bool $granted) => $this->onPermissionDecision($granted),
+    failure: fn (string $message) => $this->onPermissionFailure($message),
+);
+```
+
+The failure callback is optional; omitting it preserves existing error reporting.
 On Android, place the Firebase client file at
 `.pam/google-services.json` (preferred) or `google-services.json` in the PAM
 project root. The generated host then enables Firebase Messaging,

--- a/packages/native/src/System/Notifications.php
+++ b/packages/native/src/System/Notifications.php
@@ -18,12 +18,15 @@ final class Notifications
     {
     }
 
-    /** @param Closure(bool): void $callback */
-    public static function requestPermission(Closure $callback): int
+    /**
+     * @param Closure(bool): void $callback
+     * @param Closure(string): void|null $failure
+     */
+    public static function requestPermission(Closure $callback, ?Closure $failure = null): int
     {
         return self::call('requestPermission', [], static function (array $values) use ($callback): void {
             $callback((bool) ($values['granted'] ?? false));
-        });
+        }, $failure);
     }
 
     public static function schedule(
@@ -73,14 +76,18 @@ final class Notifications
         );
     }
 
-    private static function call(string $method, array $payload, Closure $callback): int
+    private static function call(string $method, array $payload, Closure $callback, ?Closure $failure = null): int
     {
         return NativeModules::call(
             'notifications',
             $method,
             $payload,
-            static function ($result) use ($callback): void {
+            static function ($result) use ($callback, $failure): void {
                 if ($result->status === ModuleResultStatus::Failure) {
+                    if ($failure !== null) {
+                        $failure($result->payload);
+                        return;
+                    }
                     throw new RuntimeException($result->payload);
                 }
                 $callback($result->payload === '' ? [] : Wire::decodeMap($result->payload));

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -3235,6 +3235,30 @@ $assert(
     'Location failures must reach the optional failure callback.',
 );
 
+foreach ([true, false] as $notificationGranted) {
+    $notificationDecision = null;
+    $permissionRequest = \Pam\Native\System\Notifications::requestPermission(
+        static function (bool $granted) use (&$notificationDecision): void { $notificationDecision = $granted; },
+        failure: static function (string $message): void { throw new RuntimeException('A permission decision is not a failure.'); },
+    );
+    Runtime::dispatchModuleResult($permissionRequest, ModuleResultStatus::Success->value, Wire::map(['granted' => $notificationGranted]));
+    $assert($notificationDecision === $notificationGranted, 'Notification permission must preserve granted and denied decisions.');
+}
+$notificationFailure = null;
+$permissionRequest = \Pam\Native\System\Notifications::requestPermission(
+    static function (bool $granted): void { throw new RuntimeException('Native failure must not invoke permission success.'); },
+    failure: static function (string $message) use (&$notificationFailure): void { $notificationFailure = $message; },
+);
+Runtime::dispatchModuleResult($permissionRequest, ModuleResultStatus::Failure->value, 'No foreground activity.');
+$assert($notificationFailure === 'No foreground activity.', 'Notification permission failure must reach the optional callback.');
+$permissionRequest = \Pam\Native\System\Notifications::requestPermission(static function (bool $granted): void {});
+$permissionErrorsBefore = count(TestDiagnostics::$messages);
+Runtime::dispatchModuleResult($permissionRequest, ModuleResultStatus::Failure->value, 'Permission module failed.');
+$assert(count(TestDiagnostics::$messages) === $permissionErrorsBefore + 1
+    && str_contains(TestDiagnostics::$messages[array_key_last(TestDiagnostics::$messages)], 'Permission module failed.'),
+    'Omitting the permission failure callback must preserve legacy error reporting.');
+array_pop(TestDiagnostics::$messages);
+
 $pushRegistrationFailure = null;
 $pushRegistrationRequest = PushNotifications::register(
     static function (): void {


### PR DESCRIPTION
Unexpected native failures in notification permission requests currently reach the global runtime error handler. Add an optional failure callback so apps can display a recoverable error, while permission denial remains a normal `false` decision and existing callers retain their error reporting.

Validated with the full PHP SDK test runner (`pam exec packages/native/tests/run.php`), covering granted/denied decisions, failure callbacks, and legacy reporting. Documents the callback alongside notification setup. No Android/iOS host code or dependencies change.
