### PR TITLE
release: prepare PAM Native 1.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.19 - 2026-09-06
+
+- Allow applications to recover from native notification permission failures through an optional failure callback.
+- Preserve the existing permission granted/denied callbacks and global error reporting when no failure callback is supplied.
+
 ## 1.0.18 - 2026-09-05
 
 - Measure variable fonts using their requested weight and update automatic layout when weight or accessibility scale changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.18"
+version = "1.0.19"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.18"
+version = "1.0.19"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.18';
+    public const string SDK_VERSION = '1.0.19';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6333,8 +6333,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.18',
-    'The runtime SDK contract must match the stable 1.0.18 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.19',
+    'The runtime SDK contract must match the stable 1.0.19 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Applications can handle unexpected notification permission failures through the optional callback added in #113. This release aligns the PHP SDK and Rust workspace versions at 1.0.19 and documents the backwards-compatible behavior.

Validation: PHP SDK tests, protocol parity, locked offline Cargo metadata and git diff checks passed. No third-party dependency versions changed. Release artifacts must pass the official publication workflow before installation in Linkinpay.
