### PR TITLE
feat: add expiring sensitive clipboard writes

### DIFF
--- a/android/app/src/main/java/dev/pam/nativeapp/modules/ClipboardPrivacyPolicy.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/ClipboardPrivacyPolicy.kt
@@ -1,0 +1,16 @@
+package dev.pam.nativeapp.modules
+
+internal object ClipboardPrivacyPolicy {
+    const val sensitiveExtra = "android.content.extra.IS_SENSITIVE"
+    const val defaultExpirySeconds = 60L
+
+    fun expiryMillis(seconds: Long): Long {
+        require(seconds in 15L..300L) {
+            "Sensitive clipboard expiry must be between 15 and 300 seconds"
+        }
+        return seconds * 1_000L
+    }
+
+    fun shouldClear(expectedText: String, currentText: String?): Boolean =
+        currentText == expectedText
+}

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/SystemModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/SystemModule.kt
@@ -304,7 +304,7 @@ internal class SystemModule(private val context: Context) : AutoCloseable {
         val clearAfterMillis = if (sensitive) ClipboardPrivacyPolicy.expiryMillis(clearAfterSeconds) else 0L
         main.post {
             val clip = ClipData.newPlainText("", text)
-            if (sensitive && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            if (sensitive) {
                 clip.description.extras = PersistableBundle().apply {
                     putBoolean(ClipboardPrivacyPolicy.sensitiveExtra, true)
                 }

--- a/android/app/src/main/java/dev/pam/nativeapp/modules/SystemModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/SystemModule.kt
@@ -16,6 +16,7 @@ import android.hardware.SensorManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.PersistableBundle
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
@@ -290,14 +291,40 @@ internal class SystemModule(private val context: Context) : AutoCloseable {
     }
 
     private fun clipboardSetText(payload: ByteArray, completion: ModuleCompletion) {
-        val text = WireMap.decode(payload).text("text")
+        val values = WireMap.decode(payload)
+        val text = values.text("text")
+        val sensitive = values.flag("sensitive", false)
+        val clearAfterSeconds = values.integer(
+            "clearAfterSeconds",
+            ClipboardPrivacyPolicy.defaultExpirySeconds,
+        )
         require(text.toByteArray(Charsets.UTF_8).size <= MAX_CLIPBOARD_BYTES) {
             "Clipboard text exceeds one megabyte"
         }
+        val clearAfterMillis = if (sensitive) ClipboardPrivacyPolicy.expiryMillis(clearAfterSeconds) else 0L
         main.post {
-            clipboard().setPrimaryClip(ClipData.newPlainText("", text))
+            val clip = ClipData.newPlainText("", text)
+            if (sensitive && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                clip.description.extras = PersistableBundle().apply {
+                    putBoolean(ClipboardPrivacyPolicy.sensitiveExtra, true)
+                }
+            }
+            clipboard().setPrimaryClip(clip)
+            if (sensitive) scheduleClipboardClear(text, clearAfterMillis)
             completion.success()
         }
+    }
+
+    private fun scheduleClipboardClear(expectedText: String, delayMillis: Long) {
+        main.postDelayed({
+            if (closed.get()) return@postDelayed
+            val manager = clipboard()
+            val current = manager.primaryClip?.takeIf { it.itemCount > 0 }
+                ?.getItemAt(0)?.text?.toString()
+            if (!ClipboardPrivacyPolicy.shouldClear(expectedText, current)) return@postDelayed
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) manager.clearPrimaryClip()
+            else manager.setPrimaryClip(ClipData.newPlainText("", ""))
+        }, delayMillis)
     }
 
     private fun clipboardGetText(completion: ModuleCompletion) {

--- a/android/app/src/test/java/dev/pam/nativeapp/modules/ClipboardPrivacyPolicyTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/modules/ClipboardPrivacyPolicyTest.kt
@@ -1,0 +1,26 @@
+package dev.pam.nativeapp.modules
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClipboardPrivacyPolicyTest {
+    @Test
+    fun expiryIsBoundedAndConvertedWithoutOverflow() {
+        assertEquals(15_000L, ClipboardPrivacyPolicy.expiryMillis(15))
+        assertEquals(60_000L, ClipboardPrivacyPolicy.expiryMillis(60))
+        assertEquals(300_000L, ClipboardPrivacyPolicy.expiryMillis(300))
+        listOf(14L, 301L).forEach { seconds ->
+            runCatching { ClipboardPrivacyPolicy.expiryMillis(seconds) }
+                .onSuccess { error("Unsafe expiry $seconds was accepted") }
+        }
+    }
+
+    @Test
+    fun scheduledCleanupNeverDeletesAClipboardReplacedByTheUser() {
+        assertTrue(ClipboardPrivacyPolicy.shouldClear("pix-code", "pix-code"))
+        assertFalse(ClipboardPrivacyPolicy.shouldClear("pix-code", "new clipboard value"))
+        assertFalse(ClipboardPrivacyPolicy.shouldClear("pix-code", null))
+    }
+}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -244,6 +244,8 @@ execution window, not an unlimited background service.
 use Pam\Native\System\Clipboard;
 
 Clipboard::setText('Invite code: PAM42');
+// Private values are marked as sensitive and expire after 60 seconds.
+Clipboard::setSensitiveText($pixCode);
 Clipboard::hasText(function (bool $available): void {
     if ($available) {
         Clipboard::getText(fn (string $text) => $this->paste($text));

--- a/ios/Sources/PamNative/Modules/SystemModule.swift
+++ b/ios/Sources/PamNative/Modules/SystemModule.swift
@@ -363,7 +363,25 @@ public final class SystemModule: NativeModule, ClosableNativeModule, @unchecked 
                 throw RuntimeError("Clipboard text exceeds one megabyte")
             }
             DispatchQueue.main.async {
-                UIPasteboard.general.string = text
+                let sensitive: Bool
+                if case .flag(true)? = values["sensitive"] {
+                    sensitive = true
+                } else {
+                    sensitive = false
+                }
+                if sensitive {
+                    guard case let .integer(seconds)? = values["clearAfterSeconds"],
+                          (15...300).contains(seconds) else {
+                        completion(.failure, "Sensitive clipboard expiry must be between 15 and 300 seconds".data(using: .utf8) ?? Data())
+                        return
+                    }
+                    UIPasteboard.general.setItems(
+                        [["public.utf8-plain-text": text]],
+                        options: [.localOnly: true, .expirationDate: Date().addingTimeInterval(TimeInterval(seconds))]
+                    )
+                } else {
+                    UIPasteboard.general.string = text
+                }
                 completion(.success, Data())
             }
         } catch {

--- a/packages/native/src/System/Clipboard.php
+++ b/packages/native/src/System/Clipboard.php
@@ -34,6 +34,36 @@ final class Clipboard
         );
     }
 
+    /**
+     * Copies private text with platform sensitivity metadata and automatic expiry.
+     *
+     * @param Closure(bool): void|null $completed
+     */
+    public static function setSensitiveText(
+        string $text,
+        int $clearAfterSeconds = 60,
+        ?Closure $completed = null,
+    ): int {
+        if (strlen($text) > self::MAX_TEXT_BYTES) {
+            throw new \InvalidArgumentException('Clipboard text cannot exceed one megabyte.');
+        }
+        if ($clearAfterSeconds < 15 || $clearAfterSeconds > 300) {
+            throw new \InvalidArgumentException('Sensitive clipboard expiry must be between 15 and 300 seconds.');
+        }
+
+        return Runtime::callNative(
+            NativeOperation::ClipboardSetText,
+            Wire::map([
+                'text' => $text,
+                'sensitive' => true,
+                'clearAfterSeconds' => $clearAfterSeconds,
+            ]),
+            static function (ModuleResultStatus $status) use ($completed): void {
+                $completed?->__invoke($status === ModuleResultStatus::Success);
+            },
+        );
+    }
+
     /** @param Closure(?string): void $completed */
     public static function getText(Closure $completed): int
     {

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -1309,6 +1309,23 @@ $assert(
             === 'Pam Native',
     'Clipboard writes must use the bounded typed native operation channel.',
 );
+Clipboard::setSensitiveText('private-pix-code', 45);
+$sensitiveClipboardPayload = Wire::decodeMap(TestDiagnostics::$typedCall['payload']);
+$assert(
+    TestDiagnostics::$typedCall['operation'] === NativeOperation::ClipboardSetText->value
+        && $sensitiveClipboardPayload['text'] === 'private-pix-code'
+        && $sensitiveClipboardPayload['sensitive'] === true
+        && $sensitiveClipboardPayload['clearAfterSeconds'] === 45,
+    'Sensitive clipboard writes must carry bounded privacy metadata.',
+);
+foreach ([14, 301] as $invalidClipboardExpiry) {
+    try {
+        Clipboard::setSensitiveText('private', $invalidClipboardExpiry);
+        $assert(false, 'Sensitive clipboard expiry must reject unsafe bounds.');
+    } catch (InvalidArgumentException) {
+        $assert(true, 'Sensitive clipboard expiry rejects unsafe bounds.');
+    }
+}
 $assert(
     array_map(
         static fn (NativeOperation $operation): int => $operation->value,


### PR DESCRIPTION
Pix codes, authentication secrets, and other private values currently use the generic clipboard API and can remain available longer than intended. This adds `Clipboard::setSensitiveText()` with a bounded 15–300 second expiry. Android marks the clip as sensitive and clears it only if the user has not replaced it. iOS keeps it local to the device and delegates expiration to `UIPasteboard`.

Validation:
- `php packages/native/tests/run.php`
- `./gradlew :app:testDebugUnitTest`
- `git diff --check`

The PR CI provides the required macOS/Swift and Android device matrix before release.
