### PR TITLE
release: prepare PAM Native 1.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.21 - 2026-09-06
+
+- Add `Clipboard::setSensitiveText()` for expiring sensitive clipboard writes.
+- Mark sensitive Android clips so supported keyboards and system surfaces avoid previews.
+- Clear unchanged sensitive Android clips after a bounded lifetime and use native expiration on iOS.
+
 ## 1.0.20 - 2026-09-06
 
 - Add `Http::upload()` for native streaming PUT uploads from private files, with bounded snapshots, network deadlines and cleanup on completion or failure.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.20"
+version = "1.0.21"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.20"
+version = "1.0.21"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.20';
+    public const string SDK_VERSION = '1.0.21';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6413,8 +6413,8 @@ $assert(
     'Grouped drawer state must restore selection and expanded sections.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.20',
-    'The runtime SDK contract must match the stable 1.0.20 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.21',
+    'The runtime SDK contract must match the stable 1.0.21 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Publishes the expiring sensitive clipboard API across PHP, Android, and iOS.

Validation: `php packages/native/tests/run.php`; `cargo test --workspace`.
