### PR TITLE
feat(files): compute SHA-256 without bridging file bytes

### DIFF
--- a/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/FilesModule.kt
@@ -37,6 +37,7 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
         runCatching {
             when (method) {
                 "read" -> executor.execute { read(payload, completion) }
+                "sha256" -> executor.execute { sha256(payload, completion) }
                 "write" -> executor.execute { write(payload, completion) }
                 "copyAsset" -> executor.execute { copyAsset(payload, completion) }
                 "download" -> executor.execute { download(payload, completion) }
@@ -53,6 +54,13 @@ internal class FilesModule(private val activity: PamActivity) : NativeModule, Au
                 "capture" -> capture(payload, completion)
                 else -> error("Unknown files method $method")
             }
+        }.onFailure { completion.failure(it) }
+    }
+
+    private fun sha256(payload: ByteArray, completion: ModuleCompletion) {
+        runCatching {
+            val digest = PrivateFileSha256.digest(root, WireMap.decode(payload).requiredText("path"))
+            completion.complete(ModuleResultStatus.SUCCESS, WireMap.encode(mapOf("sha256" to WireValue.Text(digest))))
         }.onFailure { completion.failure(it) }
     }
 

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/PrivateFileSha256.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/PrivateFileSha256.kt
@@ -1,0 +1,34 @@
+package dev.pam.nativeapp.modules
+
+import java.io.File
+import java.security.MessageDigest
+
+internal object PrivateFileSha256 {
+    const val MAX_BYTES = 64L * 1024 * 1024
+
+    fun digest(root: File, path: String, cancelled: () -> Boolean = { Thread.currentThread().isInterrupted }): String {
+        require(path.isNotBlank() && path.toByteArray(Charsets.UTF_8).size <= 4096 && !path.startsWith('/') && '\\' !in path
+            && path.none { it.code < 32 || it.code == 127 }
+            && path.split('/').none { it.isEmpty() || it == "." || it == ".." }) { "Invalid private file path" }
+        val base = root.canonicalFile
+        val file = File(base, path).canonicalFile
+        require(file.path.startsWith(base.path + File.separator) && file.isFile) { "File does not exist in the private directory" }
+        val expected = file.length()
+        require(expected <= MAX_BYTES) { "File exceeds the 64 MiB hash limit" }
+        val hash = MessageDigest.getInstance("SHA-256")
+        var count = 0L
+        file.inputStream().use { input ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                check(!cancelled()) { "File hashing cancelled" }
+                val read = input.read(buffer)
+                if (read < 0) break
+                count += read
+                require(count <= expected && count <= MAX_BYTES) { "File changed while hashing" }
+                hash.update(buffer, 0, read)
+            }
+        }
+        require(count == expected) { "File changed while hashing" }
+        return hash.digest().joinToString("") { "%02x".format(it.toInt() and 255) }
+    }
+}

--- a/android/app/src/test/java/dev/pam/nativeapp/modules/PrivateFileSha256Test.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/modules/PrivateFileSha256Test.kt
@@ -1,0 +1,52 @@
+package dev.pam.nativeapp.modules
+
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.file.Files
+import org.junit.Assert.*
+import org.junit.Test
+
+class PrivateFileSha256Test {
+    @Test fun hashesKnownVectorsAndFileBeyondBridgeLimit() = temporary { root ->
+        val file = File(root, "document.bin")
+        file.writeBytes(byteArrayOf())
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", PrivateFileSha256.digest(root, file.name))
+        file.writeText("abc")
+        assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", PrivateFileSha256.digest(root, file.name))
+        file.writeBytes(ByteArray(2 * 1024 * 1024) { 42 })
+        assertEquals("52d434cbc3b76fa5ce4480fefe3c7769b6be2708434ed3ea735c31b1213c1d38", PrivateFileSha256.digest(root, file.name))
+        assertEquals(2L * 1024 * 1024, file.length())
+    }
+
+    @Test fun rejectsUnsafePathsAndExternalSymlinks() = temporary { root ->
+        File(root, "folder").mkdir()
+        for (path in listOf("", " ", "../outside", "/absolute", "folder", "missing", "a//b", "a/../b", "a\\b", "bad\nname")) {
+            assertThrows(IllegalArgumentException::class.java) { PrivateFileSha256.digest(root, path) }
+        }
+        val outside = File(root.parentFile, "outside").apply { writeText("secret") }
+        Files.createSymbolicLink(File(root, "link").toPath(), outside.toPath())
+        assertThrows(IllegalArgumentException::class.java) { PrivateFileSha256.digest(root, "link") }
+    }
+
+    @Test fun rejectsOversizeCancellationAndTruncatedSource() = temporary { root ->
+        val source = File(root, "large.bin")
+        RandomAccessFile(source, "rw").use { it.setLength(PrivateFileSha256.MAX_BYTES + 1) }
+        assertThrows(IllegalArgumentException::class.java) { PrivateFileSha256.digest(root, source.name) }
+        source.writeBytes(ByteArray(128 * 1024))
+        assertThrows(IllegalStateException::class.java) { PrivateFileSha256.digest(root, source.name) { true } }
+        assertEquals(128L * 1024, source.length())
+        var checks = 0
+        assertThrows(IllegalArgumentException::class.java) {
+            PrivateFileSha256.digest(root, source.name) {
+                if (++checks == 2) RandomAccessFile(source, "rw").use { it.setLength(1) }
+                false
+            }
+        }
+    }
+
+    private fun temporary(test: (File) -> Unit) {
+        val directory = Files.createTempDirectory("pam-file-sha256-test").toFile()
+        try { test(File(directory, "files").apply { mkdir() }) }
+        finally { directory.deleteRecursively() }
+    }
+}

