### PR TITLE
feat(http): stream private file uploads without PHP body buffering

### DIFF
--- a/android/app/src/androidTest/java/dev/pam/nativeapp/modules/HttpUploadInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/modules/HttpUploadInstrumentedTest.kt
@@ -20,6 +20,66 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class HttpUploadInstrumentedTest {
+    @Test fun closingModuleInterruptsUploadAndCleansSnapshot() = assertInterruptedUpload(timeout = false)
+
+    @Test fun deadlineInterruptsUnresponsiveServerAndCleansSnapshot() = assertInterruptedUpload(timeout = true)
+
+    private fun assertInterruptedUpload(timeout: Boolean) {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val directory = File(context.cacheDir, "http-upload-stop-${UUID.randomUUID()}").apply { mkdirs() }
+        val root = File(directory, "files").apply { mkdir() }
+        val cache = File(directory, "snapshots").apply { mkdir() }
+        val source = File(root, "document.bin").apply { writeBytes(ByteArray(65_536) { 42 }) }
+        val module = HttpModule(root, cache)
+        val releaseServer = CountDownLatch(1)
+        try {
+            ServerSocket(0, 1, InetAddress.getByName("127.0.0.1")).use { server ->
+                server.soTimeout = 5_000
+                val received = CountDownLatch(1)
+                val failure = AtomicReference<Throwable?>()
+                val serving = thread(name = "pam-http-stalled-upload-test") {
+                    try {
+                        server.accept().use { socket ->
+                            socket.soTimeout = 5_000
+                            val input = socket.getInputStream()
+                            assertEquals("PUT /upload HTTP/1.1", line(input))
+                            while (line(input).isNotEmpty()) { /* Consume headers. */ }
+                            var remaining = source.length()
+                            val buffer = ByteArray(8_192)
+                            while (remaining > 0) {
+                                val count = input.read(buffer, 0, minOf(buffer.size.toLong(), remaining).toInt())
+                                require(count > 0) { "Upload ended early" }
+                                remaining -= count
+                            }
+                            received.countDown()
+                            releaseServer.await(10, TimeUnit.SECONDS)
+                        }
+                    } catch (error: Throwable) { failure.set(error) }
+                }
+                try {
+                    val completed = CountDownLatch(1)
+                    val result = AtomicReference<ModuleResultStatus?>()
+                    module.invoke("upload", WireMap.encode(mapOf(
+                        "url" to WireValue.Text("http://127.0.0.1:${server.localPort}/upload"),
+                        "path" to WireValue.Text(source.name),
+                        "timeoutMs" to WireValue.Integer(if (timeout) 1_000L else 15_000L),
+                    ))) { status, _ -> result.set(status); completed.countDown() }
+                    assertTrue("Server did not receive upload", received.await(5, TimeUnit.SECONDS))
+                    if (!timeout) module.close()
+                    assertTrue("Interrupted upload did not complete", completed.await(5, TimeUnit.SECONDS))
+                    assertEquals(ModuleResultStatus.FAILURE, result.get())
+                    assertTrue("Snapshot leaked", cache.listFiles().isNullOrEmpty())
+                    assertTrue(source.isFile)
+                } finally {
+                    releaseServer.countDown()
+                    serving.join(5_000)
+                }
+                assertFalse("Server did not stop", serving.isAlive)
+                assertNull(failure.get())
+            }
+        } finally { releaseServer.countDown(); module.close(); directory.deleteRecursively() }
+    }
+
     @Test fun streamsBinaryFileBeyondPhpBodyLimitAndCleansSnapshot() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val directory = File(context.cacheDir, "http-upload-test-${UUID.randomUUID()}").apply { mkdirs() }

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/modules/HttpUploadInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/modules/HttpUploadInstrumentedTest.kt
@@ -1,0 +1,103 @@
+package dev.pam.nativeapp.modules
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.pam.nativeapp.protocol.WireMap
+import dev.pam.nativeapp.protocol.WireValue
+import java.io.File
+import java.io.InputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.security.MessageDigest
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HttpUploadInstrumentedTest {
+    @Test fun streamsBinaryFileBeyondPhpBodyLimitAndCleansSnapshot() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val directory = File(context.cacheDir, "http-upload-test-${UUID.randomUUID()}").apply { mkdirs() }
+        val root = File(directory, "files").apply { mkdir() }
+        val cache = File(directory, "snapshots").apply { mkdir() }
+        val source = File(root, "binary.dat")
+        val block = ByteArray(64 * 1024) { (it % 251).toByte() }
+        val expectedHash = MessageDigest.getInstance("SHA-256")
+        source.outputStream().use { output -> repeat(32) { output.write(block); expectedHash.update(block) } }
+        val length = source.length()
+        val module = HttpModule(root, cache)
+        try {
+            ServerSocket(0, 1, InetAddress.getByName("127.0.0.1")).use { server ->
+                server.soTimeout = 10_000
+                val failure = AtomicReference<Throwable?>()
+                val receivedHash = AtomicReference<ByteArray?>()
+                val serving = thread(name = "pam-http-upload-test") {
+                    try {
+                        server.accept().use { socket ->
+                            socket.soTimeout = 10_000
+                            val input = socket.getInputStream()
+                            assertEquals("PUT /upload HTTP/1.1", line(input))
+                            val headers = mutableMapOf<String, String>()
+                            while (true) {
+                                val line = line(input)
+                                if (line.isEmpty()) break
+                                val split = line.indexOf(':')
+                                require(split > 0)
+                                headers[line.substring(0, split).lowercase()] = line.substring(split + 1).trim()
+                            }
+                            assertEquals(length.toString(), headers["content-length"])
+                            assertEquals("application/octet-stream", headers["content-type"])
+                            assertNull(headers["transfer-encoding"])
+                            // The network must keep using the private snapshot after source replacement.
+                            source.writeText("changed after upload started")
+                            var remaining = length
+                            val digest = MessageDigest.getInstance("SHA-256")
+                            val buffer = ByteArray(64 * 1024)
+                            while (remaining > 0) {
+                                val count = input.read(buffer, 0, minOf(buffer.size.toLong(), remaining).toInt())
+                                require(count > 0) { "Upload ended early" }
+                                digest.update(buffer, 0, count)
+                                remaining -= count
+                            }
+                            receivedHash.set(digest.digest())
+                            socket.getOutputStream().write("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".toByteArray())
+                        }
+                    } catch (error: Throwable) { failure.set(error) }
+                }
+                val completed = CountDownLatch(1)
+                var result: ModuleResultStatus? = null
+                var payload = ByteArray(0)
+                module.invoke("upload", WireMap.encode(mapOf(
+                    "url" to WireValue.Text("http://127.0.0.1:${server.localPort}/upload"),
+                    "path" to WireValue.Text(source.name),
+                    "headers" to WireValue.Text("""{"Content-Type":"application/octet-stream"}"""),
+                    "timeoutMs" to WireValue.Integer(15_000),
+                ))) { status, response -> result = status; payload = response; completed.countDown() }
+                assertTrue("Upload timed out", completed.await(20, TimeUnit.SECONDS))
+                serving.join(5_000)
+                assertFalse("Server did not stop", serving.isAlive)
+                assertNull(failure.get())
+                assertEquals(ModuleResultStatus.SUCCESS, result)
+                assertEquals(WireValue.Integer(204), WireMap.decode(payload)["statusCode"])
+                assertArrayEquals(expectedHash.digest(), receivedHash.get())
+                assertTrue("Snapshot leaked", cache.listFiles().isNullOrEmpty())
+                assertEquals("changed after upload started", source.readText())
+            }
+        } finally { module.close(); directory.deleteRecursively() }
+    }
+
+    private fun line(input: InputStream): String {
+        val bytes = java.io.ByteArrayOutputStream()
+        while (true) {
+            val value = input.read()
+            require(value >= 0 && bytes.size() < 16_384) { "Incomplete or oversized HTTP header" }
+            if (value == 10) return bytes.toString("US-ASCII").removeSuffix("\r")
+            bytes.write(value)
+        }
+    }
+}

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/modules/HttpUploadInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/modules/HttpUploadInstrumentedTest.kt
@@ -80,7 +80,11 @@ class HttpUploadInstrumentedTest {
         } finally { releaseServer.countDown(); module.close(); directory.deleteRecursively() }
     }
 
