### PR TITLE
fix(ios): refuse HTTP redirects consistently with Android

### DIFF
--- a/ios/Sources/PamNative/Modules/HttpModule.swift
+++ b/ios/Sources/PamNative/Modules/HttpModule.swift
@@ -10,7 +10,7 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
     }
 
     init(configuration: URLSessionConfiguration) {
-        session = URLSession(configuration: configuration)
+        session = URLSession(configuration: configuration, delegate: HttpRedirectPolicy(), delegateQueue: nil)
     }
 
     public func invoke(method: String, payload: Data, completion: @escaping ModuleCompletion) {
@@ -175,5 +175,18 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
         let canonicalHost = host.contains(":") ? "[\(host)]" : host
         let port = url.port.flatMap { $0 == 443 ? nil : ":\($0)" } ?? ""
         return "\(scheme)://\(canonicalHost)\(port)"
+    }
+}
+
+// Keep HTTP requests bound to the URL chosen by the caller, matching Android.
+private final class HttpRedirectPolicy: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping @Sendable (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
     }
 }

--- a/ios/Tests/PamNativeTests/HttpModuleTests.swift
+++ b/ios/Tests/PamNativeTests/HttpModuleTests.swift
@@ -75,7 +75,7 @@ final class HttpModuleTests: XCTestCase {
             wait(for: [ready], timeout: 5)
             let completed = expectation(description: "Redirect returned without following")
             let payload = try WireMap.encode([
-                "url": .text(server.url),
+                "url": .text(try XCTUnwrap(server.url)),
                 "method": .text("POST"),
                 "headers": .text(#"{"Authorization":"Bearer test-only"}"#),
                 "body": .text("private test payload"),
@@ -184,7 +184,7 @@ private final class RedirectHTTPServer: @unchecked Sendable {
     private var connections: [NWConnection] = []
     private let crossOrigin: Bool
 
-    var url: String { "http://127.0.0.1:\(listener.port!.rawValue)/upload" }
+    var url: String? { listener.port.map { "http://127.0.0.1:\($0.rawValue)/upload" } }
     var requestCount: Int { queue.sync { count } }
 
     init(crossOrigin: Bool, ready: @escaping () -> Void) throws {
@@ -212,9 +212,10 @@ private final class RedirectHTTPServer: @unchecked Sendable {
                 if finished { connection.cancel() } else { self.receive(connection, head: head) }
                 return
             }
+            guard let port = self.listener.port else { connection.cancel(); return }
             self.count += 1
             let host = self.crossOrigin ? "localhost" : "127.0.0.1"
-            let location = "http://\(host):\(self.listener.port!.rawValue)/redirected"
+            let location = "http://\(host):\(port.rawValue)/redirected"
             let response = self.count == 1
                 ? "HTTP/1.1 307 Temporary Redirect\r\nLocation: \(location)\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
                 : "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"

--- a/ios/Tests/PamNativeTests/HttpModuleTests.swift
+++ b/ios/Tests/PamNativeTests/HttpModuleTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Network
 @testable import PamNative
 
 final class HttpModuleTests: XCTestCase {
@@ -66,37 +67,31 @@ final class HttpModuleTests: XCTestCase {
     }
 
     func testRedirectDoesNotForwardHeadersOrBodyToAnotherRequest() throws {
-        for target in ["https://api.example.test/redirected", "https://other.example.test/redirected"] {
-            let configuration = URLSessionConfiguration.ephemeral
-            configuration.protocolClasses = [HTTPURLProtocol.self]
-            let module = HttpModule(configuration: configuration)
+        for crossOrigin in [false, true] {
+            let ready = expectation(description: "Loopback HTTP server ready")
+            let server = try RedirectHTTPServer(crossOrigin: crossOrigin) { ready.fulfill() }
+            let module = HttpModule(configuration: .ephemeral)
+            defer { module.close(); server.stop() }
+            wait(for: [ready], timeout: 5)
             let completed = expectation(description: "Redirect returned without following")
-            var requests = 0
-            HTTPURLProtocol.handler = { request in
-                requests += 1
-                XCTAssertEqual(request.url?.absoluteString, "https://api.example.test/upload")
-                return (
-                    HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 307,
-                                    httpVersion: nil, headerFields: ["Location": target])!,
-                    Data()
-                )
-            }
             let payload = try WireMap.encode([
-                "url": .text("https://api.example.test/upload"),
+                "url": .text(server.url),
                 "method": .text("POST"),
                 "headers": .text(#"{"Authorization":"Bearer test-only"}"#),
                 "body": .text("private test payload"),
             ])
             module.invoke(method: "request", payload: payload) { status, response in
-                XCTAssertEqual(status, .success)
+                defer { completed.fulfill() }
+                guard status == .success else {
+                    XCTFail("HTTP failed: \(String(data: response, encoding: .utf8) ?? "unknown")")
+                    return
+                }
                 do {
                     XCTAssertEqual(try WireMap.decode(response)["statusCode"], .integer(307))
                 } catch { XCTFail("Cannot decode redirect response: \(error)") }
-                completed.fulfill()
             }
-            wait(for: [completed], timeout: 5)
-            XCTAssertEqual(requests, 1)
-            module.close()
+            wait(for: [completed], timeout: 10)
+            XCTAssertEqual(server.requestCount, 1)
         }
     }
 
@@ -171,10 +166,6 @@ private final class HTTPURLProtocol: URLProtocol {
     override func startLoading() {
         do {
             let (response, data) = try XCTUnwrap(Self.handler)(request)
-            if let target = response.value(forHTTPHeaderField: "Location"), let url = URL(string: target) {
-                client?.urlProtocol(self, wasRedirectedTo: URLRequest(url: url), redirectResponse: response)
-                return
-            }
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)
             client?.urlProtocolDidFinishLoading(self)
@@ -184,4 +175,55 @@ private final class HTTPURLProtocol: URLProtocol {
     }
 
     override func stopLoading() {}
+}
+
+private final class RedirectHTTPServer: @unchecked Sendable {
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "pam.test.http.redirect")
+    private var count = 0
+    private var connections: [NWConnection] = []
+    private let crossOrigin: Bool
+
+    var url: String { "http://127.0.0.1:\(listener.port!.rawValue)/upload" }
+    var requestCount: Int { queue.sync { count } }
+
+    init(crossOrigin: Bool, ready: @escaping () -> Void) throws {
+        self.crossOrigin = crossOrigin
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
+        listener = try NWListener(using: parameters)
+        listener.stateUpdateHandler = { state in if case .ready = state { ready() } }
+        listener.newConnectionHandler = { [weak self] connection in
+            guard let self else { connection.cancel(); return }
+            self.connections.append(connection)
+            connection.start(queue: self.queue)
+            self.receive(connection, head: Data())
+        }
+        listener.start(queue: queue)
+    }
+
+    private func receive(_ connection: NWConnection, head: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 16_384) { [weak self] data, _, finished, error in
+            guard let self, let data, error == nil else { connection.cancel(); return }
+            var head = head
+            head.append(data)
+            guard head.count <= 16_384 else { connection.cancel(); return }
+            guard head.range(of: Data("\r\n\r\n".utf8)) != nil else {
+                if finished { connection.cancel() } else { self.receive(connection, head: head) }
+                return
+            }
+            self.count += 1
+            let host = self.crossOrigin ? "localhost" : "127.0.0.1"
+            let location = "http://\(host):\(self.listener.port!.rawValue)/redirected"
+            let response = self.count == 1
+                ? "HTTP/1.1 307 Temporary Redirect\r\nLocation: \(location)\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                : "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in connection.cancel() })
+        }
+    }
+
+    func stop() {
+        listener.cancel()
+        queue.sync { connections.forEach { $0.cancel() }; connections.removeAll() }
+    }
 }

--- a/ios/Tests/PamNativeTests/HttpModuleTests.swift
+++ b/ios/Tests/PamNativeTests/HttpModuleTests.swift
@@ -65,6 +65,41 @@ final class HttpModuleTests: XCTestCase {
         module.close()
     }
 
+    func testRedirectDoesNotForwardHeadersOrBodyToAnotherRequest() throws {
+        for target in ["https://api.example.test/redirected", "https://other.example.test/redirected"] {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [HTTPURLProtocol.self]
+            let module = HttpModule(configuration: configuration)
+            let completed = expectation(description: "Redirect returned without following")
+            var requests = 0
+            HTTPURLProtocol.handler = { request in
+                requests += 1
+                XCTAssertEqual(request.url?.absoluteString, "https://api.example.test/upload")
+                return (
+                    HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 307,
+                                    httpVersion: nil, headerFields: ["Location": target])!,
+                    Data()
+                )
+            }
+            let payload = try WireMap.encode([
+                "url": .text("https://api.example.test/upload"),
+                "method": .text("POST"),
+                "headers": .text(#"{"Authorization":"Bearer test-only"}"#),
+                "body": .text("private test payload"),
+            ])
+            module.invoke(method: "request", payload: payload) { status, response in
+                XCTAssertEqual(status, .success)
+                do {
+                    XCTAssertEqual(try WireMap.decode(response)["statusCode"], .integer(307))
+                } catch { XCTFail("Cannot decode redirect response: \(error)") }
+                completed.fulfill()
+            }
+            wait(for: [completed], timeout: 5)
+            XCTAssertEqual(requests, 1)
+            module.close()
+        }
+    }
+
     func testRejectsGenericAndCrossOriginTraceHeaders() throws {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [HTTPURLProtocol.self]
@@ -136,6 +171,10 @@ private final class HTTPURLProtocol: URLProtocol {
     override func startLoading() {
         do {
             let (response, data) = try XCTUnwrap(Self.handler)(request)
+            if let target = response.value(forHTTPHeaderField: "Location"), let url = URL(string: target) {
+                client?.urlProtocol(self, wasRedirectedTo: URLRequest(url: url), redirectResponse: response)
+                return
+            }
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)
             client?.urlProtocolDidFinishLoading(self)


### PR DESCRIPTION
The iOS HTTP module creates a URLSession without a redirect delegate, so it can follow a redirect after validating only the original URL and trace origin. Android already disables redirects.

Attach a task delegate that refuses redirects and lets the caller handle the original HTTP status. Add URLProtocol-backed coverage for same-origin and cross-origin307 responses with a POST body and authorization header, checking that no second request is issued.

Validation pending: Swift/UIKit CI compilation and execution. Local diff whitespace check passed. No native app/vendor edits or release/install. This applies to the normal HTTP session; it does not change the separate background-transfer library or add file streaming.