--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -137,6 +137,19 @@ reject embedded credentials and non-HTTPS URLs, enforce a caller-controlled
 size limit (64 MiB by default, 256 MiB maximum), and replace the destination
 atomically only after a successful transfer.
 
+`Files::sha256($file->path, $callback, $failure)` computes a lowercase SHA-256
+digest on the native file worker. Only the private path and 64-character digest
+cross the bridge. Files are read in 64 KiB blocks and limited to 64 MiB; empty
+files have the standard SHA-256 empty digest. The optional failure callback
+receives native read, path or size errors. Without it, native failure follows
+the normal exception behavior. This API is currently unreleased.
+
+Use it before requesting an upload grant that binds the expected content
+digest. Keep the source unchanged until the upload completes and require the
+server to validate the uploaded bytes: hashing alone does not lock the file
+or prevent a concurrent write of the same size. The operation does not copy,
+delete or modify the source file.
+
 Use `Files::downloadWithProgress()` for authenticated documents or visible
 transfer UI. Request headers are validated on both sides of the bridge;
 connection framing headers and CR/LF values are rejected. The progress closure

--- a/ios/Sources/PamNative/Modules/FilesModule.swift
+++ b/ios/Sources/PamNative/Modules/FilesModule.swift
@@ -23,6 +23,8 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
             switch method {
             case "read":
                 queue.async { self.read(payload, completion) }
+            case "sha256":
+                queue.async { self.sha256(payload, completion) }
             case "write":
                 queue.async { self.write(payload, completion) }
             case "copyAsset":
@@ -53,6 +55,15 @@ final class FilesModule: NSObject, NativeModule, ClosableNativeModule,
         } catch {
             completion(.failure, Data(error.localizedDescription.utf8))
         }