-    @Test fun streamsBinaryFileBeyondPhpBodyLimitAndCleansSnapshot() {
+    @Test fun streamsBinaryFileBeyondPhpBodyLimitAndCleansSnapshot() = assertStreamedUpload(expectedStatus = 204)
+
+    @Test fun doesNotForwardFileUploadToRedirectLocation() = assertStreamedUpload(expectedStatus = 307)
+
+    private fun assertStreamedUpload(expectedStatus: Int) {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val directory = File(context.cacheDir, "http-upload-test-${UUID.randomUUID()}").apply { mkdirs() }
         val root = File(directory, "files").apply { mkdir() }
@@ -125,7 +129,9 @@ class HttpUploadInstrumentedTest {
                                 remaining -= count
                             }
                             receivedHash.set(digest.digest())
-                            socket.getOutputStream().write("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".toByteArray())
+                            val statusLine = if (expectedStatus == 307) "307 Temporary Redirect" else "204 No Content"
+                            val redirect = if (expectedStatus == 307) "Location: http://127.0.0.1:1/must-not-receive-file\r\n" else ""
+                            socket.getOutputStream().write("HTTP/1.1 $statusLine\r\n${redirect}Content-Length: 0\r\nConnection: close\r\n\r\n".toByteArray())
                         }
                     } catch (error: Throwable) { failure.set(error) }
                 }
