### PR TITLE
release: prepare PAM Native 1.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.20 - 2026-09-06
+
+- Add `Http::upload()` for native streaming PUT uploads from private files, with bounded snapshots, network deadlines and cleanup on completion or failure.
+- Refuse HTTP redirects on iOS, matching Android, including file uploads.
+- Add `Files::sha256()` to hash private files in native workers without passing their bytes through PHP.
+- Document upload limits and uncertain outcomes; foreground uploads do not provide progress, individual cancellation or restart recovery.
+- Add reproducible VS Code extension packaging with metadata, license and checksum verification.
+
 ## 1.0.19 - 2026-09-06
 
 - Allow applications to recover from native notification permission failures through an optional failure callback.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.19"
+version = "1.0.20"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.19"
+version = "1.0.20"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -142,7 +142,7 @@ digest on the native file worker. Only the private path and 64-character digest
 cross the bridge. Files are read in 64 KiB blocks and limited to 64 MiB; empty
 files have the standard SHA-256 empty digest. The optional failure callback
 receives native read, path or size errors. Without it, native failure follows
-the normal exception behavior. This API is currently unreleased.
+the normal exception behavior. Available since SDK 1.0.20.
 
 Use it before requesting an upload grant that binds the expected content
 digest. Keep the source unchanged until the upload completes and require the
@@ -170,8 +170,7 @@ document picker remains the portable fallback.
 
 `Http::upload()` sends a private `Files` path as the raw body of an HTTPS
 `PUT`. Pass `FileReference::$path`, not its `pam-file://` URI or an absolute
-device path. This API is available in the source branch; it is not yet part
-of a published SDK release.
+device path. Available since SDK 1.0.20.
 
 ```php
 use Pam\Native\Http\Http;

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.19';
+    public const string SDK_VERSION = '1.0.20';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6396,8 +6396,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.19',
-    'The runtime SDK contract must match the stable 1.0.19 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.20',
+    'The runtime SDK contract must match the stable 1.0.20 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Prepare PAM Native 1.0.20 with native file uploads, SHA-256 hashing, consistent HTTP redirect refusal and reproducible editor packaging from PRs 115–118.

Update the SDK identity, internal Rust package versions, matching contract assertions and changelog together. All 22 external Rust dependency blocks remain byte-for-byte unchanged; Composer continues to require only PHP ^8.5. Package metadata and offline locked Cargo metadata were checked before editing.

Local validation: complete PHP SDK contracts, protocol parity, locked Cargo metadata and git diff --check passed. Feature PRs 117 and 118 each passed their full CI. This release candidate runs the combined tree through CI before tagging; the tag workflow must subsequently pass its artifact and community first-run gates before publication. No release/tag or application installation has occurred.