+    }
+
+    private func sha256(_ payload: Data, _ completion: @escaping ModuleCompletion) {
+        do {
+            let values = try WireMap.decode(payload)
+            guard case let .text(path)? = values["path"] else { throw FileModuleError("Hash source path is required") }
+            let digest = try PrivateFileSha256.digest(root: root, path: path)
+            completion(.success, try WireMap.encode(["sha256": .text(digest)]))
+        } catch { completion(.failure, Data(error.localizedDescription.utf8)) }
     }
 
     private func stat(_ payload: Data, _ completion: @escaping ModuleCompletion) {

--- a/ios/Sources/PamNative/Modules/PrivateFileSha256.swift
+++ b/ios/Sources/PamNative/Modules/PrivateFileSha256.swift
@@ -1,0 +1,40 @@
+import Foundation
+import CryptoKit
+
+enum PrivateFileSha256 {
+    static let maximumBytes = 64 * 1024 * 1024
+
+    static func digest(root: URL, path: String, cancelled: () -> Bool = { false }) throws -> String {
+        guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              path.utf8.count <= 4096, !path.hasPrefix("/"), !path.contains("\\"),
+              !path.unicodeScalars.contains(where: { $0.value < 32 || $0.value == 127 }),
+              !path.components(separatedBy: "/").contains(where: { $0.isEmpty || $0 == "." || $0 == ".." }) else {
+            throw HashError("Invalid private file path")
+        }
+        let base = root.standardizedFileURL.resolvingSymlinksInPath()
+        let file = base.appendingPathComponent(path).standardizedFileURL.resolvingSymlinksInPath()
+        guard file.path.hasPrefix(base.path + "/") else { throw HashError("File is outside the private directory") }
+        let metadata = try file.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        guard metadata.isRegularFile == true, let expected = metadata.fileSize else { throw HashError("File does not exist") }
+        guard expected <= maximumBytes else { throw HashError("File exceeds the 64 MiB hash limit") }
+        let input = try FileHandle(forReadingFrom: file)
+        defer { try? input.close() }
+        var hash = SHA256()
+        var count = 0
+        while true {
+            guard !cancelled() else { throw HashError("File hashing cancelled") }
+            guard let data = try input.read(upToCount: 64 * 1024), !data.isEmpty else { break }
+            count += data.count
+            guard count <= expected, count <= maximumBytes else { throw HashError("File changed while hashing") }
+            hash.update(data: data)
+        }
+        guard count == expected else { throw HashError("File changed while hashing") }
+        return hash.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private struct HashError: LocalizedError {
+        let message: String
+        init(_ message: String) { self.message = message }
+        var errorDescription: String? { message }
+    }
+}

--- a/ios/Tests/PamNativeTests/PrivateFileSha256Tests.swift
+++ b/ios/Tests/PamNativeTests/PrivateFileSha256Tests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import PamNative
+
+final class PrivateFileSha256Tests: XCTestCase {
+    func testKnownVectorsAndFileBeyondBridgeLimit() throws {
+        try temporary { root in
+            let file = root.appendingPathComponent("document.bin")
+            try Data().write(to: file)
+            XCTAssertEqual(try PrivateFileSha256.digest(root: root, path: "document.bin"), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+            try Data("abc".utf8).write(to: file)
+            XCTAssertEqual(try PrivateFileSha256.digest(root: root, path: "document.bin"), "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+            try Data(repeating: 42, count: 2 * 1024 * 1024).write(to: file)
+            XCTAssertEqual(try PrivateFileSha256.digest(root: root, path: "document.bin"), "52d434cbc3b76fa5ce4480fefe3c7769b6be2708434ed3ea735c31b1213c1d38")
+            XCTAssertEqual(try file.resourceValues(forKeys: [.fileSizeKey]).fileSize, 2 * 1024 * 1024)
+        }
+    }
+
+    func testUnsafePathsAndExternalSymlinks() throws {
+        try temporary { root in
+            try FileManager.default.createDirectory(at: root.appendingPathComponent("folder"), withIntermediateDirectories: true)
+            for path in ["", " ", "../outside", "/absolute", "folder", "missing", "a//b", "a/../b", "a\\b", "bad\nname"] {
+                XCTAssertThrowsError(try PrivateFileSha256.digest(root: root, path: path))
+            }
+            let outside = root.deletingLastPathComponent().appendingPathComponent("outside")
+            try Data("secret".utf8).write(to: outside)
+            try FileManager.default.createSymbolicLink(at: root.appendingPathComponent("link"), withDestinationURL: outside)
+            XCTAssertThrowsError(try PrivateFileSha256.digest(root: root, path: "link"))
+        }
+    }
+
+    func testOversizeCancellationAndTruncatedSource() throws {
+        try temporary { root in
+            let source = root.appendingPathComponent("large.bin")
+            try Data().write(to: source)
+            let writer = try FileHandle(forWritingTo: source)
+            defer { try? writer.close() }
+            try writer.truncate(atOffset: UInt64(PrivateFileSha256.maximumBytes + 1))
+            XCTAssertThrowsError(try PrivateFileSha256.digest(root: root, path: "large.bin"))
+            try writer.truncate(atOffset: 128 * 1024)
+            XCTAssertThrowsError(try PrivateFileSha256.digest(root: root, path: "large.bin", cancelled: { true }))
+            XCTAssertEqual(try source.resourceValues(forKeys: [.fileSizeKey]).fileSize, 128 * 1024)
+            var checks = 0
+            XCTAssertThrowsError(try PrivateFileSha256.digest(root: root, path: "large.bin", cancelled: {
+                checks += 1
+                if checks == 2 { try? writer.truncate(atOffset: 1) }
+                return false
+            }))
+        }
+    }
+
+    private func temporary(_ test: (URL) throws -> Void) throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let root = directory.appendingPathComponent("files")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try test(root)
+    }
+}

--- a/packages/native/src/System/Files.php
+++ b/packages/native/src/System/Files.php
@@ -38,6 +38,28 @@ final class Files
         });
     }
 
