### PR TITLE
build(editor): package reproducible VSIX with standard Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           python3 -m json.tool packages/native/resources/pam-native-ui-ir.schema.json >/dev/null
           node --check editors/vscode/extension.js
           node editors/vscode/test.js
+          python3 editors/vscode/test_package.py
       - name: Remove regenerable build artifacts
         if: always()
         run: scripts/cleanup-build-artifacts.sh

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -45,3 +45,8 @@ the distributed extension. A SHA-256 sidecar accompanies the VSIX. Entries have
 fixed ordering, timestamps and permissions, producing identical archives when
 built with the same Python/zlib toolchain. Release automation may upload both
 files; this command does not publish to GitHub or the VS Code Marketplace.
+
+CI runs `python3 editors/vscode/test_package.py` to check deterministic output,
+checksums, XML metadata, bundled runtime/grammar paths, license inclusion and
+exclusion of development files. A VS Code installation smoke check remains a
+separate release validation.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -28,3 +28,20 @@ with this directory as `--extensionDevelopmentPath`, the test file as
 `--extensionTestsPath`, and the sample app as the workspace. Intelephense must be
 installed. It checks PHP language identity, SDK class definition, inherited method
 definition and PHP hover. The test does not claim universal PHP language coverage.
+
+## Build an installable extension
+
+From the SDK checkout, run:
+
+```sh
+python3 editors/vscode/package.py --output /tmp/pam-vscode-dist
+code --install-extension /tmp/pam-vscode-dist/pam-native-vscode-0.1.1.vsix
+```
+
+The filename follows the version in `package.json`. The build uses Python's standard
+library and does not install npm dependencies. It includes only the extension
+runtime, grammar, manifest, README and SDK license; development tests stay outside
+the distributed extension. A SHA-256 sidecar accompanies the VSIX. Entries have
+fixed ordering, timestamps and permissions, producing identical archives when
+built with the same Python/zlib toolchain. Release automation may upload both
+files; this command does not publish to GitHub or the VS Code Marketplace.

--- a/editors/vscode/package.py
+++ b/editors/vscode/package.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Build a deterministic VSIX from tracked extension sources, without npm installs."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from xml.sax.saxutils import escape
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+
+
+def package(output: Path) -> Path:
+    root = Path(__file__).resolve().parent
+    metadata = json.loads((root / 'package.json').read_text())
+    version = metadata['version']
+    fields = {key: escape(metadata[key], {'"': '&quot;'})
+              for key in ('name', 'version', 'publisher', 'displayName', 'description')}
+    engine = escape(metadata['engines']['vscode'], {'"': '&quot;'})
+    extension_pack = escape(','.join(metadata.get('extensionPack', [])), {'"': '&quot;'})
+    manifest = f'''<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
+<Metadata><Identity Language="en-US" Id="{fields['name']}" Version="{fields['version']}" Publisher="{fields['publisher']}"/>
+<DisplayName>{fields['displayName']}</DisplayName><Description xml:space="preserve">{fields['description']}</Description>
+<Categories>Programming Languages,Formatters</Categories><Properties>
+<Property Id="Microsoft.VisualStudio.Code.Engine" Value="{engine}"/>
+<Property Id="Microsoft.VisualStudio.Code.ExtensionPack" Value="{extension_pack}"/>
+</Properties></Metadata><Installation><InstallationTarget Id="Microsoft.VisualStudio.Code"/></Installation>
+<Dependencies/><Assets><Asset Type="Microsoft.VisualStudio.Code.Manifest" Path="extension/package.json" Addressable="true"/></Assets>
+</PackageManifest>'''
+    content_types = '''<?xml version="1.0" encoding="utf-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="json" ContentType="application/json"/><Default Extension="js" ContentType="application/javascript"/>
+<Default Extension="md" ContentType="text/markdown"/><Default Extension="vsixmanifest" ContentType="text/xml"/>
+<Default Extension="txt" ContentType="text/plain"/></Types>'''
+    entries = {'extension.vsixmanifest': manifest.encode(), '[Content_Types].xml': content_types.encode(),
+               'extension/LICENSE.txt': (root.parent.parent / 'LICENSE').read_bytes()}
+    for name in ('package.json', 'extension.js', 'language-configuration.json', 'README.md',
+                 'syntaxes/pam.tmLanguage.json', 'syntaxes/pam-php.injection.json'):
+        entries['extension/' + name] = (root / name).read_bytes()
+    output.mkdir(parents=True, exist_ok=True)
+    target = output / f'pam-native-vscode-{version}.vsix'
+    with ZipFile(target, 'w', compression=ZIP_DEFLATED, compresslevel=9) as archive:
+        for name, data in sorted(entries.items()):
+            info = ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = ZIP_DEFLATED
+            info.create_system = 3
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, data, compresslevel=9)
+    digest = hashlib.sha256(target.read_bytes()).hexdigest()
+    target.with_suffix('.vsix.sha256').write_text(f'{digest}  {target.name}\n')
+    return target
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    print(package(parser.parse_args().output))

--- a/editors/vscode/test_package.py
+++ b/editors/vscode/test_package.py
@@ -1,0 +1,41 @@
+"""Distribution contract for the VS Code extension archive."""
+import hashlib
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from xml.etree import ElementTree
+from zipfile import ZipFile
+
+from package import package
+
+
+class PackageTest(unittest.TestCase):
+    def test_installable_archive_is_deterministic_and_self_contained(self):
+        with TemporaryDirectory() as directory:
+            first = package(Path(directory) / 'first')
+            second = package(Path(directory) / 'second')
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+            self.assertEqual(first.with_suffix('.vsix.sha256').read_text(),
+                             hashlib.sha256(first.read_bytes()).hexdigest() + '  ' + first.name + '\n')
+            with ZipFile(first) as archive:
+                self.assertIsNone(archive.testzip())
+                metadata = json.loads(archive.read('extension/package.json'))
+                manifest = ElementTree.fromstring(archive.read('extension.vsixmanifest'))
+                namespace = {'v': 'http://schemas.microsoft.com/developer/vsx-schema/2011'}
+                identity = manifest.find('v:Metadata/v:Identity', namespace)
+                self.assertEqual(identity.get('Version'), metadata['version'])
+                self.assertEqual(identity.get('Publisher'), metadata['publisher'])
+                self.assertEqual(identity.get('Id'), metadata['name'])
+                for asset in manifest.findall('v:Assets/v:Asset', namespace):
+                    self.assertIn(asset.get('Path'), archive.namelist())
+                self.assertIn('extension/' + metadata['main'].removeprefix('./'), archive.namelist())
+                for grammar in metadata['contributes']['grammars']:
+                    self.assertIn('extension/' + grammar['path'].removeprefix('./'), archive.namelist())
+                self.assertIn('Apache License', archive.read('extension/LICENSE.txt').decode())
+                self.assertFalse(any('test' in name or name.endswith('.py') for name in archive.namelist()))
+                ElementTree.fromstring(archive.read('[Content_Types].xml'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The VS Code extension has no checked-in way to produce an installable VSIX. Add a Python standard-library packager that reads extension identity/version, includes runtime files and the SDK license, excludes development tests, and emits a SHA-256 sidecar. Fixed ZIP metadata and ordering make repeated builds identical under the same toolchain.

Validation: two archives compared byte-for-byte; ZIP integrity and manifest XML parsed; license and excluded tests checked; VS Code 1.136.1 accepted the generated VSIX in an isolated extensions directory. Existing node syntax and extension tests passed before packaging. This does not change runtime behavior, install dependencies, or publish to Marketplace. Release workflow integration remains separate.