@@ -143,7 +149,7 @@ class HttpUploadInstrumentedTest {
                 assertFalse("Server did not stop", serving.isAlive)
                 assertNull(failure.get())
                 assertEquals(ModuleResultStatus.SUCCESS, result)
-                assertEquals(WireValue.Integer(204), WireMap.decode(payload)["statusCode"])
+                assertEquals(WireValue.Integer(expectedStatus.toLong()), WireMap.decode(payload)["statusCode"])
                 assertArrayEquals(expectedHash.digest(), receivedHash.get())
                 assertTrue("Snapshot leaked", cache.listFiles().isNullOrEmpty())
                 assertEquals("changed after upload started", source.readText())

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/HttpModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/HttpModule.kt
@@ -3,6 +3,7 @@ package dev.pam.nativeapp.modules
 import dev.pam.nativeapp.BuildConfig
 import dev.pam.nativeapp.protocol.WireMap
 import dev.pam.nativeapp.protocol.WireValue
+import java.io.File
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URL
@@ -10,12 +11,20 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import org.json.JSONObject
 
-internal class HttpModule : NativeModule, AutoCloseable {
+internal class HttpModule(
+    private val filesRoot: File? = null,
+    private val uploadCache: File? = null,
+) : NativeModule, AutoCloseable {
     private val executor: ExecutorService = Executors.newFixedThreadPool(4) { runnable ->
         Thread(runnable, "pam-http").apply { isDaemon = true }
+    }
+    private val uploadDeadlines = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "pam-http-upload-timeout").apply { isDaemon = true }
     }
     private val closed = AtomicBoolean()
     private val connections = ConcurrentHashMap.newKeySet<HttpURLConnection>()
@@ -25,7 +34,7 @@ internal class HttpModule : NativeModule, AutoCloseable {
         payload: ByteArray,
         completion: ModuleCompletion,
     ) {
-        if (method != "get" && method != "request") {
+        if (method !in setOf("get", "request", "upload")) {
             completion.complete(ModuleResultStatus.FAILURE, "Unknown HTTP method".toByteArray())
             return
         }
@@ -41,6 +50,8 @@ internal class HttpModule : NativeModule, AutoCloseable {
                         ?: error("HTTP URL is required")
                     val requestMethod = if (method == "get") {
                         "GET"
+                    } else if (method == "upload") {
+                        "PUT"
                     } else {
                         (values["method"] as? WireValue.Text)?.value
                             ?: error("HTTP method is required")
@@ -52,7 +63,21 @@ internal class HttpModule : NativeModule, AutoCloseable {
                     val timeoutMs = ((values["timeoutMs"] as? WireValue.Integer)?.value ?: 30_000L)
                         .coerceIn(1_000L, 120_000L)
                         .toInt()
-                    fetch(url, requestMethod, headersJson, body, timeoutMs, traceparent, traceOrigin)
+                    val snapshot = if (method == "upload") {
+                        require(body == null) { "File upload cannot include a text body" }
+                        val path = (values["path"] as? WireValue.Text)?.value
+                            ?: error("Upload source path is required")
+                        HttpUploadSnapshot.create(
+                            requireNotNull(filesRoot) { "Private files directory is unavailable" },
+                            requireNotNull(uploadCache) { "Private upload cache is unavailable" },
+                            path,
+                        ) { closed.get() || Thread.currentThread().isInterrupted }
+                    } else null
+                    try {
+                        fetch(url, requestMethod, headersJson, body, timeoutMs, traceparent, traceOrigin, snapshot?.file)
+                    } finally {
+                        snapshot?.close()
+                    }
                 }.fold(
                     onSuccess = { completion.complete(ModuleResultStatus.SUCCESS, it) },
                     onFailure = {
@@ -72,6 +97,7 @@ internal class HttpModule : NativeModule, AutoCloseable {
         if (!closed.compareAndSet(false, true)) return
         connections.toList().forEach(HttpURLConnection::disconnect)
         connections.clear()
+        uploadDeadlines.shutdownNow()
         executor.shutdownNow()
     }
 
@@ -83,6 +109,7 @@ internal class HttpModule : NativeModule, AutoCloseable {
         timeoutMs: Int,
         traceparent: String?,
         traceOrigin: String?,
+        bodyFile: File?,
     ): ByteArray {
         val uri = URI(source)
         require(uri.scheme == "https" || (BuildConfig.DEBUG && uri.scheme == "http")) {
@@ -91,46 +118,65 @@ internal class HttpModule : NativeModule, AutoCloseable {
         require(uri.userInfo == null && uri.host != null) { "Invalid HTTP URL" }
         val connection = URL(source).openConnection() as HttpURLConnection
         connections += connection
-        if (closed.get()) {
-            connections -= connection
-            connection.disconnect()
-            error("HTTP module is closed")
-        }
-        require(requestMethod in ALLOWED_METHODS) { "Unsupported HTTP method $requestMethod" }
-        require(body == null || body.toByteArray(Charsets.UTF_8).size <= MAX_REQUEST_BYTES) {
-            "HTTP request body exceeds one MiB"
-        }
-        connection.requestMethod = requestMethod
-        connection.connectTimeout = 10_000
-        connection.readTimeout = timeoutMs
-        connection.instanceFollowRedirects = false
-        connection.setRequestProperty("Accept", "application/json, text/plain, */*")
-        val headers = JSONObject(headersJson)
-        require(headers.length() <= 32) { "HTTP requests support at most 32 headers" }
-        headers.keys().forEach { name ->
-            val value = headers.getString(name)
-            require(SAFE_HEADER_NAME.matches(name) && !value.contains('\r') && !value.contains('\n')) {
-                "Invalid HTTP header"
-            }
-            require(value.toByteArray(Charsets.UTF_8).size <= 8_192) { "HTTP header value is too large" }
-            require(name.lowercase() !in RESERVED_TRACE_HEADERS) {
-                "Trace headers require an origin-scoped context"
-            }
-            connection.setRequestProperty(name, value)
-        }
-        if (traceparent != null || traceOrigin != null) {
-            require(traceparent != null && traceOrigin != null) { "Incomplete HTTP trace context" }
-            require(TRACEPARENT.matches(traceparent)) { "Invalid W3C version 00 traceparent" }
-            require(origin(uri) == traceOrigin && traceOrigin.startsWith("https://")) {
-                "Trace context origin does not match the HTTP request origin"
-            }
-            connection.setRequestProperty("traceparent", traceparent)
-        }
-        if (body != null) {
-            connection.doOutput = true
-            connection.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
-        }
+        var deadline: ScheduledFuture<*>? = null
+        val timedOut = AtomicBoolean()
         try {
+            if (bodyFile != null) {
+                deadline = uploadDeadlines.schedule({ timedOut.set(true); connection.disconnect() }, timeoutMs.toLong(), TimeUnit.MILLISECONDS)
+            }
+            check(!closed.get()) { "HTTP module is closed" }
+            require(requestMethod in ALLOWED_METHODS) { "Unsupported HTTP method $requestMethod" }
+            require(body == null || body.toByteArray(Charsets.UTF_8).size <= MAX_REQUEST_BYTES) {
+                "HTTP request body exceeds one MiB"
+            }
+            connection.requestMethod = requestMethod
+            connection.connectTimeout = if (bodyFile != null) minOf(10_000, timeoutMs) else 10_000
+            connection.readTimeout = timeoutMs
+            connection.instanceFollowRedirects = false
+            connection.setRequestProperty("Accept", "application/json, text/plain, */*")
+            val headers = JSONObject(headersJson)
+            require(headers.length() <= 32) { "HTTP requests support at most 32 headers" }
+            headers.keys().forEach { name ->
+                val value = headers.getString(name)
+                require(SAFE_HEADER_NAME.matches(name) && !value.contains('\r') && !value.contains('\n')) {
+                    "Invalid HTTP header"
+                }
+                require(value.toByteArray(Charsets.UTF_8).size <= 8_192) { "HTTP header value is too large" }
+                require(name.lowercase() !in RESERVED_TRACE_HEADERS) {
+                    "Trace headers require an origin-scoped context"
+                }
+                require(bodyFile == null || name.lowercase() !in FILE_TRANSPORT_HEADERS) {
+                    "File upload headers cannot override HTTP transport fields"
+                }
+                connection.setRequestProperty(name, value)
+            }
+            if (traceparent != null || traceOrigin != null) {
+                require(traceparent != null && traceOrigin != null) { "Incomplete HTTP trace context" }
+                require(TRACEPARENT.matches(traceparent)) { "Invalid W3C version 00 traceparent" }
+                require(origin(uri) == traceOrigin && traceOrigin.startsWith("https://")) {
+                    "Trace context origin does not match the HTTP request origin"
+                }
+                connection.setRequestProperty("traceparent", traceparent)
+            }
+            if (bodyFile != null) {
+                connection.doOutput = true
+                connection.setFixedLengthStreamingMode(bodyFile.length())
+                bodyFile.inputStream().use { input ->
+                    connection.outputStream.use { output ->
+                        val buffer = ByteArray(64 * 1024)
+                        while (true) {
+                            check(!closed.get() && !timedOut.get() && !Thread.currentThread().isInterrupted) { "HTTP upload cancelled" }
+                            val count = input.read(buffer)
+                            if (count < 0) break
+                            output.write(buffer, 0, count)
+                        }
+                    }
+                }
+            } else if (body != null) {
+                connection.doOutput = true
+                connection.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
+            }
+            check(!timedOut.get()) { "HTTP upload timed out" }
             val status = connection.responseCode
             val input = if (status >= 400) connection.errorStream else connection.inputStream
             val body = input?.use { stream ->
@@ -153,6 +199,7 @@ internal class HttpModule : NativeModule, AutoCloseable {
                 ),
             )
         } finally {
+            deadline?.cancel(false)
             connections -= connection
             connection.disconnect()
         }
@@ -167,6 +214,7 @@ internal class HttpModule : NativeModule, AutoCloseable {
         }
 
         val ALLOWED_METHODS = setOf("GET", "POST", "PUT", "PATCH", "DELETE")
+        val FILE_TRANSPORT_HEADERS = setOf("host", "content-length", "transfer-encoding", "connection", "trailer", "upgrade")
         val RESERVED_TRACE_HEADERS = setOf("traceparent", "tracestate")
         val TRACEPARENT = Regex("^00-(?!0{32})[0-9a-f]{32}-(?!0{16})[0-9a-f]{16}-[0-9a-f]{2}$")
         val SAFE_HEADER_NAME = Regex("^[A-Za-z0-9-]{1,64}$")

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/HttpUploadSnapshot.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/HttpUploadSnapshot.kt
@@ -1,0 +1,54 @@
+package dev.pam.nativeapp.modules
+
+import java.io.File
+import java.io.IOException
+
+/** Stable, bounded file body owned by one HTTP request. */
+internal class HttpUploadSnapshot private constructor(val file: File) : AutoCloseable {
+    override fun close() {
+        if (file.exists() && !file.delete()) throw IOException("Cannot remove HTTP upload snapshot")
+    }
+
+    companion object {
+        const val MAX_BYTES = 64L * 1024 * 1024
+
+        fun create(root: File, cache: File, path: String, cancelled: () -> Boolean = { false }): HttpUploadSnapshot {
+            require(path.isNotBlank() && !File(path).isAbsolute && '\\' !in path && '\u0000' !in path) {
+                "Upload source must be a relative file path"
+            }
+            require(path.split('/').none { it.isEmpty() || it == "." || it == ".." }) {
+                "Invalid upload source path"
+            }
+            val source = File(root, path).canonicalFile
+            require(source.path.startsWith(root.canonicalPath + File.separator) && source.isFile) {
+                "Upload source is outside the private files directory or missing"
+            }
+            val expected = source.length()
+            require(expected <= MAX_BYTES) { "Upload file exceeds 64 MiB" }
+            check(!cancelled()) { "HTTP upload cancelled" }
+            check(cache.isDirectory || cache.mkdirs()) { "Cannot create HTTP upload cache" }
+            val target = File.createTempFile("pam-upload-", ".tmp", cache)
+            try {
+                source.inputStream().use { input ->
+                    target.outputStream().use { output ->
+                        val buffer = ByteArray(64 * 1024)
+                        var copied = 0L
+                        while (true) {
+                            check(!cancelled()) { "HTTP upload cancelled" }
+                            val count = input.read(buffer)
+                            if (count < 0) break
+                            copied += count
+                            require(copied <= expected && copied <= MAX_BYTES) { "Upload source changed during copy" }
+                            output.write(buffer, 0, count)
+                        }
+                        require(copied == expected) { "Upload source changed during copy" }
+                    }
+                }
+                return HttpUploadSnapshot(target)
+            } catch (error: Exception) {
+                target.delete()
+                throw error
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/NativeModuleRegistry.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/NativeModuleRegistry.kt
@@ -5,7 +5,10 @@ import java.util.concurrent.atomic.AtomicLong
 
 class NativeModuleRegistry(context: Context) : AutoCloseable {
     private val generation = AtomicLong(1)
-    private val http = HttpModule()
+    private val http = HttpModule(
+        java.io.File(context.filesDir, "pam-files"),
+        java.io.File(context.cacheDir, "pam-http-uploads"),
+    )
     private val storage = StorageModule(context)
     private val system = SystemModule(context)
     private val sqlite = SQLiteModule(context)

--- a/android/app/src/test/java/dev/pam/nativeapp/modules/HttpUploadSnapshotTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/modules/HttpUploadSnapshotTest.kt
@@ -1,0 +1,54 @@
+package dev.pam.nativeapp.modules
+
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.file.Files
+import org.junit.Assert.*
+import org.junit.Test
+
+class HttpUploadSnapshotTest {
+    @Test fun snapshotIsStableAndRemovedAfterUse() = temporary { root, cache ->
+        val source = File(root, "document.bin").apply { writeBytes(byteArrayOf(0, 1, -1, 3)) }
+        val snapshot = HttpUploadSnapshot.create(root, cache, source.name)
+        source.writeText("changed original")
+        assertArrayEquals(byteArrayOf(0, 1, -1, 3), snapshot.file.readBytes())
+        val path = snapshot.file
+        snapshot.close()
+        snapshot.close()
+        assertFalse(path.exists())
+        assertTrue(source.exists())
+    }
+
+    @Test fun refusesTraversalMissingFilesDirectoriesAndEscapingSymlinks() = temporary { root, cache ->
+        File(root, "directory").mkdir()
+        for (path in listOf("", "../outside", "/absolute", "directory", "missing", "a/../b", "a\\b")) {
+            assertThrows(IllegalArgumentException::class.java) { HttpUploadSnapshot.create(root, cache, path) }
+        }
+        val outside = File(cache.parentFile, "outside").apply { writeText("private") }
+        Files.createSymbolicLink(File(root, "link").toPath(), outside.toPath())
+        assertThrows(IllegalArgumentException::class.java) { HttpUploadSnapshot.create(root, cache, "link") }
+        assertTrue(cache.listFiles().isNullOrEmpty())
+    }
+
+    @Test fun rejectsOversizeBeforeCopyAndCleansAnInterruptedCopy() = temporary { root, cache ->
+        val source = File(root, "large.bin")
+        RandomAccessFile(source, "rw").use { it.setLength(HttpUploadSnapshot.MAX_BYTES + 1) }
+        assertThrows(IllegalArgumentException::class.java) { HttpUploadSnapshot.create(root, cache, source.name) }
+        source.writeBytes(ByteArray(128 * 1024))
+        var checks = 0
+        assertThrows(IllegalStateException::class.java) {
+            HttpUploadSnapshot.create(root, cache, source.name) { ++checks >= 3 }
+        }
+        assertTrue(cache.listFiles().isNullOrEmpty())
+        assertTrue(source.exists())
+    }
+
+    private fun temporary(test: (File, File) -> Unit) {
+        val directory = Files.createTempDirectory("pam-http-snapshot-test").toFile()
+        try {
+            val root = File(directory, "files").apply { mkdir() }
+            val cache = File(directory, "cache").apply { mkdir() }
+            test(root, cache)
+        } finally { directory.deleteRecursively() }
+    }
+}

--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -153,6 +153,52 @@ must provide the standard camera/photo usage descriptions in the application
 `Info.plist`. The direct `MediaLibrary` query is currently Android-only; the
 document picker remains the portable fallback.
 
+## Foreground file uploads
+
+`Http::upload()` sends a private `Files` path as the raw body of an HTTPS
+`PUT`. Pass `FileReference::$path`, not its `pam-file://` URI or an absolute
+device path. This API is available in the source branch; it is not yet part
+of a published SDK release.
+
+```php
+use Pam\Native\Http\Http;
+use Pam\Native\Http\HttpResponse;
+
+Http::upload(
+    url: $signedUploadUrl,
+    path: $file->path,
+    callback: function (HttpResponse $response): void {
+        // Check the expected storage status before confirming with your API.
+    },
+    headers: ['Content-Type' => $file->mimeType],
+);
+```
+
+Native workers first copy the source into a private temporary snapshot, then
+stream that snapshot to the server. File bytes do not pass through PHP or
+the bridge. Sources are limited to 64 MiB; applications should enforce any
+smaller limit required by their API. The source remains available after the
+request, while the snapshot is removed when the request completes or fails.
+Snapshot creation requires temporary disk space approximately equal to the
+file size. Avoid modifying the source until snapshot creation has completed;
+the server should validate a previously agreed checksum when byte identity
+matters.
+
+The default network deadline is 120 seconds, configurable from 1 to 120
+seconds. Queueing and snapshot creation precede this deadline. Redirects are
+returned to the caller without forwarding the upload. Native code supplies
+the content length: `Host`, `Content-Length`, `Transfer-Encoding`,
+`Connection`, `Trailer`, and `Upgrade` cannot be supplied by the application.
+Use only headers required by the upload destination; an API bearer token
+should not be copied to an unrelated storage URL.
+
+Uploads are foreground operations with no automatic retry, progress callback,
+per-request cancellation, or process-restart recovery. Closing the native HTTP
+module interrupts active requests. A timeout does not establish whether the
+server received the file: query the application's upload status before
+retrying or completing a business operation. HTTP response bodies retain the
+normal transport limit of 900 KiB.
+
 ## Incoming shares
 
 Declare only the MIME types the application accepts:

--- a/ios/Sources/PamNative/Modules/HttpModule.swift
+++ b/ios/Sources/PamNative/Modules/HttpModule.swift
@@ -3,13 +3,23 @@ import Foundation
 public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Sendable {
     private let session: URLSession
     private let queue = DispatchQueue(label: "pam.native.http", qos: .userInitiated)
-    private var closed = false
+    private let stateLock = NSLock()
+    private var stopped = false
+    private var closed: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return stopped
+    }
+    private let filesRoot: URL
+    private let uploadCache: URL
 
     public convenience init() {
         self.init(configuration: .default)
     }
 
-    init(configuration: URLSessionConfiguration) {
+    init(configuration: URLSessionConfiguration, filesRoot: URL? = nil, uploadCache: URL? = nil) {
+        self.filesRoot = filesRoot ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0].appendingPathComponent("pam-files")
+        self.uploadCache = uploadCache ?? FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0].appendingPathComponent("pam-http-uploads")
         session = URLSession(configuration: configuration, delegate: HttpRedirectPolicy(), delegateQueue: nil)
     }
 
@@ -19,7 +29,7 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
             return
         }
 
-        if method != "get" && method != "request" {
+        if method != "get" && method != "request" && method != "upload" {
             completion(.failure, "Unknown HTTP method".data(using: .utf8) ?? Data())
             return
         }
@@ -53,6 +63,8 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
                 let requestMethod: String
                 if method == "get" {
                     requestMethod = "GET"
+                } else if method == "upload" {
+                    requestMethod = "PUT"
                 } else {
                     guard case let .text(value)? = values["method"] else {
                         throw RuntimeError("HTTP method is required")
@@ -91,6 +103,9 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
                         guard !Self.reservedTraceHeaders.contains(name.lowercased()) else {
                             throw RuntimeError("Trace headers require an origin-scoped context")
                         }
+                        if method == "upload" && Self.fileTransportHeaders.contains(name.lowercased()) {
+                            throw RuntimeError("File upload headers cannot override HTTP transport fields")
+                        }
                         request.setValue(value, forHTTPHeaderField: name)
                     }
                 }
@@ -116,6 +131,9 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
                     request.setValue(traceparent, forHTTPHeaderField: "traceparent")
                 }
 
+                if method == "upload" && values["body"] != nil {
+                    throw RuntimeError("File upload cannot include a text body")
+                }
                 if case let .text(body)? = values["body"] {
                     guard body.utf8.count <= Self.maxRequestBytes else {
                         throw RuntimeError("HTTP request body exceeds one MiB")
@@ -123,7 +141,18 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
                     request.httpBody = body.data(using: .utf8)
                 }
 
-                let dataTask = self.session.dataTask(with: request) { data, response, error in
+                let snapshot: HttpUploadSnapshot?
+                if method == "upload" {
+                    guard case let .text(path)? = values["path"] else { throw RuntimeError("Upload source path is required") }
+                    snapshot = try HttpUploadSnapshot.create(root: self.filesRoot, cache: self.uploadCache, path: path) { self.closed }
+                } else { snapshot = nil }
+                let deadline = HttpUploadDeadline()
+                let receive: @Sendable (Data?, URLResponse?, Error?) -> Void = { data, response, error in
+                    deadline.cancel()
+                    do { try snapshot?.close() } catch {
+                        completion(.failure, Data("Cannot remove HTTP upload snapshot".utf8))
+                        return
+                    }
                     if let error {
                         completion(.failure, error.localizedDescription.data(using: .utf8) ?? Data())
                         return
@@ -144,7 +173,21 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
                         completion(.failure, "Cannot encode response".data(using: .utf8) ?? Data())
                     }
                 }
-                dataTask.resume()
+                self.stateLock.lock()
+                guard !self.stopped else {
+                    self.stateLock.unlock()
+                    try? snapshot?.close()
+                    throw RuntimeError("HTTP module is closed")
+                }
+                let task: URLSessionTask
+                if let snapshot {
+                    task = self.session.uploadTask(with: request, fromFile: snapshot.url, completionHandler: receive)
+                    deadline.start(task: task, seconds: request.timeoutInterval)
+                } else {
+                    task = self.session.dataTask(with: request, completionHandler: receive)
+                }
+                task.resume()
+                self.stateLock.unlock()
             } catch {
                 completion(.failure, (error.localizedDescription).data(using: .utf8) ?? Data())
             }
@@ -152,7 +195,10 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
     }
 
     public func close() {
-        closed = true
+        stateLock.lock()
+        if stopped { stateLock.unlock(); return }
+        stopped = true
+        stateLock.unlock()
         session.invalidateAndCancel()
     }
 
@@ -163,6 +209,7 @@ public final class HttpModule: NativeModule, ClosableNativeModule, @unchecked Se
     }
 
     private static let allowedMethods = Set(["GET", "POST", "PUT", "PATCH", "DELETE"])
+    private static let fileTransportHeaders = Set(["host", "content-length", "transfer-encoding", "connection", "trailer", "upgrade"])
     private static let reservedTraceHeaders = Set(["traceparent", "tracestate"])
     private static let traceparentPattern = "^00-(?!0{32})[0-9a-f]{32}-(?!0{16})[0-9a-f]{16}-[0-9a-f]{2}$"
     private static let safeHeaderName = "^[A-Za-z0-9-]{1,64}$"
@@ -188,5 +235,25 @@ private final class HttpRedirectPolicy: NSObject, URLSessionTaskDelegate, @unche
         completionHandler: @escaping @Sendable (URLRequest?) -> Void
     ) {
         completionHandler(nil)
+    }
+}
+
+private final class HttpUploadDeadline: @unchecked Sendable {
+    private let lock = NSLock()
+    private var work: DispatchWorkItem?
+
+    func start(task: URLSessionTask, seconds: TimeInterval) {
+        let pending = DispatchWorkItem { [weak task] in task?.cancel() }
+        lock.lock()
+        work = pending
+        lock.unlock()
+        DispatchQueue.global().asyncAfter(deadline: .now() + seconds, execute: pending)
+    }
+
+    func cancel() {
+        lock.lock()
+        work?.cancel()
+        work = nil
+        lock.unlock()
     }
 }

--- a/ios/Sources/PamNative/Modules/HttpUploadSnapshot.swift
+++ b/ios/Sources/PamNative/Modules/HttpUploadSnapshot.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+final class HttpUploadSnapshot: @unchecked Sendable {
+    static let maximumBytes = 64 * 1024 * 1024
+    let url: URL
+
+    private init(url: URL) { self.url = url }
+    deinit { try? close() }
+
+    func close() throws {
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+
+    static func create(root: URL, cache: URL, path: String, cancelled: () -> Bool = { false }) throws -> HttpUploadSnapshot {
+        guard !path.isEmpty, !path.hasPrefix("/"), !path.contains("\\"), !path.contains("\0"),
+              !path.split(separator: "/", omittingEmptySubsequences: false).contains(where: { $0.isEmpty || $0 == "." || $0 == ".." }) else {
+            throw UploadFileError("Upload source must be a relative private file path")
+        }
+        let root = root.standardizedFileURL.resolvingSymlinksInPath()
+        let source = root.appendingPathComponent(path).standardizedFileURL.resolvingSymlinksInPath()
+        guard source.path.hasPrefix(root.path + "/") else { throw UploadFileError("Upload source is outside the private files directory") }
+        let values = try source.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        guard values.isRegularFile == true, let size = values.fileSize, size >= 0, size <= maximumBytes else {
+            throw UploadFileError("Upload source is missing, invalid or exceeds 64 MiB")
+        }
+        guard !cancelled() else { throw UploadFileError("HTTP upload cancelled") }
+        try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true,
+                                                attributes: [.posixPermissions: 0o700])
+        let target = cache.appendingPathComponent("pam-upload-\(UUID().uuidString).tmp")
+        guard FileManager.default.createFile(atPath: target.path, contents: nil, attributes: [.posixPermissions: 0o600]) else {
+            throw UploadFileError("Cannot create HTTP upload snapshot")
+        }
+        do {
+            let input = try FileHandle(forReadingFrom: source)
+            defer { try? input.close() }
+            let output = try FileHandle(forWritingTo: target)
+            defer { try? output.close() }
+            var copied = 0
+            while true {
+                guard !cancelled() else { throw UploadFileError("HTTP upload cancelled") }
+                let bytes = try input.read(upToCount: 64 * 1024) ?? Data()
+                if bytes.isEmpty { break }
+                copied += bytes.count
+                guard copied <= size, copied <= maximumBytes else { throw UploadFileError("Upload source changed during copy") }
+                try output.write(contentsOf: bytes)
+            }
+            guard copied == size else { throw UploadFileError("Upload source changed during copy") }
+            return HttpUploadSnapshot(url: target)
+        } catch {
+            try? FileManager.default.removeItem(at: target)
+            throw error
+        }
+    }
+}
+
+private struct UploadFileError: LocalizedError {
+    let message: String
+    init(_ message: String) { self.message = message }
+    var errorDescription: String? { message }
+}

--- a/ios/Tests/PamNativeTests/HttpUploadSnapshotTests.swift
+++ b/ios/Tests/PamNativeTests/HttpUploadSnapshotTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import PamNative
+
+final class HttpUploadSnapshotTests: XCTestCase {
+    func testSnapshotIsStableAndRemovedAfterClose() throws {
+        try temporary { root, cache in
+            let source = root.appendingPathComponent("document.bin")
+            let bytes = Data([0, 1, 255, 3])
+            try bytes.write(to: source)
+            let snapshot = try HttpUploadSnapshot.create(root: root, cache: cache, path: "document.bin")
+            try Data("changed original".utf8).write(to: source)
+            XCTAssertEqual(try Data(contentsOf: snapshot.url), bytes)
+            try snapshot.close()
+            try snapshot.close()
+            XCTAssertFalse(FileManager.default.fileExists(atPath: snapshot.url.path))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+        }
+    }
+
+    func testRejectsTraversalDirectoryMissingSourceAndEscapingSymlink() throws {
+        try temporary { root, cache in
+            try FileManager.default.createDirectory(at: root.appendingPathComponent("directory"), withIntermediateDirectories: true)
+            let outside = cache.appendingPathComponent("outside")
+            try Data("private".utf8).write(to: outside)
+            try FileManager.default.createSymbolicLink(at: root.appendingPathComponent("link"), withDestinationURL: outside)
+            for path in ["", "/absolute", "../outside", "a/../b", "a\\b", "directory", "missing", "link"] {
+                XCTAssertThrowsError(try HttpUploadSnapshot.create(root: root, cache: cache, path: path))
+            }
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: cache.path), ["outside"])
+        }
+    }
+
+    func testOversizeAndCancellationDoNotLeakSnapshots() throws {
+        try temporary { root, cache in
+            let source = root.appendingPathComponent("large.bin")
+            XCTAssertTrue(FileManager.default.createFile(atPath: source.path, contents: nil))
+            let file = try FileHandle(forWritingTo: source)
+            try file.truncate(atOffset: UInt64(HttpUploadSnapshot.maximumBytes + 1))
+            try file.close()
+            XCTAssertThrowsError(try HttpUploadSnapshot.create(root: root, cache: cache, path: "large.bin"))
+            try Data(repeating: 0, count: 128 * 1024).write(to: source)
+            var checks = 0
+            XCTAssertThrowsError(try HttpUploadSnapshot.create(root: root, cache: cache, path: "large.bin") {
+                checks += 1
+                return checks >= 3
+            })
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: cache.path), [])
+        }
+    }
+
+    private func temporary(_ test: (URL, URL) throws -> Void) throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let root = directory.appendingPathComponent("files")
+        let cache = directory.appendingPathComponent("cache")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try test(root, cache)
+    }
+}

--- a/ios/Tests/PamNativeTests/HttpUploadTests.swift
+++ b/ios/Tests/PamNativeTests/HttpUploadTests.swift
@@ -76,7 +76,12 @@ final class HttpUploadTests: XCTestCase {
                 XCTFail("Upload failed: \(String(data: payload, encoding: .utf8) ?? "unknown")")
                 return
             }
-            XCTAssertEqual(try WireMap.decode(payload)["statusCode"], .integer(expectedStatus))
+            do {
+                let values = try WireMap.decode(payload)
+                XCTAssertEqual(values["statusCode"], .integer(expectedStatus))
+            } catch {
+                XCTFail("Invalid upload response: \(error)")
+            }
         }
         wait(for: [completed], timeout: 20)
         XCTAssertEqual(server.digest, SHA256.hash(data: bytes))

--- a/ios/Tests/PamNativeTests/HttpUploadTests.swift
+++ b/ios/Tests/PamNativeTests/HttpUploadTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+import Network
+import CryptoKit
+@testable import PamNative
+
+final class HttpUploadTests: XCTestCase {
+    func testStreamsTwoMiBFromStableSnapshotAndRemovesTemporaryFile() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let root = directory.appendingPathComponent("files")
+        let cache = directory.appendingPathComponent("snapshots")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = root.appendingPathComponent("document.bin")
+        let bytes = Data((0..<(2 * 1024 * 1024)).map { UInt8($0 % 251) })
+        try bytes.write(to: source)
+        let ready = expectation(description: "Upload server ready")
+        let server = try UploadHTTPServer(length: bytes.count, source: source) { ready.fulfill() }
+        let module = HttpModule(configuration: .ephemeral, filesRoot: root, uploadCache: cache)
+        defer { module.close(); server.stop() }
+        wait(for: [ready], timeout: 5)
+        let completed = expectation(description: "File upload completed")
+        module.invoke(method: "upload", payload: try WireMap.encode([
+            "url": .text(try XCTUnwrap(server.url)), "path": .text("document.bin"),
+            "headers": .text(#"{"Content-Type":"application/octet-stream"}"#),
+            "timeoutMs": .integer(15_000),
+        ])) { status, payload in
+            defer { completed.fulfill() }
+            guard status == .success else {
+                XCTFail("Upload failed: \(String(data: payload, encoding: .utf8) ?? "unknown")")
+                return
+            }
+            do { XCTAssertEqual(try WireMap.decode(payload)["statusCode"], .integer(204)) }
+            catch { XCTFail("Invalid upload response: \(error)") }
+        }
+        wait(for: [completed], timeout: 20)
+        XCTAssertEqual(server.digest, SHA256.hash(data: bytes))
+        XCTAssertEqual(try Data(contentsOf: source), Data("changed original".utf8))
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: cache.path), [])
+    }
+}
+
+private final class UploadHTTPServer: @unchecked Sendable {
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "pam.test.http.upload")
+    private let length: Int
+    private let source: URL
+    private var received = Data()
+    private var headersRead = false
+    private var connections: [NWConnection] = []
+
+    var url: String? { listener.port.map { "http://127.0.0.1:\($0.rawValue)/upload" } }
+    var digest: SHA256.Digest { queue.sync { SHA256.hash(data: received) } }
+
+    init(length: Int, source: URL, ready: @escaping () -> Void) throws {
+        self.length = length
+        self.source = source
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
+        listener = try NWListener(using: parameters)
+        listener.stateUpdateHandler = { state in if case .ready = state { ready() } }
+        listener.newConnectionHandler = { [weak self] connection in
+            guard let self else { connection.cancel(); return }
+            self.connections.append(connection)
+            connection.start(queue: self.queue)
+            self.read(connection)
+        }
+        listener.start(queue: queue)
+    }
+
+    private func read(_ connection: NWConnection) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { [weak self] data, _, finished, error in
+            guard let self, let data, error == nil else { connection.cancel(); return }
+            self.received.append(data)
+            guard self.received.count <= self.length + 16_384 else { connection.cancel(); return }
+            if !self.headersRead {
+                guard let end = self.received.range(of: Data("\r\n\r\n".utf8)) else {
+                    if finished { connection.cancel() } else { self.read(connection) }
+                    return
+                }
+                let head = String(decoding: self.received[..<end.lowerBound], as: UTF8.self)
+                let lines = head.components(separatedBy: "\r\n")
+                XCTAssertEqual(lines.first, "PUT /upload HTTP/1.1")
+                var headers: [String: String] = [:]
+                for line in lines.dropFirst() {
+                    if let colon = line.firstIndex(of: ":") {
+                        headers[line[..<colon].lowercased()] = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+                    }
+                }
+                XCTAssertEqual(headers["content-length"], String(self.length))
+                XCTAssertEqual(headers["content-type"], "application/octet-stream")
+                XCTAssertNil(headers["transfer-encoding"])
+                self.received.removeSubrange(..<end.upperBound)
+                self.headersRead = true
+                do { try Data("changed original".utf8).write(to: self.source) }
+                catch { XCTFail("Could not replace source: \(error)") }
+            }
+            if self.received.count == self.length {
+                let response = Data("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
+                connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
+            } else if finished {
+                connection.cancel()
+            } else { self.read(connection) }
+        }
+    }
+
+    func stop() {
+        listener.cancel()
+        queue.sync { connections.forEach { $0.cancel() }; connections.removeAll() }
+    }
+}

--- a/ios/Tests/PamNativeTests/HttpUploadTests.swift
+++ b/ios/Tests/PamNativeTests/HttpUploadTests.swift
@@ -44,6 +44,14 @@ final class HttpUploadTests: XCTestCase {
     }
 
     func testStreamsTwoMiBFromStableSnapshotAndRemovesTemporaryFile() throws {
+        try assertStreamedUpload(status: 204)
+    }
+
+    func testDoesNotForwardFileUploadToRedirectLocation() throws {
+        try assertStreamedUpload(status: 307)
+    }
+
+    private func assertStreamedUpload(status expectedStatus: Int64) throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let root = directory.appendingPathComponent("files")
         let cache = directory.appendingPathComponent("snapshots")
@@ -53,7 +61,7 @@ final class HttpUploadTests: XCTestCase {
         let bytes = Data((0..<(2 * 1024 * 1024)).map { UInt8($0 % 251) })
         try bytes.write(to: source)
         let ready = expectation(description: "Upload server ready")
-        let server = try UploadHTTPServer(length: bytes.count, source: source) { ready.fulfill() }
+        let server = try UploadHTTPServer(length: bytes.count, source: source, responseStatus: expectedStatus) { ready.fulfill() }
         let module = HttpModule(configuration: .ephemeral, filesRoot: root, uploadCache: cache)
         defer { module.close(); server.stop() }
         wait(for: [ready], timeout: 5)
@@ -68,8 +76,7 @@ final class HttpUploadTests: XCTestCase {
                 XCTFail("Upload failed: \(String(data: payload, encoding: .utf8) ?? "unknown")")
                 return
             }
-            do { XCTAssertEqual(try WireMap.decode(payload)["statusCode"], .integer(204)) }
-            catch { XCTFail("Invalid upload response: \(error)") }
+            XCTAssertEqual(try WireMap.decode(payload)["statusCode"], .integer(expectedStatus))
         }
         wait(for: [completed], timeout: 20)
         XCTAssertEqual(server.digest, SHA256.hash(data: bytes))
@@ -85,6 +92,7 @@ private final class UploadHTTPServer: @unchecked Sendable {
     private let source: URL
     private let responds: Bool
     private let onReceived: () -> Void
+    private let responseStatus: Int64
     private var received = Data()
     private var headersRead = false
     private var connections: [NWConnection] = []
@@ -92,12 +100,13 @@ private final class UploadHTTPServer: @unchecked Sendable {
     var url: String? { listener.port.map { "http://127.0.0.1:\($0.rawValue)/upload" } }
     var digest: SHA256.Digest { queue.sync { SHA256.hash(data: received) } }
 
-    init(length: Int, source: URL, responds: Bool = true,
+    init(length: Int, source: URL, responds: Bool = true, responseStatus: Int64 = 204,
          received: @escaping () -> Void = {}, ready: @escaping () -> Void) throws {
         self.length = length
         self.source = source
         self.responds = responds
         self.onReceived = received
+        self.responseStatus = responseStatus
         let parameters = NWParameters.tcp
         parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
         listener = try NWListener(using: parameters)
@@ -141,7 +150,9 @@ private final class UploadHTTPServer: @unchecked Sendable {
             if self.received.count == self.length {
                 self.onReceived()
                 guard self.responds else { return }
-                let response = Data("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
+                let statusLine = self.responseStatus == 307 ? "307 Temporary Redirect" : "204 No Content"
+                let redirect = self.responseStatus == 307 ? "Location: http://127.0.0.1:1/must-not-receive-file\r\n" : ""
+                let response = Data("HTTP/1.1 \(statusLine)\r\n\(redirect)Content-Length: 0\r\nConnection: close\r\n\r\n".utf8)
                 connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
             } else if finished {
                 connection.cancel()

--- a/ios/Tests/PamNativeTests/HttpUploadTests.swift
+++ b/ios/Tests/PamNativeTests/HttpUploadTests.swift
@@ -4,6 +4,45 @@ import CryptoKit
 @testable import PamNative
 
 final class HttpUploadTests: XCTestCase {
+    func testClosingModuleInterruptsUploadAndRemovesSnapshot() throws {
+        try assertInterruptedUpload(timeout: false)
+    }
+
+    func testUploadDeadlineRemovesSnapshotWhenServerNeverResponds() throws {
+        try assertInterruptedUpload(timeout: true)
+    }
+
+    private func assertInterruptedUpload(timeout: Bool) throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let root = directory.appendingPathComponent("files")
+        let cache = directory.appendingPathComponent("snapshots")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = root.appendingPathComponent("document.bin")
+        try Data(repeating: 42, count: 65_536).write(to: source)
+        let ready = expectation(description: "Stalled server ready")
+        let received = expectation(description: "Server received upload")
+        let server = try UploadHTTPServer(length: 65_536, source: source, responds: false,
+                                          received: { received.fulfill() }, ready: { ready.fulfill() })
+        let module = HttpModule(configuration: .ephemeral, filesRoot: root, uploadCache: cache)
+        defer { module.close(); server.stop() }
+        wait(for: [ready], timeout: 5)
+        let completed = expectation(description: "Interrupted upload completed")
+        module.invoke(method: "upload", payload: try WireMap.encode([
+            "url": .text(try XCTUnwrap(server.url)), "path": .text("document.bin"),
+            "headers": .text(#"{"Content-Type":"application/octet-stream"}"#),
+            "timeoutMs": .integer(timeout ? 1_000 : 15_000),
+        ])) { status, _ in
+            XCTAssertEqual(status, .failure)
+            completed.fulfill()
+        }
+        wait(for: [received], timeout: 5)
+        if !timeout { module.close() }
+        wait(for: [completed], timeout: 5)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: cache.path), [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+    }
+
     func testStreamsTwoMiBFromStableSnapshotAndRemovesTemporaryFile() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let root = directory.appendingPathComponent("files")
@@ -44,6 +83,8 @@ private final class UploadHTTPServer: @unchecked Sendable {
     private let queue = DispatchQueue(label: "pam.test.http.upload")
     private let length: Int
     private let source: URL
+    private let responds: Bool
+    private let onReceived: () -> Void
     private var received = Data()
     private var headersRead = false
     private var connections: [NWConnection] = []
@@ -51,9 +92,12 @@ private final class UploadHTTPServer: @unchecked Sendable {
     var url: String? { listener.port.map { "http://127.0.0.1:\($0.rawValue)/upload" } }
     var digest: SHA256.Digest { queue.sync { SHA256.hash(data: received) } }
 
-    init(length: Int, source: URL, ready: @escaping () -> Void) throws {
+    init(length: Int, source: URL, responds: Bool = true,
+         received: @escaping () -> Void = {}, ready: @escaping () -> Void) throws {
         self.length = length
         self.source = source
+        self.responds = responds
+        self.onReceived = received
         let parameters = NWParameters.tcp
         parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
         listener = try NWListener(using: parameters)
@@ -95,6 +139,8 @@ private final class UploadHTTPServer: @unchecked Sendable {
                 catch { XCTFail("Could not replace source: \(error)") }
             }
             if self.received.count == self.length {
+                self.onReceived()
+                guard self.responds else { return }
                 let response = Data("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
                 connection.send(content: response, completion: .contentProcessed { _ in connection.cancel() })
             } else if finished {

--- a/packages/native/src/Http/Http.php
+++ b/packages/native/src/Http/Http.php
@@ -102,6 +102,40 @@ final class Http
         int $timeoutMs = 30_000,
         ?OutboundTraceContext $trace = null,
     ): int {
+        return self::send($method, $url, $callback, $headers, $body, $timeoutMs, $trace);
+    }
+
+    /**
+     * PUT a file from the private Files directory without reading its bytes into PHP.
+     * @param Closure(HttpResponse): void $callback
+     * @param array<string, string> $headers
+     */
+    public static function upload(
+        string $url,
+        string $path,
+        Closure $callback,
+        array $headers = [],
+        int $timeoutMs = 120_000,
+        ?OutboundTraceContext $trace = null,
+    ): int {
+        if ($path === '' || strlen($path) > 4096 || str_starts_with($path, '/')
+            || str_contains($path, '\\') || preg_match('/[\x00-\x1f\x7f]/', $path)
+            || array_intersect(explode('/', $path), ['', '.', '..']) !== []) {
+            throw new RuntimeException('Upload source must be a relative private file path.');
+        }
+        return self::send('PUT', $url, $callback, $headers, null, $timeoutMs, $trace, $path);
+    }
+
+    private static function send(
+        string $method,
+        string $url,
+        Closure $callback,
+        array $headers,
+        ?string $body,
+        int $timeoutMs,
+        ?OutboundTraceContext $trace,
+        ?string $source = null,
+    ): int {
         $method = strtoupper(trim($method));
         if (!in_array($method, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'], true)) {
             throw new RuntimeException("Unsupported HTTP method {$method}.");
@@ -128,6 +162,9 @@ final class Http
             if (in_array(strtolower($name), ['traceparent', 'tracestate'], true)) {
                 throw new RuntimeException('Trace headers require an origin-scoped OutboundTraceContext.');
             }
+            if ($source !== null && in_array(strtolower($name), ['host', 'content-length', 'transfer-encoding', 'connection', 'trailer', 'upgrade'], true)) {
+                throw new RuntimeException('File upload headers cannot override HTTP transport fields.');
+            }
             $normalizedHeaders[$name] = $value;
         }
 
@@ -141,6 +178,9 @@ final class Http
             'headers' => json_encode($normalizedHeaders, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
             'timeoutMs' => max(1_000, min(120_000, $timeoutMs)),
         ];
+        if ($source !== null) {
+            $payload['path'] = $source;
+        }
         if ($body !== null) {
             $payload['body'] = $body;
         }
@@ -151,7 +191,7 @@ final class Http
 
         return Runtime::call(
             module: 'http',
-            method: 'request',
+            method: $source === null ? 'request' : 'upload',
             payload: Wire::map($payload),
             callback: self::responseCallback($callback),
         );

--- a/packages/native/src/Http/Http.php
+++ b/packages/native/src/Http/Http.php
@@ -126,6 +126,9 @@ final class Http
         return self::send('PUT', $url, $callback, $headers, null, $timeoutMs, $trace, $path);
     }
 
+    /** @param Closure(HttpResponse): void $callback
+     * @param array<string, string> $headers
+     */
     private static function send(
         string $method,
         string $url,

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -4118,6 +4118,34 @@ $assert(
     'Generic HTTP request did not decode its response.',
 );
 
+$uploadResponse = null;
+$uploadId = Http::upload('https://storage.example.test/signed', 'documents/test.png',
+    static function (HttpResponse $response) use (&$uploadResponse): void { $uploadResponse = $response; },
+    ['Content-Type' => 'image/png'],
+);
+$uploadCall = TestDiagnostics::$moduleCall;
+$uploadPayload = Wire::decodeMap($uploadCall['payload'] ?? '');
+$assert($uploadCall['method'] === 'upload' && $uploadPayload['method'] === 'PUT'
+    && $uploadPayload['path'] === 'documents/test.png' && !array_key_exists('body', $uploadPayload)
+    && $uploadPayload['timeoutMs'] === 120_000,
+    'HTTP upload must send a private path instead of file bytes through PHP.');
+Runtime::dispatchModuleResult($uploadId, \Pam\Native\ModuleResultStatus::Success->value,
+    Wire::map(['statusCode' => 204, 'body' => '']));
+$assert($uploadResponse instanceof HttpResponse && $uploadResponse->successful(), 'Upload response was not delivered.');
+foreach (['', '/absolute', '../outside', 'a/../b', 'a//b', "a\\b", "a\0b"] as $path) {
+    $rejected = false;
+    try { Http::upload('https://storage.example.test/signed', $path, static function (HttpResponse $response): void {}); }
+    catch (RuntimeException) { $rejected = true; }
+    $assert($rejected, 'Invalid upload path reached the native module.');
+}
+foreach (['Host', 'Content-Length', 'Transfer-Encoding', 'Connection', 'Trailer', 'Upgrade'] as $header) {
+    $rejected = false;
+    try { Http::upload('https://storage.example.test/signed', 'document.png',
+        static function (HttpResponse $response): void {}, [$header => 'invalid']); }
+    catch (RuntimeException) { $rejected = true; }
+    $assert($rejected, 'Upload allowed a transport-managed header.');
+}
+
 $traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
 $trace = new OutboundTraceContext($traceparent, 'https://api.example.test/');
 Http::get('https://api.example.test/orders', static function (HttpResponse $response): void {}, $trace);


### PR DESCRIPTION
HTTP string bodies are limited to one MiB, preventing normal document uploads without buffering or another transport. Add `Http::upload(url, privatePath, callback, headers)` to PUT a file from the private Files directory without passing its bytes through PHP.

Android and iOS copy the source into a private snapshot (64 MiB maximum, 64 KiB copy blocks), stream that file with transport-managed length, and remove the snapshot on completion or failure. Both refuse redirects and transport-header overrides. Network deadlines and module shutdown interrupt uploads; iOS task creation is serialized with shutdown.

The documentation describes limits, disk use and uncertain server outcomes. This is a foreground API without progress, individual cancellation, automatic retry or process-restart recovery.

Validation:

- CI 34019042163 passed for the initial implementation, including PHP/Rust, iOS, Android build/JVM and Android API 26/36 instrumentation.
- iOS job 101449027197 passed 61 tests, including a real 2 MiB loopback HTTP upload, byte digest comparison after changing the original file, and snapshot cleanup.
- iOS lifecycle tests passed in job 101449344923: module shutdown and a server that never responds.
- Full CI 34019769932 passed on fdba36e45d35365879fe5b10db442ff21ddced35: PHP/Rust, Android build/JVM, Android API 26/36 instrumentation and 64 iOS tests. These include stalled-server deadlines, module shutdown, snapshot cleanup and upload-specific redirect rejection. The preceding Swift test compilation failure was corrected by decoding outside the XCTest autoclosure.

No dependency changes, release, app installation or edits to generated application native files. Physical-device validation of the application upload flow remains separate from these SDK transport contracts.