+    /**
+     * Hash a private file natively without moving its bytes through PHP.
+     * @param Closure(string): void $callback
+     * @param null|Closure(string): void $failure
+     */
+    public static function sha256(string $path, Closure $callback, ?Closure $failure = null): int
+    {
+        if (trim($path) === '' || strlen($path) > 4096 || str_starts_with($path, '/')
+            || str_contains($path, '\\') || preg_match('/[\x00-\x1f\x7f]/', $path)
+            || array_intersect(explode('/', $path), ['', '.', '..']) !== []) {
+            throw new InvalidArgumentException('Hash source must be a relative private file path.');
+        }
+
+        return self::invokeOptionalFailure('sha256', ['path' => $path], static function (array $values) use ($callback): void {
+            $digest = $values['sha256'] ?? null;
+            if (!is_string($digest) || preg_match('/^[a-f0-9]{64}$/D', $digest) !== 1) {
+                throw new RuntimeException('Native SHA-256 result is invalid.');
+            }
+            $callback($digest);
+        }, $failure);
+    }
+
     public static function write(string $path, string $contents, ?Closure $callback = null): int
     {
         return self::invoke(

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -3460,6 +3460,41 @@ $assert(
     'Media capture must resolve user cancellation with null instead of throwing.',
 );
 
+$fileDigest = null;
+$hashRequest = Files::sha256('documents/identity.pdf', static function (string $digest) use (&$fileDigest): void {
+    $fileDigest = $digest;
+});
+$hashCall = TestDiagnostics::$moduleCall;
+$assert($hashCall !== null && $hashCall['module'] === 'files' && $hashCall['method'] === 'sha256'
+    && Wire::decodeMap($hashCall['payload']) === ['path' => 'documents/identity.pdf'],
+    'Files SHA-256 must bridge only a private path, never file bytes.');
+Runtime::dispatchModuleResult($hashRequest, ModuleResultStatus::Success->value, Wire::map(['sha256' => hash('sha256', 'abc')]));
+$assert($fileDigest === hash('sha256', 'abc'), 'Files SHA-256 must deliver the native digest.');
+
+$hashFailure = null;
+$hashRequest = Files::sha256('missing.pdf', static function (string $_): void {}, static function (string $message) use (&$hashFailure): void {
+    $hashFailure = $message;
+});
+Runtime::dispatchModuleResult($hashRequest, ModuleResultStatus::Failure->value, 'File does not exist');
+$assert($hashFailure === 'File does not exist', 'Files SHA-256 must expose native failure through the optional failure callback.');
+
+foreach (['', ' ', '/absolute', '../outside', 'a//b', 'a/../b', 'a\\b', "bad\nname", str_repeat('a', 4097)] as $unsafeHashPath) {
+    $rejected = false;
+    try { Files::sha256($unsafeHashPath, static function (string $_): void {}); }
+    catch (InvalidArgumentException) { $rejected = true; }
+    $assert($rejected, 'Files SHA-256 must reject unsafe private paths before crossing the bridge.');
+}
+$diagnosticsBeforeHashTests = TestDiagnostics::$messages;
+foreach (['', str_repeat('A', 64), str_repeat('g', 64), str_repeat('a', 63), str_repeat('a', 64)."\n", 42] as $invalidDigest) {
+    $fileDigest = null;
+    $beforeMessages = count(TestDiagnostics::$messages);
+    $hashRequest = Files::sha256('document.pdf', static function (string $digest) use (&$fileDigest): void { $fileDigest = $digest; });
+    Runtime::dispatchModuleResult($hashRequest, ModuleResultStatus::Success->value, Wire::map(['sha256' => $invalidDigest]));
+    $assert($fileDigest === null && count(TestDiagnostics::$messages) > $beforeMessages,
+        'Files SHA-256 must reject malformed native digest results.');
+}
+TestDiagnostics::$messages = $diagnosticsBeforeHashTests;
+
 $copiedAsset = null;
 $copyAssetRequest = Files::copyAsset(
     'assets/templates/story.webp',


### PR DESCRIPTION
Files::read bridges at most one MiB, so callers cannot compute the checksum of ordinary document files without another native operation. Add Files::sha256(path, callback, failure) to hash a private file on Android and iOS workers and return only its lowercase digest.

Native implementations read 64 KiB blocks, enforce a 64 MiB source limit, reject paths outside the private directory and detect changes to the byte count. PHP validates the private path and returned digest. Hashing leaves the source unchanged; documentation requires keeping it unchanged through upload and validating the received digest on the server. It does not promise protection against concurrent same-size writes or filesystem link swaps.

Validation: full CI 34020008230 passed on 19b8ffc621bb6da7f45a4c5e6af0f2e82298d784, including PHP/Rust, Android build/JVM, Android API 26/36 instrumentation, Swift/UIKit and accessibility evidence. Sixty Swift tests passed, including the three new hash tests. Three targeted JVM tests and the complete PHP SDK contracts also passed locally. Tests cover standard empty/abc vectors, a 2 MiB fixture with an independently calculated digest, traversal/external symlinks, size limits, interruption and truncation. No dependencies changed, no release and no application native edits.
