### PR TITLE
fix: harden native layout and interaction rendering

### DIFF
--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamModalHostInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamModalHostInstrumentedTest.kt
@@ -29,4 +29,20 @@ class PamModalHostInstrumentedTest {
         assertEquals(640, sheet.height)
         assertEquals(Gravity.BOTTOM, sheet.gravity)
     }
+
+    @Test
+    fun nonDismissibleModalBlocksUserDismissalIndependentOfPresentation() {
+        assertEquals(true, blocksModalDismissal(dismissible = false))
+        assertEquals(false, blocksModalDismissal(dismissible = true))
+    }
+
+    @Test
+    fun dialogBackdropHitTestingSeparatesSurfaceFromDismissibleScrim() {
+        assertEquals(false, isPointOutsideModalChild(320f, 480f, 120, 300, 960, 720))
+        assertEquals(false, isPointOutsideModalChild(120f, 300f, 120, 300, 960, 720))
+        assertEquals(true, isPointOutsideModalChild(119f, 480f, 120, 300, 960, 720))
+        assertEquals(true, isPointOutsideModalChild(320f, 299f, 120, 300, 960, 720))
+        assertEquals(true, isPointOutsideModalChild(960f, 480f, 120, 300, 960, 720))
+        assertEquals(true, isPointOutsideModalChild(320f, 720f, 120, 300, 960, 720))
+    }
 }

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamNavigationHostInstrumentedTest.kt
@@ -550,6 +550,82 @@ class PamNavigationHostInstrumentedTest {
         }
     }
 
+    @Test
+    fun permanentDrawerKeepsEnginePartitionedChildrenAtTheirAuthoredFrames() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var content: View
+            lateinit var drawer: View
+            onMain(instrumentation) {
+                val density = activity.resources.displayMetrics.density
+                val parentWidth = (900f * density).toInt()
+                val drawerWidth = (240f * density).toInt()
+                content = View(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        parentWidth - drawerWidth,
+                        1_200,
+                    ).apply { leftMargin = drawerWidth }
+                }
+                drawer = View(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(drawerWidth, 1_200)
+                }
+                val layout = PamDrawerLayout(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(parentWidth, 1_200)
+                    insert(content, 0)
+                    insert(drawer, 1)
+                    setDrawerWidth(240f)
+                    setDrawerType(TYPE_PERMANENT)
+                }
+                activity.host.addView(layout)
+                layout.layout(0, 0, parentWidth, 1_200)
+            }
+
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                assertEquals(0f, content.translationX, 0.01f)
+                assertEquals(0f, drawer.translationX, 0.01f)
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
+    @Test
+    fun permanentToFrontTransitionCancelsTheObsoleteContentAnimation() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var layout: PamDrawerLayout
+            lateinit var content: View
+            onMain(instrumentation) {
+                content = View(activity)
+                layout = PamDrawerLayout(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(1_080, 2_280)
+                    addView(content)
+                    addView(View(activity))
+                    setDrawerType(TYPE_PERMANENT)
+                }
+                activity.host.addView(layout)
+                layout.layout(0, 0, 1_080, 2_280)
+
+                // Mirrors incremental property order after rotating from an
+                // expanded permanent drawer back to compact Front.
+                layout.setOpen(true, animated = false)
+                layout.setOpen(false, animated = true)
+                layout.setDrawerType(TYPE_FRONT)
+            }
+
+            Thread.sleep(350)
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                assertEquals(0f, content.translationX, 0.01f)
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
     private fun launchActivity(instrumentation: Instrumentation): PamTestActivity =
         instrumentation.startActivitySync(
             Intent(instrumentation.targetContext, PamTestActivity::class.java).apply {
@@ -567,5 +643,6 @@ class PamNavigationHostInstrumentedTest {
         const val TRANSITION_SLIDE_FROM_RIGHT = 2
         const val TRANSITION_NONE = 8
         const val TYPE_PERMANENT = 4
+        const val TYPE_FRONT = 1
     }
 }

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamRendererInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamRendererInstrumentedTest.kt
@@ -2,6 +2,7 @@ package dev.pam.nativeapp.render
 
 import android.app.Instrumentation
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
@@ -17,6 +18,7 @@ import android.view.ViewGroup
 import android.view.MotionEvent
 import android.view.TextureView
 import android.view.WindowInsetsController
+import android.view.WindowInsets
 import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.Button
 import android.widget.EditText
@@ -40,9 +42,203 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.math.roundToInt
 
 @RunWith(AndroidJUnit4::class)
 class PamRendererInstrumentedTest {
+    @Test
+    fun nestedRowKeepsExplicitCrossAxisHeightWhileItsNativeRelayoutIsPending() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        lateinit var renderer: PamRenderer
+        try {
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                renderer = PamRenderer(activity, activity.host) { _, _, _ -> }
+                renderer.commit(
+                    listOf(
+                        listOf(
+                            Mutation.Create(node(1, 0, NodeKind.SCREEN)),
+                            Mutation.Create(node(
+                                2,
+                                1,
+                                NodeKind.VIEW,
+                                mapOf(PropKey.TEST_ID to PropValue.Text("number-field")),
+                            )),
+                            Mutation.Create(node(3, 2, NodeKind.ROW)),
+                            Mutation.Create(node(
+                                4,
+                                3,
+                                NodeKind.INPUT,
+                                mapOf(PropKey.TEST_ID to PropValue.Text("stacked-input")),
+                            )),
+                            Mutation.Create(node(
+                                5,
+                                3,
+                                NodeKind.COLUMN,
+                                mapOf(PropKey.TEST_ID to PropValue.Text("stacked-controls")),
+                            )),
+                            Mutation.Create(node(
+                                6,
+                                5,
+                                NodeKind.PRESSABLE,
+                                mapOf(PropKey.TEST_ID to PropValue.Text("stacked-increase")),
+                            )),
+                            Mutation.Create(node(
+                                7,
+                                5,
+                                NodeKind.PRESSABLE,
+                                mapOf(PropKey.TEST_ID to PropValue.Text("stacked-decrease")),
+                            )),
+                            Mutation.Layout(1, Frame(0f, 0f, 360f, 640f)),
+                            Mutation.Layout(2, Frame(16f, 32f, 328f, 64f)),
+                            Mutation.Layout(3, Frame(16f, 48f, 328f, 48f)),
+                            Mutation.Layout(4, Frame(16f, 48f, 276f, 48f)),
+                            Mutation.Layout(5, Frame(296f, 48f, 48f, 48f)),
+                            Mutation.Layout(6, Frame(296f, 48f, 48f, 24f)),
+                            Mutation.Layout(7, Frame(296f, 72f, 48f, 24f)),
+                            Mutation.SetRoot(1),
+                        ),
+                    ),
+                )
+            }
+            instrumentation.waitForIdleSync()
+
+            onMain(instrumentation) {
+                renderer.commit(
+                    listOf(
+                        listOf(
+                            Mutation.Layout(4, Frame(16f, 48f, 276f, 96f)),
+                            Mutation.Layout(5, Frame(296f, 48f, 48f, 96f)),
+                            Mutation.Layout(6, Frame(296f, 48f, 48f, 48f)),
+                            Mutation.Layout(7, Frame(296f, 96f, 48f, 48f)),
+                            // The engine may emit flattened descendants before their
+                            // materialized host. Host relayout must reconcile them.
+                            Mutation.Layout(3, Frame(16f, 48f, 328f, 96f)),
+                            Mutation.Layout(2, Frame(16f, 32f, 328f, 112f)),
+                        ),
+                    ),
+                )
+
+                val density = activity.host.resources.displayMetrics.density
+                val field = requireNotNull(activity.host.findByTransitionName("number-field"))
+                val input = requireNotNull(activity.host.findByTransitionName("stacked-input"))
+                val controls = requireNotNull(
+                    activity.host.findByTransitionName("stacked-controls"),
+                )
+                val increase = requireNotNull(
+                    activity.host.findByTransitionName("stacked-increase"),
+                )
+                val decrease = requireNotNull(
+                    activity.host.findByTransitionName("stacked-decrease"),
+                )
+
+                assertEquals((112f * density).roundToInt(), field.layoutParams.height)
+                assertEquals((96f * density).roundToInt(), input.layoutParams.height)
+                assertEquals((96f * density).roundToInt(), controls.layoutParams.height)
+                assertEquals((48f * density).roundToInt(), increase.layoutParams.height)
+                assertEquals((48f * density).roundToInt(), decrease.layoutParams.height)
+                renderer.close()
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
+    @Test
+    fun safeAreaRestoresTheBottomNavigationInsetAfterLandscapeRoundTrip() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        lateinit var renderer: PamRenderer
+        try {
+            onMain(instrumentation) {
+                renderer = PamRenderer(activity, activity.host) { _, _, _ -> }
+                val density = activity.host.resources.displayMetrics.density
+                val width = activity.host.width / density
+                val height = activity.host.height / density
+                renderer.commit(
+                    listOf(
+                        listOf(
+                            Mutation.Create(node(1, 0, NodeKind.SCREEN)),
+                            Mutation.Create(node(
+                                2,
+                                1,
+                                NodeKind.SAFE_AREA_VIEW,
+                                mapOf(
+                                    PropKey.TEST_ID to PropValue.Text("rotation-safe-area"),
+                                ),
+                            )),
+                            Mutation.Layout(1, Frame(0f, 0f, width, height)),
+                            Mutation.Layout(2, Frame(0f, 0f, width, height)),
+                            Mutation.SetRoot(1),
+                        ),
+                    ),
+                )
+                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            }
+            waitForOrientation(instrumentation, activity, landscape = true)
+            resizeRootToActivity(instrumentation, activity, renderer)
+
+            onMain(instrumentation) {
+                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            }
+            waitForOrientation(instrumentation, activity, landscape = false)
+            resizeRootToActivity(instrumentation, activity, renderer)
+            instrumentation.waitForIdleSync()
+            Thread.sleep(250)
+
+            onMain(instrumentation) {
+                val safeArea = activity.host.findByTransitionName("rotation-safe-area")
+                assertTrue(safeArea is ViewGroup)
+                val expectedBottom = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    activity.host.rootWindowInsets
+                        ?.getInsetsIgnoringVisibility(
+                            WindowInsets.Type.systemBars() or
+                                WindowInsets.Type.displayCutout(),
+                        )
+                        ?.bottom ?: 0
+                } else {
+                    @Suppress("DEPRECATION")
+                    activity.host.rootWindowInsets?.systemWindowInsetBottom ?: 0
+                }
+                assertTrue("Portrait device must expose a bottom navigation inset", expectedBottom > 0)
+                assertEquals(expectedBottom, requireNotNull(safeArea).paddingBottom)
+                renderer.close()
+            }
+        } finally {
+            onMain(instrumentation) {
+                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+                activity.finish()
+            }
+        }
+    }
+
+    @Test
+    fun transparentInputUnderlineRemovesOnlyThePlatformBackground() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            onMain(instrumentation) {
+                val input = PamEditText(activity)
+                val platformBackground = input.background
+                assertTrue(platformBackground != null)
+
+                input.setUnderlineColor(Color.TRANSPARENT)
+                assertNull(input.background)
+
+                input.setUnderlineColor(null)
+                assertSame(platformBackground, input.background)
+
+                val customBackground = ColorDrawable(Color.BLUE)
+                input.background = customBackground
+                input.setUnderlineColor(Color.TRANSPARENT)
+                assertSame(customBackground, input.background)
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
     @Test
     fun keyboardFocusUsesVisibleSystemHighlightAndSkipsDisabledControls() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
@@ -68,6 +264,17 @@ class PamRendererInstrumentedTest {
                 pressable.isEnabled = false
                 assertFalse(pressable.isEnabled)
                 assertFalse(pressable.isFocusable)
+
+                val input = PamEditText(activity)
+                assertTrue(input.isFocusable)
+                assertTrue(input.isFocusableInTouchMode)
+                input.isEnabled = false
+                assertFalse(input.isEnabled)
+                assertFalse(input.isFocusable)
+                assertFalse(input.isFocusableInTouchMode)
+                input.isEnabled = true
+                assertTrue(input.isFocusable)
+                assertTrue(input.isFocusableInTouchMode)
             }
         } finally {
             activity.finish()
@@ -159,6 +366,83 @@ class PamRendererInstrumentedTest {
         val alreadyLarge = minimumTouchTargetInsets(64, 52, 48)
         assertEquals(0, alreadyLarge.left + alreadyLarge.right)
         assertEquals(0, alreadyLarge.top + alreadyLarge.bottom)
+    }
+
+    @Test
+    fun rendererRoutesExpandedMinimumTouchTargetBeforeNormalChildHitTesting() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        val events = ArrayList<Pair<Long, Int>>()
+        lateinit var renderer: PamRenderer
+        try {
+            onMain(instrumentation) {
+                renderer = PamRenderer(activity, activity.host) { id, kind, _ ->
+                    events += id to kind
+                }
+                renderer.commit(
+                    listOf(
+                        listOf(
+                            Mutation.Create(node(1, 0, NodeKind.SCREEN)),
+                            Mutation.Create(node(
+                                2,
+                                1,
+                                NodeKind.PRESSABLE,
+                                mapOf(
+                                    PropKey.ON_PRESS to PropValue.Flag(true),
+                                    PropKey.TEST_ID to PropValue.Text("minimum-target"),
+                                ),
+                            )),
+                            Mutation.Layout(1, Frame(0f, 0f, 360f, 720f)),
+                            Mutation.Layout(2, Frame(100f, 100f, 40f, 40f)),
+                            Mutation.SetRoot(1),
+                        ),
+                    ),
+                )
+            }
+            instrumentation.waitForIdleSync()
+
+            onMain(instrumentation) {
+                val target = requireNotNull(
+                    activity.host.findByTransitionName("minimum-target"),
+                )
+                val parent = target.parent as ViewGroup
+                assertEquals(dp(activity.host, 40f), target.width)
+                assertEquals(dp(activity.host, 40f), target.height)
+
+                val targetLocation = IntArray(2)
+                val parentLocation = IntArray(2)
+                target.getLocationOnScreen(targetLocation)
+                parent.getLocationOnScreen(parentLocation)
+                val x = targetLocation[0] - parentLocation[0] - dp(activity.host, 3f)
+                val y = targetLocation[1] - parentLocation[1] + target.height / 2
+                val downAt = SystemClock.uptimeMillis()
+                val down = MotionEvent.obtain(
+                    downAt,
+                    downAt,
+                    MotionEvent.ACTION_DOWN,
+                    x.toFloat(),
+                    y.toFloat(),
+                    0,
+                )
+                val up = MotionEvent.obtain(
+                    downAt,
+                    downAt + 16,
+                    MotionEvent.ACTION_UP,
+                    x.toFloat(),
+                    y.toFloat(),
+                    0,
+                )
+                assertTrue(parent.dispatchTouchEvent(down))
+                assertTrue(parent.dispatchTouchEvent(up))
+                down.recycle()
+                up.recycle()
+
+                assertEquals(listOf(2L to 1), events)
+                renderer.close()
+            }
+        } finally {
+            activity.finish()
+        }
     }
 
     private fun recordingButton(activity: PamTestActivity, onUp: () -> Unit): Button =
@@ -1490,6 +1774,49 @@ class PamRendererInstrumentedTest {
 
     private fun onMain(instrumentation: Instrumentation, block: () -> Unit) {
         instrumentation.runOnMainSync(block)
+    }
+
+    private fun waitForOrientation(
+        instrumentation: Instrumentation,
+        activity: PamTestActivity,
+        landscape: Boolean,
+    ) {
+        val deadline = SystemClock.uptimeMillis() + 10_000
+        while (SystemClock.uptimeMillis() < deadline) {
+            instrumentation.waitForIdleSync()
+            var matches = false
+            onMain(instrumentation) {
+                matches = if (landscape) {
+                    activity.host.width > activity.host.height
+                } else {
+                    activity.host.height > activity.host.width
+                }
+            }
+            if (matches) return
+            Thread.sleep(100)
+        }
+        throw AssertionError("Test activity did not reach the requested orientation")
+    }
+
+    private fun resizeRootToActivity(
+        instrumentation: Instrumentation,
+        activity: PamTestActivity,
+        renderer: PamRenderer,
+    ) {
+        onMain(instrumentation) {
+            val density = activity.host.resources.displayMetrics.density
+            val width = activity.host.width / density
+            val height = activity.host.height / density
+            renderer.commit(
+                listOf(
+                    listOf(
+                        Mutation.Layout(1, Frame(0f, 0f, width, height)),
+                        Mutation.Layout(2, Frame(0f, 0f, width, height)),
+                    ),
+                ),
+            )
+        }
+        instrumentation.waitForIdleSync()
     }
 
     private fun dp(view: View, value: Float): Int =

--- a/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamScrollContainerInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/pam/nativeapp/render/PamScrollContainerInstrumentedTest.kt
@@ -224,6 +224,150 @@ class PamScrollContainerInstrumentedTest {
     }
 
     @Test
+    fun resizedViewportScrollsFocusedFormTargetIntoVisibleViewport() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var scroll: PamScrollContainer
+            lateinit var input: View
+            onMain(instrumentation) {
+                scroll = PamScrollContainer(activity)
+                val column = FrameLayout(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        1_000,
+                    )
+                }
+                input = View(activity)
+                column.addView(
+                    input,
+                    FrameLayout.LayoutParams(300, 80).apply { topMargin = 720 },
+                )
+                scroll.insert(column)
+                activity.host.addView(scroll, FrameLayout.LayoutParams(300, 400))
+                relayout(activity.host)
+
+                scroll.layoutParams = scroll.layoutParams.apply { height = 200 }
+                relayout(activity.host)
+                // A reactive renderer commit restores its retained offset via
+                // a posted callback immediately before focus reconciliation.
+                scroll.restoreOffsetPixels(0, 0)
+                scroll.ensureViewportTargetVisible(input)
+            }
+            instrumentation.waitForIdleSync()
+            Thread.sleep(120)
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                val targetLocation = IntArray(2)
+                val scrollLocation = IntArray(2)
+                input.getLocationOnScreen(targetLocation)
+                scroll.getLocationOnScreen(scrollLocation)
+
+                assertTrue(scroll.snapshotOffsetPixels().second > 0)
+                val targetBottom = targetLocation[1] + input.height
+                val viewportBottom = scrollLocation[1] + scroll.height
+                assertTrue(
+                    "targetBottom=$targetBottom viewportBottom=$viewportBottom " +
+                        "offset=${scroll.snapshotOffsetPixels().second}",
+                    targetBottom <= viewportBottom,
+                )
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
+    @Test
+    fun keyboardClearanceAtContentEndClampsWithoutRepeatedScrolling() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var scroll: PamScrollContainer
+            lateinit var input: View
+            var viewportEvents = 0
+            onMain(instrumentation) {
+                scroll = PamScrollContainer(activity)
+                val column = FrameLayout(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        1_000,
+                    )
+                }
+                input = View(activity)
+                column.addView(
+                    input,
+                    FrameLayout.LayoutParams(300, 80).apply { topMargin = 920 },
+                )
+                scroll.insert(column)
+                scroll.setOnViewportChanged { _, _ -> viewportEvents += 1 }
+                activity.host.addView(scroll, FrameLayout.LayoutParams(300, 200))
+                relayout(activity.host)
+                scroll.ensureViewportTargetVisible(input)
+            }
+            instrumentation.waitForIdleSync()
+            val eventsAtEnd = viewportEvents
+            onMain(instrumentation) {
+                assertEquals(800, scroll.snapshotOffsetPixels().second)
+                scroll.ensureViewportTargetVisible(input)
+            }
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                assertEquals(800, scroll.snapshotOffsetPixels().second)
+                assertEquals(eventsAtEnd, viewportEvents)
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
+    @Test
+    fun constrainedKeyboardViewportUsesStableSymmetricClearance() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = launchActivity(instrumentation)
+        try {
+            lateinit var scroll: PamScrollContainer
+            lateinit var input: View
+            var viewportEvents = 0
+            onMain(instrumentation) {
+                scroll = PamScrollContainer(activity)
+                val column = FrameLayout(activity).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        1_000,
+                    )
+                }
+                input = View(activity)
+                column.addView(
+                    input,
+                    FrameLayout.LayoutParams(300, 73).apply { topMargin = 800 },
+                )
+                scroll.insert(column)
+                scroll.setOnViewportChanged { _, _ -> viewportEvents += 1 }
+                activity.host.addView(scroll, FrameLayout.LayoutParams(300, 85))
+                relayout(activity.host)
+                scroll.ensureViewportTargetVisible(input)
+            }
+            instrumentation.waitForIdleSync()
+            val stableOffset = scroll.snapshotOffsetPixels().second
+            val stableEvents = viewportEvents
+            onMain(instrumentation) {
+                // Only twelve pixels remain around a 73px editor. Splitting
+                // those pixels evenly keeps both edges visible and prevents
+                // alternating between incompatible top/bottom clearances.
+                assertEquals(794, stableOffset)
+                scroll.ensureViewportTargetVisible(input)
+            }
+            instrumentation.waitForIdleSync()
+            onMain(instrumentation) {
+                assertEquals(stableOffset, scroll.snapshotOffsetPixels().second)
+                assertEquals(stableEvents, viewportEvents)
+            }
+        } finally {
+            activity.finish()
+        }
+    }
+
+    @Test
     fun requestScrollJumpsToEndOrIdentifiedDescendant() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val activity = launchActivity(instrumentation)

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -8,6 +8,7 @@
         tools:replace="android:usesCleartextTraffic">
         <activity
             android:name=".PamTestActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:exported="false"
             android:theme="@android:style/Theme.Material.Light.NoActionBar" />
         <activity

--- a/android/app/src/debug/java/dev/pam/nativeapp/PamTestActivity.kt
+++ b/android/app/src/debug/java/dev/pam/nativeapp/PamTestActivity.kt
@@ -1,6 +1,7 @@
 package dev.pam.nativeapp
 
 import android.os.Bundle
+import androidx.core.view.WindowCompat
 import androidx.fragment.app.FragmentActivity
 import dev.pam.nativeapp.render.PamRootHost
 
@@ -11,6 +12,10 @@ class PamTestActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Match PamActivity's edge-to-edge contract so renderer integration
+        // tests exercise PAM-owned system-bar insets instead of decor-fitted
+        // coordinates that have already consumed them.
+        WindowCompat.enableEdgeToEdge(window)
         host
     }
 }

--- a/android/app/src/main/java/dev/pam/nativeapp/PamActivity.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/PamActivity.kt
@@ -62,6 +62,9 @@ class PamActivity : FragmentActivity() {
     private val diagnosticsExecutor: ExecutorService = Executors.newSingleThreadExecutor()
     private var viewportWidth = 0
     private var viewportHeight = 0
+    private var viewportUpdateScheduled = false
+    private var viewportUpdateReplayRequested = false
+    private var forceScheduledViewportUpdate = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -144,9 +147,9 @@ class PamActivity : FragmentActivity() {
                 isDarkAppearance(),
             )
             runtimeStarted = true
-            rootHost.onStableInsetsChanged = { updateViewportFromWindow() }
+            rootHost.onStableInsetsChanged = { scheduleViewportUpdate() }
             window.decorView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                updateViewportFromWindow()
+                scheduleViewportUpdate()
             }
             if (BuildConfig.DEBUG) {
                 hotReload = HotReloadClient(
@@ -202,7 +205,7 @@ class PamActivity : FragmentActivity() {
         super.onConfigurationChanged(newConfig)
         if (!runtimeStarted) return
         applyDefaultSystemBars()
-        updateViewportFromWindow(force = true)
+        scheduleViewportUpdate(force = true)
     }
 
     @Suppress("DEPRECATION")
@@ -230,16 +233,32 @@ class PamActivity : FragmentActivity() {
         super.onLowMemory()
     }
 
+    // API 33+ is handled by registerBackCallback(), including predictive
+    // progress on API 34+. These overrides are the legacy keyboard/button
+    // path retained exclusively for older supported Android releases.
+    @SuppressLint("GestureBackNavigation")
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-        if (
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU &&
-            keyCode == KeyEvent.KEYCODE_BACK
-        ) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
             if (consumeSuppressedBack()) return true
-            runtime.dispatchBack()
-            return true
+            if (runtime.consumePresentedModalBack()) return true
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                runtime.dispatchBack()
+                return true
+            }
         }
         return super.onKeyUp(keyCode, event)
+    }
+
+    @Suppress("DEPRECATION")
+    @SuppressLint("GestureBackNavigation")
+    override fun onBackPressed() {
+        if (!runtimeStarted) {
+            super.onBackPressed()
+            return
+        }
+        if (consumeSuppressedBack()) return
+        if (runtime.consumePresentedModalBack()) return
+        runtime.dispatchBack()
     }
 
     internal fun launchForResult(intent: Intent, callback: (Int, Intent?) -> Unit) {
@@ -392,7 +411,11 @@ class PamActivity : FragmentActivity() {
                 private var interactive = false
 
                 override fun onBackStarted(backEvent: BackEvent) {
-                    interactive = rootHost.startPredictiveBack()
+                    interactive = if (runtime.hasPresentedModal()) {
+                        false
+                    } else {
+                        rootHost.startPredictiveBack()
+                    }
                 }
 
                 override fun onBackProgressed(backEvent: BackEvent) {
@@ -410,6 +433,11 @@ class PamActivity : FragmentActivity() {
                         interactive = false
                         return
                     }
+                    if (runtime.consumePresentedModalBack()) {
+                        if (interactive) rootHost.cancelPredictiveBack()
+                        interactive = false
+                        return
+                    }
                     if (interactive) rootHost.commitPredictiveBack()
                     interactive = false
                     runtime.dispatchBack()
@@ -417,7 +445,12 @@ class PamActivity : FragmentActivity() {
             }
         } else {
             OnBackInvokedCallback {
-                if (!consumeSuppressedBack()) runtime.dispatchBack()
+                if (
+                    !consumeSuppressedBack()
+                    && !runtime.consumePresentedModalBack()
+                ) {
+                    runtime.dispatchBack()
+                }
             }
         }.also { callback ->
             onBackInvokedDispatcher.registerOnBackInvokedCallback(
@@ -433,7 +466,6 @@ class PamActivity : FragmentActivity() {
 
     private fun consumeSuppressedBack(): Boolean {
         if (SystemClock.uptimeMillis() > suppressBackUntil) return false
-        suppressBackUntil = 0L
         return true
     }
 
@@ -465,8 +497,35 @@ class PamActivity : FragmentActivity() {
     }
 
     private fun resolvedViewportSize(): Pair<Int, Int> {
-        val (width, height) = fullWindowSize()
-        return width to height
+        val (windowWidth, windowHeight) = fullWindowSize()
+        return resolvedViewportSize(
+            laidOutWidth = window.decorView.width,
+            laidOutHeight = window.decorView.height,
+            windowWidth = windowWidth,
+            windowHeight = windowHeight,
+        )
+    }
+
+    private fun scheduleViewportUpdate(force: Boolean = false) {
+        forceScheduledViewportUpdate = forceScheduledViewportUpdate || force
+        if (viewportUpdateScheduled) {
+            // A configuration callback can enqueue a pre-layout read before
+            // decorView receives its new orientation bounds. Do not discard a
+            // later onLayout signal just because that stale read is pending.
+            viewportUpdateReplayRequested = true
+            return
+        }
+        viewportUpdateScheduled = true
+        window.decorView.post {
+            viewportUpdateScheduled = false
+            val shouldForce = forceScheduledViewportUpdate
+            forceScheduledViewportUpdate = false
+            updateViewportFromWindow(force = shouldForce)
+            if (viewportUpdateReplayRequested) {
+                viewportUpdateReplayRequested = false
+                scheduleViewportUpdate()
+            }
+        }
     }
 
     private fun updateViewportFromWindow(force: Boolean = false) {
@@ -589,6 +648,6 @@ class PamActivity : FragmentActivity() {
         const val APPEARANCE_LIGHT = 1L
         const val APPEARANCE_DARK = 2L
         const val MAX_RUNTIME_RECOVERY_ATTEMPTS = 3
-        const val BACK_SUPPRESSION_WINDOW_MS = 250L
+        const val BACK_SUPPRESSION_WINDOW_MS = 1_000L
     }
 }

--- a/android/app/src/main/java/dev/pam/nativeapp/PamRuntime.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/PamRuntime.kt
@@ -143,6 +143,10 @@ class PamRuntime(
         dispatchEvent(0, EVENT_BACK)
     }
 
+    fun hasPresentedModal(): Boolean = renderer.hasPresentedModal()
+
+    fun consumePresentedModalBack(): Boolean = renderer.consumePresentedModalBack()
+
     fun reload(
         entryPath: String,
         confirmedAtNanos: Long? = null,
@@ -455,6 +459,11 @@ class PamRuntime(
         val current = ArrayList<PendingBatch>(pendingBatches.size)
         while (pendingBatches.isNotEmpty()) {
             current += pendingBatches.removeFirst()
+        }
+        if (renderer.isLayoutInProgress()) {
+            current.asReversed().forEach(pendingBatches::addFirst)
+            scheduleFrame()
+            return
         }
         val started = System.nanoTime()
         var committed = false

--- a/android/app/src/main/java/dev/pam/nativeapp/ViewportSize.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/ViewportSize.kt
@@ -1,0 +1,18 @@
+package dev.pam.nativeapp
+
+/**
+ * Prefer the viewport Android has actually laid out. On some devices,
+ * currentWindowMetrics briefly keeps the previous orientation's bounds after
+ * onConfigurationChanged. Sending those stale bounds to PAM leaves responsive
+ * navigation and Yoga frames in landscape after the native window is portrait.
+ */
+internal fun resolvedViewportSize(
+    laidOutWidth: Int,
+    laidOutHeight: Int,
+    windowWidth: Int,
+    windowHeight: Int,
+): Pair<Int, Int> = if (laidOutWidth > 0 && laidOutHeight > 0) {
+    laidOutWidth to laidOutHeight
+} else {
+    windowWidth.coerceAtLeast(0) to windowHeight.coerceAtLeast(0)
+}

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamContainer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamContainer.kt
@@ -28,8 +28,21 @@ internal open class PamContainer(context: Context) :
 
     override fun shouldDelayChildPressedState(): Boolean = false
 
-    override fun dispatchTouchEvent(event: MotionEvent): Boolean =
-        pointerEvents != POINTER_EVENTS_NONE && super.dispatchTouchEvent(event)
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (pointerEvents == POINTER_EVENTS_NONE) return false
+
+        // ViewGroup's normal dispatch can accept the delegated ACTION_DOWN as
+        // the container's own event and then skip the TouchDelegate on
+        // ACTION_UP when the pointer started outside the child's visual
+        // bounds. Route PAM's grouped delegates before child hit testing so a
+        // compact 40dp control receives the complete 48dp Material gesture.
+        val delegated = if (pointerEvents == POINTER_EVENTS_BOX_ONLY) {
+            false
+        } else {
+            (touchDelegate as? PamTouchDelegateGroup)?.onTouchEvent(event) == true
+        }
+        return delegated || super.dispatchTouchEvent(event)
+    }
 
     override fun onInterceptTouchEvent(event: MotionEvent): Boolean =
         when (pointerEvents) {

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamDrawerLayout.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.Rect
 import android.graphics.drawable.ColorDrawable
 import android.view.MotionEvent
 import android.view.View
@@ -15,6 +16,25 @@ import android.view.WindowInsetsController
 import android.view.inputmethod.InputMethodManager
 import android.widget.FrameLayout
 import kotlin.math.abs
+
+internal fun drawerIsVisuallyOpen(requestedOpen: Boolean, permanent: Boolean): Boolean =
+    requestedOpen || permanent
+
+internal fun permanentDrawerContentClip(
+    viewportLeft: Int,
+    viewportRight: Int,
+    drawerWidth: Int,
+    right: Boolean,
+): Pair<Int, Int> {
+    val safeLeft = viewportLeft.coerceAtLeast(0)
+    val safeRight = viewportRight.coerceAtLeast(safeLeft)
+    val reservation = drawerWidth.coerceIn(0, safeRight - safeLeft)
+    return if (right) {
+        safeLeft + reservation to safeRight
+    } else {
+        safeLeft to safeRight - reservation
+    }
+}
 
 internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     private var open = false
@@ -33,6 +53,7 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     private var gestureStartProgress = 0f
     private var tracking = false
     private var progress = 0f
+    private var progressAnimator: ValueAnimator? = null
     private var onOpen: (() -> Unit)? = null
     private var onClose: (() -> Unit)? = null
     private val overlayPaint = Paint(Paint.ANTI_ALIAS_FLAG)
@@ -44,6 +65,7 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     private var viewportBaseBottomPadding = 0
     private var statusBarAppearanceBeforeOpen: Int? = null
     private var systemUiVisibilityBeforeOpen: Int? = null
+    private val permanentContentClipBounds = Rect()
 
     init {
         clipChildren = false
@@ -109,17 +131,20 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
 
     fun setOpen(value: Boolean, animated: Boolean = true) {
         val permanent = resolvedType() == TYPE_PERMANENT
-        val next = value || permanent
-        if (open == next && animated) {
-            updateDrawer(true)
+        val wasVisuallyOpen = drawerIsVisuallyOpen(open, permanent)
+        if (open == value) {
+            updateDrawer(false)
             return
         }
-        val changed = open != next
-        open = next
+        open = value
+        val isVisuallyOpen = drawerIsVisuallyOpen(open, permanent)
         updateStatusBar()
-        updateDrawer(animated)
-        if (changed) {
-            if (open) onOpen?.invoke() else onClose?.invoke()
+        // Requested state can change while a permanent drawer remains
+        // visually open. Animating that no-op retains a stale permanent
+        // content translation after DRAWER_TYPE changes back to Front.
+        updateDrawer(animated && wasVisuallyOpen != isVisuallyOpen)
+        if (wasVisuallyOpen != isVisuallyOpen) {
+            if (isVisuallyOpen) onOpen?.invoke() else onClose?.invoke()
         }
     }
 
@@ -188,6 +213,7 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
             super.dispatchDraw(canvas)
             return
         }
+        updatePermanentContentClip(content)
         val drawingTime = drawingTime
         if (resolvedType() == TYPE_BACK) {
             drawChild(canvas, drawer, drawingTime)
@@ -290,23 +316,31 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     private fun updateDrawer(animated: Boolean) {
         val content = getChildAt(0) ?: return
         val drawer = getChildAt(1) ?: return
+        content.animate().cancel()
+        drawer.animate().cancel()
+        progressAnimator?.cancel()
+        progressAnimator = null
         val type = resolvedType()
-        if (type == TYPE_PERMANENT) open = true
+        val visuallyOpen = drawerIsVisuallyOpen(open, type == TYPE_PERMANENT)
         val width = drawerWidthPx()
         val direction = if (isRight()) -1f else 1f
         val openX = if (isRight()) this.width.toFloat() - width else 0f
         val closedX = if (isRight()) this.width.toFloat() else -width
         val drawerTarget = when (type) {
-            TYPE_BACK, TYPE_PERMANENT -> openX
-            TYPE_SLIDE -> if (open) openX else openX + (closedX - openX) * 0.35f
-            else -> if (open) openX else closedX
+            TYPE_PERMANENT -> 0f
+            TYPE_BACK -> openX
+            TYPE_SLIDE -> if (visuallyOpen) openX else openX + (closedX - openX) * 0.35f
+            else -> if (visuallyOpen) openX else closedX
         }
         val contentTarget = when (type) {
-            TYPE_BACK, TYPE_SLIDE -> if (open) direction * width else 0f
-            TYPE_PERMANENT -> direction * width
+            TYPE_BACK, TYPE_SLIDE -> if (visuallyOpen) direction * width else 0f
+            // The engine gives permanent drawer children disjoint frames, so
+            // translating either child here would reserve the drawer twice.
+            TYPE_PERMANENT -> 0f
             else -> 0f
         }
-        val targetProgress = if (open && type != TYPE_PERMANENT) 1f else 0f
+        val targetProgress = if (visuallyOpen && type != TYPE_PERMANENT) 1f else 0f
+        updatePermanentContentClip(content)
         if (!animated || PamMotionPolicy.isReduced(context)) {
             drawer.translationX = drawerTarget
             content.translationX = contentTarget
@@ -316,7 +350,7 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
         }
         drawer.animate().translationX(drawerTarget).setDuration(200).start()
         content.animate().translationX(contentTarget).setDuration(200).start()
-        ValueAnimator.ofFloat(progress, targetProgress).apply {
+        progressAnimator = ValueAnimator.ofFloat(progress, targetProgress).apply {
             duration = 200
             addUpdateListener {
                 progress = it.animatedValue as Float
@@ -366,6 +400,32 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
     private fun drawerWidthPx(): Float = dp(drawerWidthDp).coerceAtMost(width.toFloat())
     private fun dp(value: Float): Float = value * resources.displayMetrics.density
 
+    private fun updatePermanentContentClip(content: View) {
+        if (resolvedType() != TYPE_PERMANENT || content.width <= 0 || content.height <= 0) {
+            if (content.clipBounds != null) content.clipBounds = null
+            return
+        }
+        val reservation = drawerWidthPx().toInt()
+        val partitionedContentWidth = (width - reservation).coerceAtLeast(0)
+        if (content.width <= partitionedContentWidth + 1) {
+            if (content.clipBounds != null) content.clipBounds = null
+            return
+        }
+        val safeViewport = (content as? ViewGroup)?.getChildAt(0)
+        val viewportLeft = safeViewport?.left ?: 0
+        val viewportRight = safeViewport?.right ?: content.width
+        val (left, right) = permanentDrawerContentClip(
+            viewportLeft = viewportLeft,
+            viewportRight = viewportRight,
+            drawerWidth = reservation,
+            right = isRight(),
+        )
+        permanentContentClipBounds.set(left, 0, right, content.height)
+        if (content.clipBounds != permanentContentClipBounds) {
+            content.clipBounds = permanentContentClipBounds
+        }
+    }
+
     private fun enforceDrawerViewport(drawer: View) {
         if (insetDrawer !== drawer) {
             insetDrawer = drawer
@@ -377,12 +437,28 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
             drawer.paddingRight,
             maxOf(drawerBaseBottomPadding, navigationInsetBottom),
         )
-        val drawerParams = (drawer.layoutParams as? LayoutParams)
-            ?: LayoutParams(drawerWidthPx().toInt(), ViewGroup.LayoutParams.MATCH_PARENT)
-        drawerParams.width = drawerWidthPx().toInt()
-        drawerParams.height = ViewGroup.LayoutParams.MATCH_PARENT
-        drawerParams.topMargin = if (resolvedType() == TYPE_PERMANENT) statusInsetTop else 0
-        drawer.layoutParams = drawerParams
+        val drawerWidth = drawerWidthPx().toInt()
+        val drawerTop = if (resolvedType() == TYPE_PERMANENT) statusInsetTop else 0
+        val drawerParams = drawer.layoutParams as? LayoutParams
+        if (drawerParams == null) {
+            drawer.postOnAnimation {
+                drawer.layoutParams = LayoutParams(
+                    drawerWidth,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                ).apply { topMargin = drawerTop }
+            }
+        } else if (
+            drawerParams.width != drawerWidth
+            || drawerParams.height != ViewGroup.LayoutParams.MATCH_PARENT
+            || drawerParams.topMargin != drawerTop
+        ) {
+            drawerParams.width = drawerWidth
+            drawerParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+            drawerParams.topMargin = drawerTop
+            drawer.postOnAnimation {
+                if (drawer.isAttachedToWindow) drawer.requestLayout()
+            }
+        }
         val viewport = (drawer as? ViewGroup)?.getChildAt(0) ?: return
         if (insetViewport !== viewport) {
             insetViewport = viewport
@@ -395,12 +471,23 @@ internal class PamDrawerLayout(context: Context) : FrameLayout(context) {
             maxOf(viewportBaseBottomPadding, navigationInsetBottom),
         )
         (viewport as? ViewGroup)?.clipToPadding = true
-        viewport.layoutParams = (viewport.layoutParams ?: LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.MATCH_PARENT,
-        )).apply {
-            width = ViewGroup.LayoutParams.MATCH_PARENT
-            height = ViewGroup.LayoutParams.MATCH_PARENT
+        val viewportParams = viewport.layoutParams
+        if (viewportParams == null) {
+            viewport.postOnAnimation {
+                viewport.layoutParams = LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            }
+        } else if (
+            viewportParams.width != ViewGroup.LayoutParams.MATCH_PARENT
+            || viewportParams.height != ViewGroup.LayoutParams.MATCH_PARENT
+        ) {
+            viewportParams.width = ViewGroup.LayoutParams.MATCH_PARENT
+            viewportParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+            viewport.postOnAnimation {
+                if (viewport.isAttachedToWindow) viewport.requestLayout()
+            }
         }
     }
 

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamEditText.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamEditText.kt
@@ -2,6 +2,7 @@ package dev.pam.nativeapp.render
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.text.Editable
@@ -11,6 +12,8 @@ import android.view.ActionMode
 import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
+import android.view.WindowInsets
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputConnectionWrapper
@@ -21,6 +24,7 @@ internal class PamEditText @JvmOverloads constructor(
     attributes: AttributeSet? = null,
 ) : EditText(context, attributes) {
     private var editableKeyListener: KeyListener? = keyListener
+    private val originalBackground = background
     private val originalBackgroundTint = backgroundTintList
     private val originalCursorState: Drawable.ConstantState? =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -30,11 +34,19 @@ internal class PamEditText @JvmOverloads constructor(
         }
     private var contextMenuHidden = false
     private var contentSizeScheduled = false
+    private var focusVisibilityScheduled = false
     private var lastContentWidth = -1
     private var lastContentHeight = -1
     private var selectionCallback: ((Int, Int) -> Unit)? = null
     private var contentSizeCallback: ((Int, Int) -> Unit)? = null
     private var keyCallback: ((String) -> Unit)? = null
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+        isFocusable = enabled
+        isFocusableInTouchMode = enabled
+        if (!enabled) clearFocus()
+    }
 
     fun setInputCallbacks(
         selection: ((Int, Int) -> Unit)?,
@@ -86,6 +98,16 @@ internal class PamEditText @JvmOverloads constructor(
     }
 
     fun setUnderlineColor(color: Int?) {
+        val transparent = color != null && Color.alpha(color) == 0
+        if (transparent && background === originalBackground) {
+            // A transparent tint still lets the framework EditText drawable
+            // paint its focused accent on some Android versions. Remove only
+            // that original platform drawable; never discard a custom PAM
+            // background that may have been applied afterwards.
+            background = null
+        } else if (!transparent && background == null && originalBackground != null) {
+            background = originalBackground
+        }
         backgroundTintList = color?.let(ColorStateList::valueOf)
             ?: originalBackgroundTint
     }
@@ -114,6 +136,36 @@ internal class PamEditText @JvmOverloads constructor(
     ) {
         super.onLayout(changed, left, top, right, bottom)
         scheduleContentSize()
+        scheduleFocusedVisibility()
+    }
+
+    private fun scheduleFocusedVisibility(attempt: Int = 0) {
+        if (!hasFocus() || focusVisibilityScheduled) return
+        focusVisibilityScheduled = true
+        postDelayed({
+            focusVisibilityScheduled = false
+            if (!isAttachedToWindow || !hasFocus()) return@postDelayed
+            val imeVisible = !(
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                rootWindowInsets?.isVisible(WindowInsets.Type.ime()) != true
+            )
+            if (imeVisible) {
+                var ancestor = parent as? View
+                while (ancestor != null) {
+                    if (ancestor is PamScrollContainer) {
+                        ancestor.ensureViewportTargetVisible(this)
+                        break
+                    }
+                    ancestor = ancestor.parent as? View
+                }
+            }
+            // Orientation dispatches layout before the replacement IME inset
+            // is necessarily visible. Reconcile for a bounded settling window;
+            // losing focus cancels the chain on the next callback.
+            if (attempt < FOCUS_VISIBILITY_RETRIES) {
+                scheduleFocusedVisibility(attempt + 1)
+            }
+        }, if (attempt == 0) 0L else FOCUS_VISIBILITY_RETRY_MS)
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
@@ -184,6 +236,8 @@ internal class PamEditText @JvmOverloads constructor(
         }
 
     private companion object {
+        const val FOCUS_VISIBILITY_RETRIES = 8
+        const val FOCUS_VISIBILITY_RETRY_MS = 100L
         const val MAX_KEY_BYTES = 64
         val BLOCKED_ACTION_MODE = object : ActionMode.Callback {
             override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean =

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamModalHost.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamModalHost.kt
@@ -3,6 +3,7 @@ package dev.pam.nativeapp.render
 import android.animation.ValueAnimator
 import android.app.Dialog
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.PixelFormat
@@ -10,6 +11,7 @@ import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.GradientDrawable
 import android.graphics.Outline
 import android.os.Build
+import android.util.AttributeSet
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -53,7 +55,23 @@ internal fun interactiveBottomSheetLayout(
     return baseHeight.coerceAtLeast(1) to translation
 }
 
-internal class PamModalHost(context: Context) : FrameLayout(context) {
+internal fun blocksModalDismissal(dismissible: Boolean): Boolean = !dismissible
+
+internal fun isPointOutsideModalChild(
+    x: Float,
+    y: Float,
+    left: Int,
+    top: Int,
+    right: Int,
+    bottom: Int,
+): Boolean = x < left || x >= right || y < top || y >= bottom
+
+internal class PamModalHost @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    private val onBackConsumed: (() -> Unit)? = null,
+) : FrameLayout(context, attrs, defStyleAttr) {
     private val content = PamModalContent(context)
     private val handle = View(context)
     private var dialog: Dialog? = null
@@ -90,6 +108,7 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
     private var dragStartY = 0f
     private var dragActive = false
     private var dragFromHandle = false
+    private var modalBackdropPressed = false
     private var dragVelocity: VelocityTracker? = null
 
     private val updateRunnable = Runnable {
@@ -130,7 +149,7 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
             }
             insets
         }
-        content.observeMotion = ::onBottomSheetMotion
+        content.observeMotion = ::onModalMotion
     }
 
     fun insert(view: View, index: Int) {
@@ -144,6 +163,7 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
         if (presentation == value) return
         presentation = value
         dialog?.let {
+            applyDismissPolicy(it)
             applyWindowConfiguration(it)
             applyWindowLayout(it)
         }
@@ -209,6 +229,7 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
 
     fun setBottomSheetDismissible(value: Boolean) {
         bottomSheetDismissible = value
+        dialog?.let(::applyDismissPolicy)
     }
 
     fun setBottomSheetBackdropDismiss(value: Boolean) {
@@ -297,6 +318,19 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
         dragVelocity = null
     }
 
+    fun isPresented(): Boolean = dialog?.isShowing == true
+
+    /**
+     * Activity-level fallback for synthetic/OEM Back dispatch that reaches
+     * both the dialog and its host activity. A visible modal always owns Back;
+     * the activity must never pop its navigator or finish underneath it.
+     */
+    fun consumeActivityBack(): Boolean {
+        if (!isPresented()) return false
+        if (desiredVisible) requestCloseFromBack()
+        return true
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         scheduleUpdate()
@@ -353,7 +387,8 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
             modal.requestWindowFeature(Window.FEATURE_NO_TITLE)
             (content.parent as? ViewGroup)?.removeView(content)
             modal.setContentView(content)
-            modal.setCanceledOnTouchOutside(false)
+            applyDismissPolicy(modal)
+            modal.setOnCancelListener { requestClose() }
             modal.setOnKeyListener { _, keyCode, event ->
                 if (
                     keyCode == KeyEvent.KEYCODE_BACK
@@ -403,7 +438,7 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
     }
 
     private fun requestClose() {
-        if (!bottomSheetDismissible && presentation == PRESENTATION_SHEET) return
+        if (blocksModalDismissal(bottomSheetDismissible)) return
         desiredVisible = false
         val callback = onRequestClose
         if (callback != null) {
@@ -412,6 +447,17 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
             return
         }
         dismiss(notify = true, animated = true)
+    }
+
+    private fun applyDismissPolicy(modal: Dialog) {
+        val dismissible = !blocksModalDismissal(bottomSheetDismissible)
+        modal.setCancelable(dismissible)
+        // Sheets own their backdrop gesture inside PamModalContent. Dialog
+        // windows have platform decor insets outside that content, so Android
+        // itself must observe those touches and report them through onCancel.
+        modal.setCanceledOnTouchOutside(
+            presentation != PRESENTATION_SHEET && dismissible,
+        )
     }
 
     private fun registerDialogBackCallback(modal: Dialog) {
@@ -441,8 +487,18 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
 
     private fun requestCloseFromBack() {
         if (hideVisibleKeyboard()) return
-        (context as? PamActivity)?.suppressNextPamBack()
+        onBackConsumed?.invoke()
+        pamActivity()?.suppressNextPamBack()
         requestClose()
+    }
+
+    private fun pamActivity(): PamActivity? {
+        var current: Context? = context
+        while (current is ContextWrapper) {
+            if (current is PamActivity) return current
+            current = current.baseContext
+        }
+        return current as? PamActivity
     }
 
     private fun hideVisibleKeyboard(): Boolean {
@@ -550,8 +606,28 @@ internal class PamModalHost(context: Context) : FrameLayout(context) {
         updateBottomSheetChrome()
     }
 
-    private fun onBottomSheetMotion(event: MotionEvent) {
-        if (presentation != PRESENTATION_SHEET) return
+    private fun onModalMotion(event: MotionEvent) {
+        if (presentation != PRESENTATION_SHEET) {
+            val modalChild = sheetChild() ?: return
+            val outside = isPointOutsideModalChild(
+                event.x,
+                event.y,
+                modalChild.left,
+                modalChild.top,
+                modalChild.right,
+                modalChild.bottom,
+            )
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> modalBackdropPressed = outside
+                MotionEvent.ACTION_UP -> {
+                    val shouldDismiss = modalBackdropPressed && outside
+                    modalBackdropPressed = false
+                    if (shouldDismiss) requestClose()
+                }
+                MotionEvent.ACTION_CANCEL -> modalBackdropPressed = false
+            }
+            return
+        }
         val sheet = sheetChild() ?: return
         val sheetTop = content.height - sheet.height
         when (event.actionMasked) {
@@ -867,5 +943,18 @@ private class PamModalContent(context: Context) : FrameLayout(context) {
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
         observeMotion?.invoke(event)
         return super.dispatchTouchEvent(event)
+    }
+
+    // Keep a gesture that starts on the otherwise empty backdrop alive until
+    // ACTION_UP. Child controls still receive events first through
+    // dispatchTouchEvent, so this only consumes touches no descendant handled.
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_UP) performClick()
+        return true
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
     }
 }

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamRenderer.kt
@@ -86,6 +86,18 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 
+/**
+ * PAM's layout engine sends physical x/y coordinates. Keep FrameLayout from
+ * resolving its implicit START gravity again when a parent is RTL, otherwise
+ * every absolutely positioned child is anchored to the right edge.
+ */
+@SuppressLint("RtlHardcoded")
+internal const val PAM_PHYSICAL_FRAME_GRAVITY: Int = Gravity.TOP or Gravity.LEFT
+
+private const val LOCAL_MODAL_SELECTION_BEHAVIOR = 24L
+private const val KEYBOARD_VIEWPORT_RECONCILE_RETRIES = 8
+private const val KEYBOARD_VIEWPORT_RECONCILE_RETRY_MS = 100L
+
 internal inline fun <reified T> snapshotValues(
     size: Int,
     valueAt: (Int) -> Any?,
@@ -109,8 +121,29 @@ internal fun resolvedKeyboardInset(
     return max(platformInset, resizedInset)
 }
 
+internal fun isLocalModalSelectionEvent(properties: PropValue?): Boolean {
+    val host = (properties as? PropValue.Properties)?.value ?: return false
+    val behavior = (host["behavior"] as? WireValue.Integer)?.value ?: return false
+
+    return behavior == LOCAL_MODAL_SELECTION_BEHAVIOR
+}
+
 internal fun visibleImeInset(rawInset: Int, visible: Boolean): Int =
     if (visible) rawInset.coerceAtLeast(0) else 0
+
+internal fun keyboardTopForInset(windowBottom: Int, keyboardInset: Int): Int =
+    windowBottom - keyboardInset.coerceAtLeast(0)
+
+internal fun keyboardOverlapForBounds(
+    originalBottom: Float,
+    windowBottom: Int,
+    keyboardInset: Int,
+    offset: Int,
+): Int {
+    val keyboardTop = keyboardTopForInset(windowBottom, keyboardInset)
+    val visibleBottom = min(originalBottom, windowBottom.toFloat())
+    return max(0, (visibleBottom - keyboardTop + offset).toInt())
+}
 
 internal fun interactiveKeyboardTranslation(
     keyboardOverlap: Int,
@@ -134,6 +167,14 @@ internal fun keyboardAvoidingViewportHeight(
 internal fun keyboardAvoidingBehaviorReducesViewport(behavior: Int): Boolean =
     behavior == 1 || behavior == 3
 
+internal fun useDarkStatusBarIcons(
+    systemBarsAppearance: Int?,
+    darkTheme: Boolean,
+    lightStatusBarMask: Int,
+): Boolean = systemBarsAppearance?.let { appearance ->
+    appearance and lightStatusBarMask != 0
+} ?: !darkTheme
+
 internal fun safeAreaChildCrossAxisReduction(
     mainAxisHorizontal: Boolean,
     horizontalInsets: Int,
@@ -143,6 +184,26 @@ internal fun safeAreaChildCrossAxisReduction(
 } else {
     horizontalInsets to 0
 }
+
+internal fun measuredCrossAxisViewportReduction(
+    mainAxisHorizontal: Boolean,
+    engineWidth: Int,
+    measuredWidth: Int,
+    engineHeight: Int,
+    measuredHeight: Int,
+): Pair<Int, Int> = safeAreaChildCrossAxisReduction(
+    mainAxisHorizontal = mainAxisHorizontal,
+    horizontalInsets = if (measuredWidth > 0) {
+        (engineWidth - measuredWidth).coerceAtLeast(0)
+    } else {
+        0
+    },
+    verticalInsets = if (measuredHeight > 0) {
+        (engineHeight - measuredHeight).coerceAtLeast(0)
+    } else {
+        0
+    },
+)
 
 internal fun safeAreaFlexViewportExtent(
     layoutExtent: Int,
@@ -157,9 +218,31 @@ internal fun safeAreaFlexViewportExtent(
         }
     }
 
+internal fun safeAreaLayoutBoundsChanged(
+    left: Int,
+    top: Int,
+    right: Int,
+    bottom: Int,
+    oldLeft: Int,
+    oldTop: Int,
+    oldRight: Int,
+    oldBottom: Int,
+): Boolean =
+    left != oldLeft || top != oldTop || right != oldRight || bottom != oldBottom
+
 internal fun measuredParentExtent(measuredExtent: Int, layoutParamExtent: Int): Int =
     measuredExtent.takeIf { it > 0 }
         ?: layoutParamExtent.coerceAtLeast(0)
+
+internal fun parentViewportMeasurementIsStale(
+    measuredExtent: Int,
+    layoutParamExtent: Int,
+    layoutRequested: Boolean,
+): Boolean =
+    layoutRequested &&
+        measuredExtent > 0 &&
+        layoutParamExtent > 0 &&
+        measuredExtent != layoutParamExtent
 
 internal fun hostedContentExtent(
     measuredExtent: Int,
@@ -167,6 +250,9 @@ internal fun hostedContentExtent(
     nativePadding: Int,
 ): Int = (measuredParentExtent(measuredExtent, layoutParamExtent) - nativePadding)
     .coerceAtLeast(0)
+
+internal fun usesNativeViewGroupPadding(kind: NodeKind): Boolean =
+    kind == NodeKind.CUSTOM_VIEW
 
 internal fun resolvedAndroidLetterSpacing(
     logicalSpacing: Float,
@@ -324,6 +410,14 @@ class PamRenderer(
         }
     }
 
+    fun isLayoutInProgress(): Boolean {
+        if (host.isInLayout) return true
+        for (index in 0 until views.size()) {
+            if (views.valueAt(index).isInLayout) return true
+        }
+        return false
+    }
+
     fun commit(batches: List<List<Mutation>>) {
         check(Looper.myLooper() == Looper.getMainLooper()) {
             "Native mutations must be mounted on the Android UI thread"
@@ -384,6 +478,26 @@ class PamRenderer(
                 )
             }
         }
+        ensureFocusedInputVisibleAfterCommit()
+    }
+
+    private fun ensureFocusedInputVisibleAfterCommit() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+        if (currentPlatformImeInset() <= 0) return
+        val input = (host.findFocus() as? EditText)
+            ?: lastFocusedInput?.takeIf(EditText::hasFocus)
+            ?: return
+        var ancestor = input.parent as? View
+        while (ancestor != null) {
+            if (ancestor is PamScrollContainer) {
+                // Scroll-offset restoration is posted during commit. Queueing
+                // this reconciliation afterwards makes keyboard visibility win
+                // over a stale retained offset from the reactive render.
+                ancestor.ensureViewportTargetVisible(input)
+                return
+            }
+            ancestor = ancestor.parent as? View
+        }
     }
 
     private fun syncHostBackground() {
@@ -394,7 +508,11 @@ class PamRenderer(
         java.util.WeakHashMap<EditText, PamModalHost>()
 
     private fun openLocalModalInput(input: EditText) {
-        localModalInputTargets[input]?.setVisible(true)
+        val target = localModalInputTargets[input] ?: return
+        localModalInputTargets.values.toSet().forEach { modal ->
+            if (modal !== target) modal.setVisible(false)
+        }
+        target.setVisible(true)
     }
 
     private fun bindLocalModalInput(input: EditText, target: PamModalHost) {
@@ -435,7 +553,12 @@ class PamRenderer(
                 }
                 marker?.startsWith(LOCAL_MODAL_TRIGGER_PREFIX) == true -> {
                     modals[marker.removePrefix(LOCAL_MODAL_TRIGGER_PREFIX)]?.let { target ->
-                        { target.setVisible(true) }
+                        {
+                            modals.values.forEach { modal ->
+                                if (modal !== target) modal.setVisible(false)
+                            }
+                            target.setVisible(true)
+                        }
                     }
                 }
                 else -> null
@@ -565,6 +688,23 @@ class PamRenderer(
         }
     }
 
+    fun hasPresentedModal(): Boolean {
+        for (position in views.size() - 1 downTo 0) {
+            if ((views.valueAt(position) as? PamModalHost)?.isPresented() == true) {
+                return true
+            }
+        }
+        return false
+    }
+
+    fun consumePresentedModalBack(): Boolean {
+        for (position in views.size() - 1 downTo 0) {
+            val modal = views.valueAt(position) as? PamModalHost ?: continue
+            if (modal.consumeActivityBack()) return true
+        }
+        return false
+    }
+
     override fun close() {
         check(Looper.myLooper() == Looper.getMainLooper())
         for (position in 0 until views.size()) {
@@ -662,7 +802,9 @@ class PamRenderer(
             -> Space(context)
             NodeKind.ACTIVITY_INDICATOR -> PamActivityIndicator(context)
             NodeKind.SWITCH -> PamSwitch(context)
-            NodeKind.MODAL -> PamModalHost(context)
+            NodeKind.MODAL -> PamModalHost(context) {
+                (context as? PamActivity)?.suppressNextPamBack()
+            }
             NodeKind.KEYBOARD_AVOIDING_VIEW -> PamContainer(context).also {
                 installKeyboardInsets(it, requireNotNull(state))
             }
@@ -685,7 +827,12 @@ class PamRenderer(
                     ?: error("Custom native view is missing its generated name")
                 nativeViews.create(name) { kind, payload ->
                     if (kind == EVENT_NATIVE) {
-                        updateLocalModalSelection(custom.id)
+                        if (isLocalModalSelectionEvent(
+                                custom.properties[PropKey.HOST_PROPERTIES],
+                            )
+                        ) {
+                            updateLocalModalSelection(custom.id)
+                        }
                         closeLocalModalAncestor(custom.id)
                     }
                     val eventProperty = nativeEventProperty(kind)
@@ -1140,7 +1287,9 @@ class PamRenderer(
         val view = views[id] ?: return
         val state = nodes[id] ?: return
         val parentState = nodes[state.parent]
-        val parentFrame = frames[effectiveParent(state.parent)]
+        val effectiveParentId = effectiveParent(state.parent)
+        val parentFrame = frames[effectiveParentId]
+        val parentView = views[effectiveParentId]
         val density = resourcesDensity()
         val horizontal = snappedPixelSpan(
             frame.x,
@@ -1154,18 +1303,24 @@ class PamRenderer(
             parentFrame?.y ?: 0f,
             density,
         )
-        val parentSafePadding = parentState?.kind == NodeKind.SAFE_AREA_VIEW &&
-            parentState.integer(
+        val hostedParentState = nodes[effectiveParent(state.parent)]
+        val safeAreaParentState = when {
+            parentState?.kind == NodeKind.SAFE_AREA_VIEW -> parentState
+            hostedParentState?.kind == NodeKind.SAFE_AREA_VIEW -> hostedParentState
+            else -> null
+        }
+        val parentSafePadding = safeAreaParentState != null &&
+            safeAreaParentState.integer(
                 PropKey.SAFE_AREA_MODE,
                 SAFE_AREA_PADDING.toLong(),
             ).toInt() == SAFE_AREA_PADDING
         val parentSafeHorizontal = if (parentSafePadding) {
-            (if (parentState?.flag(PropKey.SAFE_AREA_LEFT, true) == true) {
-                parentState.safeAreaLeftInset
+            (if (safeAreaParentState?.flag(PropKey.SAFE_AREA_LEFT, true) == true) {
+                safeAreaParentState.safeAreaLeftInset
             } else {
                 0
-            }) + (if (parentState?.flag(PropKey.SAFE_AREA_RIGHT, true) == true) {
-                parentState.safeAreaRightInset
+            }) + (if (safeAreaParentState?.flag(PropKey.SAFE_AREA_RIGHT, true) == true) {
+                safeAreaParentState.safeAreaRightInset
             } else {
                 0
             })
@@ -1173,12 +1328,12 @@ class PamRenderer(
             0
         }
         val parentSafeVertical = if (parentSafePadding) {
-            (if (parentState?.flag(PropKey.SAFE_AREA_TOP, true) == true) {
-                parentState.safeAreaTopInset
+            (if (safeAreaParentState?.flag(PropKey.SAFE_AREA_TOP, true) == true) {
+                safeAreaParentState.safeAreaTopInset
             } else {
                 0
-            }) + (if (parentState?.flag(PropKey.SAFE_AREA_BOTTOM_EDGE, true) == true) {
-                parentState.safeAreaBottomInset
+            }) + (if (safeAreaParentState?.flag(PropKey.SAFE_AREA_BOTTOM_EDGE, true) == true) {
+                safeAreaParentState.safeAreaBottomInset
             } else {
                 0
             })
@@ -1203,6 +1358,55 @@ class PamRenderer(
                 horizontalInsets = parentSafeHorizontal,
                 verticalInsets = parentSafeVertical,
             )
+        val parentLayout = parentView?.layoutParams
+        val measuredParentWidth = parentView?.let { measured ->
+            val layoutWidth = parentLayout?.width ?: 0
+            measuredParentExtent(
+                if (parentViewportMeasurementIsStale(
+                        measured.width,
+                        layoutWidth,
+                        measured.isLayoutRequested,
+                    )
+                ) {
+                    0
+                } else {
+                    measured.width
+                },
+                layoutWidth,
+            )
+        } ?: 0
+        val measuredParentHeight = parentView?.let { measured ->
+            val layoutHeight = parentLayout?.height ?: 0
+            measuredParentExtent(
+                if (parentViewportMeasurementIsStale(
+                        measured.height,
+                        layoutHeight,
+                        measured.isLayoutRequested,
+                    )
+                ) {
+                    0
+                } else {
+                    measured.height
+                },
+                layoutHeight,
+            )
+        } ?: 0
+        val (measuredHorizontalReduction, measuredVerticalReduction) =
+            measuredCrossAxisViewportReduction(
+                mainAxisHorizontal = parentMainAxisHorizontal,
+                engineWidth = dp(parentFrame?.width ?: 0f),
+                measuredWidth = measuredParentWidth,
+                engineHeight = dp(parentFrame?.height ?: 0f),
+                measuredHeight = measuredParentHeight,
+            )
+        val parentCrossAxisWidthReduction = max(
+            parentSafeWidthReduction,
+            measuredHorizontalReduction,
+        )
+        val parentCrossAxisHeightReduction = max(
+            parentSafeHeightReduction,
+            measuredVerticalReduction,
+        )
         val safeMargin = state.kind == NodeKind.SAFE_AREA_VIEW &&
             state.integer(PropKey.SAFE_AREA_MODE, SAFE_AREA_PADDING.toLong()).toInt() ==
             SAFE_AREA_MARGIN
@@ -1230,10 +1434,10 @@ class PamRenderer(
             0
         }
         var width = (
-            horizontal.extent - safeLeft - safeRight - parentSafeWidthReduction
+            horizontal.extent - safeLeft - safeRight - parentCrossAxisWidthReduction
             ).coerceAtLeast(0)
         var height = (
-            vertical.extent - safeTop - safeBottom - parentSafeHeightReduction
+            vertical.extent - safeTop - safeBottom - parentCrossAxisHeightReduction
             ).coerceAtLeast(0)
         height = keyboardAvoidingViewportHeight(
             baseHeight = height,
@@ -1250,7 +1454,7 @@ class PamRenderer(
             // Layout-only parents have no Android View. Their children are hosted by the
             // nearest materialized ancestor, whose measured viewport is the one that can be
             // reduced by safe areas or fixed siblings.
-            parentView = views[effectiveParent(state.parent)],
+            parentView = parentView,
             applyHorizontal = { offset, reduction ->
                 leftPx -= offset
                 width = (width - reduction).coerceAtLeast(0)
@@ -1270,10 +1474,11 @@ class PamRenderer(
             current.topMargin != topPx
         if (layoutChanged) {
             view.layoutParams = FrameLayout.LayoutParams(width, height).apply {
+                gravity = PAM_PHYSICAL_FRAME_GRAVITY
                 leftMargin = leftPx
                 topMargin = topPx
             }
-            children[state.id]?.forEach(::applyLayout)
+            applyHostedChildLayouts(state.id)
         }
         // Some plugin hosts (for example Calendar) draw against tagged child
         // bounds. A descendant frame can change without mutating the host's
@@ -1320,7 +1525,16 @@ class PamRenderer(
             Axis.HORIZONTAL -> parentView.width
             Axis.VERTICAL -> parentView.height
         }
-        if (!parentView.isLaidOut || rawMeasuredExtent <= 0) {
+        val layoutParamExtent = when (axis) {
+            Axis.HORIZONTAL -> parentView.layoutParams?.width ?: 0
+            Axis.VERTICAL -> parentView.layoutParams?.height ?: 0
+        }
+        val measurementIsStale = parentViewportMeasurementIsStale(
+            measuredExtent = rawMeasuredExtent,
+            layoutParamExtent = layoutParamExtent,
+            layoutRequested = parentView.isLayoutRequested,
+        )
+        if (!parentView.isLaidOut || rawMeasuredExtent <= 0 || measurementIsStale) {
             deferViewportLayoutUntilMeasured(state.id, parentView, axis)
         }
         val hostedThroughLayoutOnlyParent = views[state.parent] == null
@@ -1334,13 +1548,13 @@ class PamRenderer(
         }
         val measuredExtent = when (axis) {
             Axis.HORIZONTAL -> hostedContentExtent(
-                parentView.width,
-                parentView.layoutParams?.width ?: 0,
+                if (measurementIsStale) 0 else parentView.width,
+                layoutParamExtent,
                 nativePadding,
             )
             Axis.VERTICAL -> hostedContentExtent(
-                parentView.height,
-                parentView.layoutParams?.height ?: 0,
+                if (measurementIsStale) 0 else parentView.height,
+                layoutParamExtent,
                 nativePadding,
             )
         }
@@ -1546,7 +1760,10 @@ class PamRenderer(
                 configurePressable(view, state)
             }
             PropKey.ACCESSIBILITY_LABEL -> view.contentDescription = value.text(key)
-            PropKey.ACCESSIBILITY_HINT -> view.tooltipText = value.text(key)
+            PropKey.ACCESSIBILITY_HINT -> {
+                view.tooltipText = null
+                configureAccessibilityDelegate(view, state)
+            }
             PropKey.TEST_ID -> view.transitionName = value.text(key)
             PropKey.SHARED_TRANSITION_TAG ->
                 view.setTag(dev.pam.nativeapp.R.id.pam_shared_transition_tag, value.text(key))
@@ -2410,7 +2627,10 @@ class PamRenderer(
                 configurePressable(view, state)
             }
             PropKey.ACCESSIBILITY_LABEL -> view.contentDescription = null
-            PropKey.ACCESSIBILITY_HINT -> view.tooltipText = null
+            PropKey.ACCESSIBILITY_HINT -> {
+                view.tooltipText = null
+                configureAccessibilityDelegate(view, state)
+            }
             PropKey.ACCESSIBILITY_ROLE -> {
                 (view as? PamActivityIndicator)?.setHostAccessibility(false)
                 configureAccessibilityDelegate(view, state)
@@ -3477,12 +3697,15 @@ class PamRenderer(
             view.scaleY = state.targetScaleY()
             view.translationX = state.number(PropKey.TRANSLATION_X, 0.0).toFloat()
             view.translationY = state.number(PropKey.TRANSLATION_Y, 0.0).toFloat()
+            view.elevation = dp(state.number(PropKey.ELEVATION, 0.0).toFloat()).toFloat()
             updateBackground(view, state)
             state.properties[PropKey.TEXT_COLOR]?.let { color ->
                 (view as? TextView)?.let { applySemanticTextColor(it, color.integer().toInt()) }
             }
             return
         }
+        var backgroundColorOverride: Int? = null
+        var borderColorOverride: Int? = null
         val keys = styles.keys()
         while (keys.hasNext()) {
             val rawKey = keys.next()
@@ -3493,12 +3716,22 @@ class PamRenderer(
                 PropKey.SCALE_Y -> view.scaleY = styles.optDouble(rawKey, view.scaleY.toDouble()).toFloat()
                 PropKey.TRANSLATION_X -> view.translationX = styles.optDouble(rawKey, view.translationX.toDouble()).toFloat()
                 PropKey.TRANSLATION_Y -> view.translationY = styles.optDouble(rawKey, view.translationY.toDouble()).toFloat()
-                PropKey.BACKGROUND_COLOR -> view.background?.mutate()?.setTint(styles.optLong(rawKey).toInt())
+                PropKey.BACKGROUND_COLOR -> backgroundColorOverride = styles.optLong(rawKey).toInt()
+                PropKey.BORDER_COLOR -> borderColorOverride = styles.optLong(rawKey).toInt()
                 PropKey.TEXT_COLOR -> (view as? TextView)?.let {
                     applySemanticTextColor(it, styles.optLong(rawKey).toInt())
                 }
+                PropKey.ELEVATION -> view.elevation = dp(styles.optDouble(rawKey).toFloat()).toFloat()
                 else -> Unit
             }
+        }
+        if (backgroundColorOverride != null || borderColorOverride != null) {
+            updateBackground(
+                view = view,
+                state = state,
+                backgroundColorOverride = backgroundColorOverride,
+                borderColorOverride = borderColorOverride,
+            )
         }
     }
 
@@ -4262,7 +4495,11 @@ class PamRenderer(
     }
 
     private fun applyLeafPadding(view: View, state: NodeState) {
-        if (view is ViewGroup) {
+        // Flex containers receive engine-computed child frames, so Android
+        // padding would offset their content twice. Custom native ViewGroups
+        // own descendant layout and must receive authored padding as real
+        // View padding (for example Material list-item content insets).
+        if (view is ViewGroup && !usesNativeViewGroupPadding(state.kind)) {
             view.setPadding(0, 0, 0, state.safeBottomInset)
             return
         }
@@ -4283,7 +4520,12 @@ class PamRenderer(
         return context.resources.getColor(identifier, context.theme)
     }
 
-    private fun updateBackground(view: View, state: NodeState) {
+    private fun updateBackground(
+        view: View,
+        state: NodeState,
+        backgroundColorOverride: Int? = null,
+        borderColorOverride: Int? = null,
+    ) {
         val defaultColor = if (
             state.kind == NodeKind.IMAGE ||
             state.kind == NodeKind.IMAGE_BACKGROUND ||
@@ -4296,7 +4538,7 @@ class PamRenderer(
         } else {
             Color.TRANSPARENT.toLong()
         }
-        val color = state.properties[PropKey.NATIVE_BACKGROUND_COLOR_RESOURCE]
+        val color = backgroundColorOverride ?: state.properties[PropKey.NATIVE_BACKGROUND_COLOR_RESOURCE]
             ?.let { resolveNativeColor(it.text(PropKey.NATIVE_BACKGROUND_COLOR_RESOURCE)) }
             ?: state.integer(PropKey.BACKGROUND_COLOR, defaultColor).toInt()
         val logicalRadius = state.number(PropKey.BORDER_RADIUS, 0.0)
@@ -4333,7 +4575,7 @@ class PamRenderer(
                 leftBorderWidth != topBorderWidth ||
                 leftBorderWidth != bottomBorderWidth
             )
-        val borderColor = state.properties[PropKey.NATIVE_BORDER_COLOR_RESOURCE]
+        val borderColor = borderColorOverride ?: state.properties[PropKey.NATIVE_BORDER_COLOR_RESOURCE]
             ?.let { resolveNativeColor(it.text(PropKey.NATIVE_BORDER_COLOR_RESOURCE)) }
             ?: state.integer(PropKey.BORDER_COLOR, Color.TRANSPARENT.toLong()).toInt()
         val borderStyle = state.integer(PropKey.BORDER_STYLE, 1).toInt()
@@ -4917,14 +5159,45 @@ class PamRenderer(
             safeArea.clipToPadding = true
         }
         view.setOnApplyWindowInsetsListener { target, insets ->
-            val raw = windowSafeAreaInsets(insets)
-            val resolved = safeAreaInsetsForView(raw, target)
-            state.safeAreaLeftInset = resolved.left
-            state.safeAreaTopInset = resolved.top
-            state.safeAreaRightInset = resolved.right
-            state.safeAreaBottomInset = resolved.bottom
-            applySafeAreaLayout(target, state)
+            refreshSafeAreaLayout(target, state, insets)
             insets
+        }
+        // Insets are normally dispatched before the orientation layout pass.
+        // Bounds-dependent consumption must therefore be recalculated once
+        // the SafeAreaView owns its final geometry; otherwise a landscape
+        // navigation inset (right edge) can remain as a zero bottom inset
+        // after returning to portrait on Samsung devices.
+        view.addOnLayoutChangeListener {
+                target,
+                left,
+                top,
+                right,
+                bottom,
+                oldLeft,
+                oldTop,
+                oldRight,
+                oldBottom,
+            ->
+            if (!safeAreaLayoutBoundsChanged(
+                    left,
+                    top,
+                    right,
+                    bottom,
+                    oldLeft,
+                    oldTop,
+                    oldRight,
+                    oldBottom,
+                )
+            ) {
+                return@addOnLayoutChangeListener
+            }
+            target.post {
+                if (!target.isAttachedToWindow || views[state.id] !== target) return@post
+                target.rootWindowInsets?.let { current ->
+                    refreshSafeAreaLayout(target, state, current)
+                }
+                target.requestApplyInsets()
+            }
         }
         if (view.isAttachedToWindow) {
             view.requestApplyInsets()
@@ -4938,6 +5211,20 @@ class PamRenderer(
                 override fun onViewDetachedFromWindow(detached: View) = Unit
             })
         }
+    }
+
+    private fun refreshSafeAreaLayout(
+        target: View,
+        state: NodeState,
+        insets: WindowInsets,
+    ) {
+        val raw = windowSafeAreaInsets(insets)
+        val resolved = safeAreaInsetsForView(raw, target)
+        state.safeAreaLeftInset = resolved.left
+        state.safeAreaTopInset = resolved.top
+        state.safeAreaRightInset = resolved.right
+        state.safeAreaBottomInset = resolved.bottom
+        applySafeAreaLayout(target, state)
     }
 
     private fun windowSafeAreaInsets(insets: WindowInsets): SafeAreaInsets {
@@ -5064,7 +5351,7 @@ class PamRenderer(
             },
         )
         applyLayout(state.id)
-        children[state.id]?.forEach(::applyLayout)
+        applyHostedChildLayouts(state.id)
     }
 
     private fun installKeyboardInsets(view: View, state: NodeState) {
@@ -5199,11 +5486,16 @@ class PamRenderer(
         ) keyboard else 0
         if (state.keyboardAvoidingViewportInset != viewportInset) {
             state.keyboardAvoidingViewportInset = viewportInset
-            applyLayout(state.id)
-            view.postOnAnimation {
+            val applyViewportLayout = {
                 if (nodes[state.id] === state) {
-                    applyDescendantLayouts(state.id)
+                    scheduleKeyboardViewportDescendantLayout(view, state)
+                    applyLayout(state.id)
                 }
+            }
+            if (host.isInLayout || view.isInLayout) {
+                view.post { applyViewportLayout() }
+            } else {
+                applyViewportLayout()
             }
         }
         when (state.keyboardBehavior) {
@@ -5254,7 +5546,9 @@ class PamRenderer(
         }
         val scroll = when (state.keyboardBehavior) {
             KEYBOARD_PAN -> precedingScrollContainer(state)
-            KEYBOARD_PADDING -> containedScrollContainer(state)
+            KEYBOARD_PADDING,
+            KEYBOARD_RESIZE,
+            -> containedScrollContainer(state)
             else -> null
         }
         val scrollId = scroll?.first ?: 0L
@@ -5267,9 +5561,17 @@ class PamRenderer(
             state.keyboardAvoidingScrollId = scrollId
         }
         scroll?.second?.let { container ->
-            container.setKeyboardAvoidanceInset(keyboard)
+            container.setKeyboardAvoidanceInset(
+                if (state.keyboardBehavior == KEYBOARD_RESIZE) 0 else keyboard,
+            )
             if (keyboard > 0) {
-                state.keyboardFocusedInput?.let(container::ensureKeyboardTargetVisible)
+                state.keyboardFocusedInput?.let { input ->
+                    if (state.keyboardBehavior == KEYBOARD_RESIZE) {
+                        container.ensureViewportTargetVisible(input)
+                    } else {
+                        container.ensureKeyboardTargetVisible(input)
+                    }
+                }
             }
         }
         if (keyboard > 0) {
@@ -5303,11 +5605,20 @@ class PamRenderer(
             rootLocation[1] + root.height +
                 ((root as? PamRootHost)?.stableSafeAreaInsets?.bottom ?: 0)
         }
-        val safe = (root as? PamRootHost)?.stableSafeAreaInsets
-        val effectiveInset = (keyboardInset - (safe?.top ?: 0))
-            .coerceAtLeast(0)
-        val keyboardTop = windowBottom - effectiveInset
-        return max(0, (originalBottom - keyboardTop + offset).toInt())
+        // WindowInsets.Type.ime() is a bottom inset in the same full-window
+        // coordinate space as `windowBottom`. Removing the top safe-area
+        // inset here leaves exactly that many pixels hidden behind the IME.
+        // A safe-area/flex parent can temporarily extend this view beyond the
+        // physical window while Android and the PHP layout settle after a
+        // rotation. That overflow is already removed by viewport compensation;
+        // counting it here would subtract the same pixels twice and collapse
+        // the keyboard-safe viewport to zero.
+        return keyboardOverlapForBounds(
+            originalBottom = originalBottom,
+            windowBottom = windowBottom,
+            keyboardInset = keyboardInset,
+            offset = offset,
+        )
     }
 
     private fun applyDescendantLayouts(parentId: Long) {
@@ -5315,6 +5626,50 @@ class PamRenderer(
             applyLayout(childId)
             applyDescendantLayouts(childId)
         }
+    }
+
+    private fun applyHostedChildLayouts(parentId: Long) {
+        children[parentId]?.forEach { childId ->
+            if (views[childId] == null) {
+                // Layout-only Row/Column/View nodes have no Android View of
+                // their own. Their nearest materialized descendants are
+                // hosted directly by this ancestor and must be reconciled
+                // whenever its native bounds change, regardless of mutation
+                // order within the frame.
+                applyHostedChildLayouts(childId)
+            } else {
+                applyLayout(childId)
+            }
+        }
+    }
+
+    private fun scheduleKeyboardViewportDescendantLayout(
+        view: View,
+        state: NodeState,
+    ) {
+        val generation = ++state.keyboardViewportReconcileGeneration
+        fun reconcile(attempt: Int) {
+            view.postDelayed({
+                if (
+                    nodes[state.id] !== state ||
+                    generation != state.keyboardViewportReconcileGeneration
+                ) {
+                    return@postDelayed
+                }
+                if (!host.isInLayout && !view.isInLayout) {
+                    // Flex descendants must be recomputed from the KAV's
+                    // measured viewport. Insets can transition through old,
+                    // zero and new values before a single Android layout pass,
+                    // so an onLayout callback alone is not a reliable signal.
+                    applyDescendantLayouts(state.id)
+                    ensureFocusedInputVisibleAfterCommit()
+                }
+                if (attempt < KEYBOARD_VIEWPORT_RECONCILE_RETRIES) {
+                    reconcile(attempt + 1)
+                }
+            }, if (attempt == 0) 0L else KEYBOARD_VIEWPORT_RECONCILE_RETRY_MS)
+        }
+        reconcile(attempt = 0)
     }
 
     private fun updateTranslatedTouchTarget(
@@ -5541,8 +5896,17 @@ class PamRenderer(
             ?: return StatusBarConfig(Color.BLACK, STATUS_BAR_LIGHT, false, false, false, false)
         val decor = window.decorView
         val lightIcons = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val appearance = decor.windowInsetsController?.systemBarsAppearance ?: 0
-            appearance and WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS == 0
+            val darkTheme = context.resources.configuration.uiMode and
+                Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
+            // A newly created controller can still expose the previous
+            // Activity's appearance until the first inset traversal. The
+            // default must be deterministic; explicit PAM StatusBar nodes are
+            // merged below and remain authoritative.
+            !useDarkStatusBarIcons(
+                systemBarsAppearance = null,
+                darkTheme = darkTheme,
+                lightStatusBarMask = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+            )
         } else {
             decor.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR == 0
         }
@@ -6160,7 +6524,9 @@ class PamRenderer(
         } else {
             emptyList()
         }
-        if (role == 1 && actions.isEmpty()) {
+        val hint = state.textOrNull(PropKey.ACCESSIBILITY_HINT)
+            ?.takeIf(String::isNotEmpty)
+        if (role == 1 && actions.isEmpty() && hint == null) {
             view.accessibilityDelegate = null
             return
         }
@@ -6174,6 +6540,9 @@ class PamRenderer(
             ) {
                 super.onInitializeAccessibilityNodeInfo(host, info)
                 info.className = accessibilityClass(role)
+                if (hint != null) {
+                    info.hintText = hint
+                }
                 applyAccessibilityRoleInfo(info, role, state)
                 actions.forEachIndexed { index, action ->
                     info.addAction(
@@ -6472,6 +6841,7 @@ class PamRenderer(
         var keyboardAnimating: Boolean = false,
         var keyboardBaseHeight: Int = 0,
         var keyboardLayoutListener: View.OnLayoutChangeListener? = null,
+        var keyboardViewportReconcileGeneration: Int = 0,
         var keyboardAvoidingScrollId: Long = 0L,
         var keyboardAvoidingViewportInset: Int = 0,
         var keyboardFocusedInput: EditText? = null,

--- a/android/app/src/main/java/dev/pam/nativeapp/render/PamScrollContainer.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/render/PamScrollContainer.kt
@@ -285,7 +285,20 @@ internal class PamScrollContainer(context: Context) : FrameLayout(context) {
     fun keyboardAvoidanceInsetPixels(): Int = keyboardAvoidanceInsetPx
 
     fun ensureKeyboardTargetVisible(target: View) {
-        if (keyboardAvoidanceInsetPx <= 0 || horizontal) return
+        if (keyboardAvoidanceInsetPx <= 0) return
+        ensureTargetVisible(target, keyboardAvoidanceInsetPx, retry = true)
+    }
+
+    fun ensureViewportTargetVisible(target: View) {
+        ensureTargetVisible(target, obscuredInsetPx = 0, retry = true)
+    }
+
+    private fun ensureTargetVisible(
+        target: View,
+        obscuredInsetPx: Int,
+        retry: Boolean,
+    ) {
+        if (horizontal) return
         activeScroll.post {
             if (
                 !isAttachedToWindow ||
@@ -297,16 +310,30 @@ internal class PamScrollContainer(context: Context) : FrameLayout(context) {
             val rect = Rect(0, 0, target.width, target.height)
             content.offsetDescendantRectToMyCoords(target, rect)
             val current = primaryCurrentOffset()
-            val clearance = dp(KEYBOARD_TARGET_CLEARANCE_DP)
+            val viewportExtent = (activeScroll.height - obscuredInsetPx)
+                .coerceAtLeast(0)
+            val clearance = minOf(
+                dp(KEYBOARD_TARGET_CLEARANCE_DP),
+                ((viewportExtent - rect.height()).coerceAtLeast(0) / 2),
+            )
             val visibleEnd = current +
-                (activeScroll.height - keyboardAvoidanceInsetPx).coerceAtLeast(0)
+                viewportExtent
             val next = when {
                 rect.bottom + clearance > visibleEnd ->
                     current + rect.bottom + clearance - visibleEnd
                 rect.top - clearance < current -> rect.top - clearance
                 else -> current
             }
-            if (next != current) scrollToPrimary(next.coerceAtLeast(0))
+            val boundedNext = next.coerceIn(0, primaryMaxOffset())
+            if (boundedNext != current) scrollToPrimary(boundedNext)
+            // Keyboard insets and orientation-driven PHP layout can settle on
+            // the next frame. Recheck once so the focused editor cannot be
+            // left outside a newly reduced viewport after rotation.
+            if (retry) {
+                activeScroll.postOnAnimation {
+                    ensureTargetVisible(target, obscuredInsetPx, retry = false)
+                }
+            }
         }
     }
 
@@ -512,10 +539,12 @@ internal class PamScrollContainer(context: Context) : FrameLayout(context) {
         if (horizontal) scrollXOf(activeScroll) else scrollYOf(activeScroll)
 
     private fun scrollToPrimary(offset: Int) {
+        val bounded = offset.coerceIn(0, primaryMaxOffset())
+        if (bounded == primaryCurrentOffset()) return
         if (horizontal) {
-            activeScroll.scrollTo(offset.coerceAtLeast(0), scrollYOf(activeScroll))
+            activeScroll.scrollTo(bounded, scrollYOf(activeScroll))
         } else {
-            activeScroll.scrollTo(scrollXOf(activeScroll), offset.coerceAtLeast(0))
+            activeScroll.scrollTo(scrollXOf(activeScroll), bounded)
         }
     }
 
@@ -769,7 +798,10 @@ internal class PamScrollContainer(context: Context) : FrameLayout(context) {
         const val KEYBOARD_DISMISS_NONE = 1
         const val KEYBOARD_DISMISS_INTERACTIVE = 3
         const val NORMAL_DECELERATION_RATE = 0.985f
-        const val KEYBOARD_TARGET_CLEARANCE_DP = 16f
+        // Material supporting text (helper/error/counter) occupies 20dp with a
+        // 4dp top gap. Keeping this full strip visible prevents focused fields
+        // from touching the IME and hiding their validation state.
+        const val KEYBOARD_TARGET_CLEARANCE_DP = 24f
 
         fun alignedTargetOffset(
             targetStart: Int,

--- a/android/app/src/test/java/dev/pam/nativeapp/ViewportSizeTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/ViewportSizeTest.kt
@@ -1,0 +1,32 @@
+package dev.pam.nativeapp
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ViewportSizeTest {
+    @Test
+    fun laidOutViewportWinsOverStaleWindowMetricsAfterRotation() {
+        assertEquals(
+            1_080 to 2_280,
+            resolvedViewportSize(
+                laidOutWidth = 1_080,
+                laidOutHeight = 2_280,
+                windowWidth = 2_280,
+                windowHeight = 1_080,
+            ),
+        )
+    }
+
+    @Test
+    fun windowMetricsBootstrapTheViewportBeforeFirstLayout() {
+        assertEquals(
+            1_080 to 2_280,
+            resolvedViewportSize(
+                laidOutWidth = 0,
+                laidOutHeight = 0,
+                windowWidth = 1_080,
+                windowHeight = 2_280,
+            ),
+        )
+    }
+}

--- a/android/app/src/test/java/dev/pam/nativeapp/render/PamCustomViewPaddingTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/render/PamCustomViewPaddingTest.kt
@@ -1,0 +1,15 @@
+package dev.pam.nativeapp.render
+
+import dev.pam.nativeapp.protocol.NodeKind
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PamCustomViewPaddingTest {
+    @Test
+    fun customNativeViewGroupsOwnTheirAuthoredContentInsets() {
+        assertTrue(usesNativeViewGroupPadding(NodeKind.CUSTOM_VIEW))
+        assertFalse(usesNativeViewGroupPadding(NodeKind.VIEW))
+        assertFalse(usesNativeViewGroupPadding(NodeKind.SCREEN))
+    }
+}

--- a/android/app/src/test/java/dev/pam/nativeapp/render/PamDrawerLayoutTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/render/PamDrawerLayoutTest.kt
@@ -1,0 +1,42 @@
+package dev.pam.nativeapp.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PamDrawerLayoutTest {
+    @Test
+    fun permanentDrawerReservesContentInsideSafeViewport() {
+        assertEquals(
+            0 to 1_482,
+            permanentDrawerContentClip(0, 2_154, 672, right = false),
+        )
+        assertEquals(
+            672 to 2_154,
+            permanentDrawerContentClip(0, 2_154, 672, right = true),
+        )
+        assertEquals(
+            126 to 1_608,
+            permanentDrawerContentClip(126, 2_280, 672, right = false),
+        )
+    }
+
+    @Test
+    fun permanentPresentationDoesNotChangeRequestedOpenState() {
+        val requestedOpen = false
+
+        assertFalse(drawerIsVisuallyOpen(requestedOpen, permanent = false))
+        assertTrue(drawerIsVisuallyOpen(requestedOpen, permanent = true))
+        assertFalse(drawerIsVisuallyOpen(requestedOpen, permanent = false))
+    }
+
+    @Test
+    fun explicitlyOpenedDrawerRemainsOpenAcrossPresentationChanges() {
+        val requestedOpen = true
+
+        assertTrue(drawerIsVisuallyOpen(requestedOpen, permanent = false))
+        assertTrue(drawerIsVisuallyOpen(requestedOpen, permanent = true))
+        assertTrue(drawerIsVisuallyOpen(requestedOpen, permanent = false))
+    }
+}

--- a/android/app/src/test/java/dev/pam/nativeapp/render/PamKeyboardAvoidanceTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/render/PamKeyboardAvoidanceTest.kt
@@ -62,6 +62,27 @@ class PamKeyboardAvoidanceTest {
     }
 
     @Test
+    fun imeTopUsesFullWindowCoordinatesWithoutSubtractingTheTopSafeArea() {
+        assertEquals(
+            1_517,
+            keyboardTopForInset(windowBottom = 2_400, keyboardInset = 883),
+        )
+    }
+
+    @Test
+    fun overlapDoesNotCountParentOverflowBeyondPhysicalWindowTwice() {
+        assertEquals(
+            686,
+            keyboardOverlapForBounds(
+                originalBottom = 1_216f,
+                windowBottom = 1_080,
+                keyboardInset = 686,
+                offset = 0,
+            ),
+        )
+    }
+
+    @Test
     fun resizeBehaviorReducesTheKeyboardAvoidingViewport() {
         assertEquals(
             1_280,

--- a/android/app/src/test/java/dev/pam/nativeapp/render/PamLocalModalSelectionTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/render/PamLocalModalSelectionTest.kt
@@ -1,0 +1,28 @@
+package dev.pam.nativeapp.render
+
+import dev.pam.nativeapp.protocol.PropValue
+import dev.pam.nativeapp.protocol.WireValue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PamLocalModalSelectionTest {
+    @Test
+    fun onlySheetItemNativeEventsMayUpdateTheLocalModalTrigger() {
+        assertTrue(
+            isLocalModalSelectionEvent(
+                PropValue.Properties(
+                    mapOf("behavior" to WireValue.Integer(24L)),
+                ),
+            ),
+        )
+        assertFalse(
+            isLocalModalSelectionEvent(
+                PropValue.Properties(
+                    mapOf("behavior" to WireValue.Integer(3L)),
+                ),
+            ),
+        )
+        assertFalse(isLocalModalSelectionEvent(null))
+    }
+}

--- a/android/app/src/test/java/dev/pam/nativeapp/render/PamPixelSnappingTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/render/PamPixelSnappingTest.kt
@@ -1,9 +1,17 @@
 package dev.pam.nativeapp.render
 
+import android.view.Gravity
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class PamPixelSnappingTest {
+    @Test
+    fun physicalFrameGravityDoesNotResolveThroughStartInRtl() {
+        assertEquals(Gravity.TOP or Gravity.LEFT, PAM_PHYSICAL_FRAME_GRAVITY)
+        assertFalse(PAM_PHYSICAL_FRAME_GRAVITY and Gravity.RELATIVE_LAYOUT_DIRECTION != 0)
+    }
+
     @Test
     fun centered_children_share_the_same_physical_center() {
         val density = 2.625f

--- a/android/app/src/test/java/dev/pam/nativeapp/render/PamSafeAreaLayoutTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/render/PamSafeAreaLayoutTest.kt
@@ -5,6 +5,36 @@ import org.junit.Test
 
 class PamSafeAreaLayoutTest {
     @Test
+    fun orientationGeometryChangeRequiresASecondInsetResolution() {
+        assertEquals(
+            true,
+            safeAreaLayoutBoundsChanged(
+                left = 0,
+                top = 112,
+                right = 1_080,
+                bottom = 2_280,
+                oldLeft = 112,
+                oldTop = 0,
+                oldRight = 2_280,
+                oldBottom = 1_080,
+            ),
+        )
+        assertEquals(
+            false,
+            safeAreaLayoutBoundsChanged(
+                left = 0,
+                top = 112,
+                right = 1_080,
+                bottom = 2_280,
+                oldLeft = 0,
+                oldTop = 112,
+                oldRight = 1_080,
+                oldBottom = 2_280,
+            ),
+        )
+    }
+
+    @Test
     fun columnChildrenKeepTheirDeclaredHeight() {
         assertEquals(
             36 to 0,
@@ -24,6 +54,20 @@ class PamSafeAreaLayoutTest {
                 mainAxisHorizontal = true,
                 horizontalInsets = 36,
                 verticalInsets = 126,
+            ),
+        )
+    }
+
+    @Test
+    fun measuredColumnParentConstrainsLandscapeChildWidth() {
+        assertEquals(
+            126 to 0,
+            measuredCrossAxisViewportReduction(
+                mainAxisHorizontal = false,
+                engineWidth = 2_280,
+                measuredWidth = 2_154,
+                engineHeight = 1_080,
+                measuredHeight = 842,
             ),
         )
     }
@@ -55,6 +99,34 @@ class PamSafeAreaLayoutTest {
     fun measuredParentSizeWinsAfterTheFirstNativeLayout() {
         assertEquals(2_148, measuredParentExtent(2_148, 2_211))
         assertEquals(2_211, measuredParentExtent(0, 2_211))
+    }
+
+    @Test
+    fun previousOrientationMeasurementIsStaleWhileRelayoutIsPending() {
+        assertEquals(
+            true,
+            parentViewportMeasurementIsStale(
+                measuredExtent = 954,
+                layoutParamExtent = 2_337,
+                layoutRequested = true,
+            ),
+        )
+        assertEquals(
+            false,
+            parentViewportMeasurementIsStale(
+                measuredExtent = 2_148,
+                layoutParamExtent = 2_211,
+                layoutRequested = false,
+            ),
+        )
+        assertEquals(
+            false,
+            parentViewportMeasurementIsStale(
+                measuredExtent = 2_337,
+                layoutParamExtent = 2_337,
+                layoutRequested = true,
+            ),
+        )
     }
 
     @Test

--- a/android/app/src/test/java/dev/pam/nativeapp/render/PamStatusBarAppearanceTest.kt
+++ b/android/app/src/test/java/dev/pam/nativeapp/render/PamStatusBarAppearanceTest.kt
@@ -1,0 +1,49 @@
+package dev.pam.nativeapp.render
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PamStatusBarAppearanceTest {
+    private val lightStatusBarMask = 8
+
+    @Test
+    fun unattachedLightThemeDefaultsToDarkIcons() {
+        assertTrue(
+            useDarkStatusBarIcons(
+                systemBarsAppearance = null,
+                darkTheme = false,
+                lightStatusBarMask = lightStatusBarMask,
+            ),
+        )
+    }
+
+    @Test
+    fun unattachedDarkThemeDefaultsToLightIcons() {
+        assertFalse(
+            useDarkStatusBarIcons(
+                systemBarsAppearance = null,
+                darkTheme = true,
+                lightStatusBarMask = lightStatusBarMask,
+            ),
+        )
+    }
+
+    @Test
+    fun attachedControllerAppearanceWinsOverThemeFallback() {
+        assertTrue(
+            useDarkStatusBarIcons(
+                systemBarsAppearance = lightStatusBarMask,
+                darkTheme = true,
+                lightStatusBarMask = lightStatusBarMask,
+            ),
+        )
+        assertFalse(
+            useDarkStatusBarIcons(
+                systemBarsAppearance = 0,
+                darkTheme = false,
+                lightStatusBarMask = lightStatusBarMask,
+            ),
+        )
+    }
+}

--- a/android/macrobenchmark/proguard-rules.pro
+++ b/android/macrobenchmark/proguard-rules.pro
@@ -1,6 +1,9 @@
 # Optional annotations and receivers referenced by the AndroidX benchmark
 # harness are not required in the instrumentation process itself.
 -keep class androidx.tracing.Trace { *; }
+# The AndroidX instrumentation bootstrap resolves Kotlin helpers through code
+# paths R8 cannot see. Keep the runtime in the minified benchmark APK.
+-keep class kotlin.** { *; }
 -dontwarn androidx.profileinstaller.ProfileInstallReceiver
 -dontwarn androidx.startup.Initializer
 -dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -5887,6 +5887,11 @@ fn ignored_project_path(path: &Path) -> bool {
         || components
             .iter()
             .any(|component| component.starts_with('.'))
+        || components.contains(&"__pycache__")
+        || matches!(
+            path.extension().and_then(OsStr::to_str),
+            Some("pyc" | "pyo")
+        )
         || components
             .iter()
             .any(|component| matches!(*component, "node_modules" | "target" | "dist" | "build"))
@@ -6818,7 +6823,12 @@ fn write_new_file(path: &Path, contents: &[u8]) -> Result<(), String> {
 }
 
 fn build_engine(native_home: &Path, abi: AndroidAbi) -> Result<(), String> {
-    if engine_ready_at(native_home, abi) {
+    // Packaged SDKs ship an immutable prebuilt archive and do not require a
+    // Rust toolchain. A source checkout is different: the archive may exist
+    // from an earlier build while layout/protocol sources have changed. Let
+    // Cargo perform its inexpensive freshness check in that case so Android
+    // builds can never silently link stale native behavior.
+    if engine_ready_at(native_home, abi) && !native_home.join(".git").is_dir() {
         return Ok(());
     }
     let installed = installed_rust_targets()?;
@@ -8030,6 +8040,11 @@ mod tests {
         assert!(ignored_project_path(Path::new(
             "vendor/package/examples/demo/vendor/autoload.php"
         )));
+        assert!(ignored_project_path(Path::new(
+            "tools/__pycache__/audit.cpython-313.pyc"
+        )));
+        assert!(ignored_project_path(Path::new("tools/audit.pyc")));
+        assert!(ignored_project_path(Path::new("tools/audit.pyo")));
         assert!(!ignored_project_path(Path::new(
             "vendor/package/src/View.php"
         )));

--- a/crates/pam-native-engine/src/layout.rs
+++ b/crates/pam-native-engine/src/layout.rs
@@ -450,16 +450,51 @@ fn layout_node(
         return Ok(());
     }
     if node.kind == NodeKind::DrawerLayout {
+        let permanent = integer(node, PropKey::DrawerType) == Some(4)
+            || number(node, PropKey::DrawerPermanentBreakpoint)
+                .is_some_and(|breakpoint| breakpoint > 0.0 && inner.width >= breakpoint);
+        let drawer_width = number(node, PropKey::DrawerWidth)
+            .or_else(|| {
+                node_children
+                    .iter()
+                    .filter(|child| visible(child))
+                    .nth(1)
+                    .and_then(|child| number(child, PropKey::Width))
+            })
+            .unwrap_or(inner.width * 0.82)
+            .clamp(0.0, inner.width);
+        let content_width = (inner.width - drawer_width).max(0.0);
+        let right = integer(node, PropKey::DrawerPosition) == Some(3);
         for (position, child) in node_children
             .iter()
             .filter(|child| visible(child))
             .enumerate()
         {
-            let child_frame = if position == 0 {
+            let child_frame = if permanent && position == 0 {
+                Layout {
+                    x: if right {
+                        inner.x
+                    } else {
+                        inner.x + drawer_width
+                    },
+                    width: content_width,
+                    ..inner
+                }
+            } else if permanent {
+                Layout {
+                    x: if right {
+                        inner.x + content_width
+                    } else {
+                        inner.x
+                    },
+                    width: drawer_width,
+                    ..inner
+                }
+            } else if position == 0 {
                 inner
             } else {
                 Layout {
-                    width: number(child, PropKey::Width).unwrap_or(inner.width * 0.82),
+                    width: drawer_width,
                     ..inner
                 }
             };
@@ -2900,6 +2935,100 @@ mod tests {
     }
 
     #[test]
+    fn permanent_drawer_reserves_layout_width_for_content_on_both_edges() {
+        let layout_for = |position: i64, drawer_type: i64, breakpoint: Option<f64>| {
+            let mut drawer_properties = vec![
+                (PropKey::DrawerType, PropValue::Integer(drawer_type)),
+                (PropKey::DrawerPosition, PropValue::Integer(position)),
+                (PropKey::DrawerWidth, PropValue::Float(256.0)),
+            ];
+            if let Some(value) = breakpoint {
+                drawer_properties
+                    .push((PropKey::DrawerPermanentBreakpoint, PropValue::Float(value)));
+            }
+            let tree = Tree {
+                root: 1,
+                nodes: BTreeMap::from([
+                    (1, node(1, 0, 0, NodeKind::DrawerLayout, drawer_properties)),
+                    (
+                        2,
+                        node(
+                            2,
+                            1,
+                            0,
+                            NodeKind::View,
+                            [(PropKey::WidthPercent, PropValue::Float(100.0))],
+                        ),
+                    ),
+                    (
+                        3,
+                        node(
+                            3,
+                            1,
+                            1,
+                            NodeKind::View,
+                            [(PropKey::Width, PropValue::Float(256.0))],
+                        ),
+                    ),
+                ]),
+            };
+
+            calculate(
+                &tree,
+                Size {
+                    width: 1_000.0,
+                    height: 700.0,
+                },
+            )
+            .expect("permanent drawer layout")
+        };
+
+        let left = layout_for(2, 4, None);
+        assert_eq!(
+            left[&2],
+            Layout {
+                x: 256.0,
+                y: 0.0,
+                width: 744.0,
+                height: 700.0
+            }
+        );
+        assert_eq!(
+            left[&3],
+            Layout {
+                x: 0.0,
+                y: 0.0,
+                width: 256.0,
+                height: 700.0
+            }
+        );
+
+        let right = layout_for(3, 4, None);
+        assert_eq!(
+            right[&2],
+            Layout {
+                x: 0.0,
+                y: 0.0,
+                width: 744.0,
+                height: 700.0
+            }
+        );
+        assert_eq!(
+            right[&3],
+            Layout {
+                x: 744.0,
+                y: 0.0,
+                width: 256.0,
+                height: 700.0
+            }
+        );
+
+        let responsive = layout_for(1, 1, Some(840.0));
+        assert_eq!(responsive[&2], left[&2]);
+        assert_eq!(responsive[&3], left[&3]);
+    }
+
+    #[test]
     fn flex_wrap_respects_intrinsic_cross_axis_minimums() {
         let tree = Tree {
             root: 1,
@@ -3745,6 +3874,136 @@ mod tests {
     }
 
     #[test]
+    fn nested_row_keeps_explicit_cross_axis_height_for_stacked_controls() {
+        let tree = Tree {
+            root: 1,
+            nodes: BTreeMap::from([
+                (1, node(1, 0, 0, NodeKind::Column, [])),
+                (
+                    2,
+                    node(
+                        2,
+                        1,
+                        0,
+                        NodeKind::CustomView,
+                        [(PropKey::WidthPercent, PropValue::Float(100.0))],
+                    ),
+                ),
+                (
+                    3,
+                    node(
+                        3,
+                        2,
+                        0,
+                        NodeKind::View,
+                        [
+                            (PropKey::Height, PropValue::Float(112.0)),
+                            (PropKey::MinHeight, PropValue::Float(112.0)),
+                            (PropKey::PaddingHorizontal, PropValue::Float(16.0)),
+                        ],
+                    ),
+                ),
+                (
+                    4,
+                    node(
+                        4,
+                        3,
+                        0,
+                        NodeKind::Text,
+                        [
+                            (PropKey::Text, PropValue::String("Number Input".into())),
+                            (PropKey::LineHeight, PropValue::Float(16.0)),
+                        ],
+                    ),
+                ),
+                (
+                    5,
+                    node(
+                        5,
+                        3,
+                        1,
+                        NodeKind::Row,
+                        [
+                            (PropKey::WidthPercent, PropValue::Float(100.0)),
+                            (PropKey::Gap, PropValue::Float(4.0)),
+                        ],
+                    ),
+                ),
+                (
+                    6,
+                    node(
+                        6,
+                        5,
+                        0,
+                        NodeKind::Input,
+                        [
+                            (PropKey::Height, PropValue::Float(96.0)),
+                            (PropKey::FlexGrow, PropValue::Float(1.0)),
+                            (PropKey::MinWidth, PropValue::Float(64.0)),
+                        ],
+                    ),
+                ),
+                (
+                    7,
+                    node(
+                        7,
+                        5,
+                        1,
+                        NodeKind::Column,
+                        [
+                            (PropKey::Width, PropValue::Float(48.0)),
+                            (PropKey::Height, PropValue::Float(96.0)),
+                        ],
+                    ),
+                ),
+                (
+                    8,
+                    node(
+                        8,
+                        7,
+                        0,
+                        NodeKind::Pressable,
+                        [
+                            (PropKey::Width, PropValue::Float(48.0)),
+                            (PropKey::Height, PropValue::Float(48.0)),
+                        ],
+                    ),
+                ),
+                (
+                    9,
+                    node(
+                        9,
+                        7,
+                        1,
+                        NodeKind::Pressable,
+                        [
+                            (PropKey::Width, PropValue::Float(48.0)),
+                            (PropKey::Height, PropValue::Float(48.0)),
+                        ],
+                    ),
+                ),
+            ]),
+        };
+
+        let layouts = calculate(
+            &tree,
+            Size {
+                width: 360.0,
+                height: 640.0,
+            },
+        )
+        .expect("stacked number input layout");
+
+        assert_eq!(layouts[&3].height, 112.0);
+        assert_eq!(layouts[&5].height, 96.0);
+        assert_eq!(layouts[&6].height, 96.0);
+        assert_eq!(layouts[&7].height, 96.0);
+        assert_eq!(layouts[&8].height, 48.0);
+        assert_eq!(layouts[&9].height, 48.0);
+        assert_eq!(layouts[&9].y, layouts[&8].y + layouts[&8].height);
+    }
+
+    #[test]
     fn native_grid_uses_its_authored_minimum_instead_of_fallback_child_flow() {
         let tree = Tree {
             root: 1,
@@ -3877,7 +4136,7 @@ mod tests {
             [
                 (
                     PropKey::Text,
-                    PropValue::String("pushinbr/pam-mobile-ui".into()),
+                    PropValue::String("pushinbr/pam-native-ui".into()),
                 ),
                 (PropKey::FontSize, PropValue::Float(12.0)),
             ],
@@ -3890,7 +4149,7 @@ mod tests {
             [
                 (
                     PropKey::Text,
-                    PropValue::String("pushinbr/pam-mobile-ui".into()),
+                    PropValue::String("pushinbr/pam-native-ui".into()),
                 ),
                 (PropKey::FontSize, PropValue::Float(12.0)),
                 (PropKey::TextTransform, PropValue::Integer(2)),

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -28,7 +28,6 @@ with this directory as `--extensionDevelopmentPath`, the test file as
 `--extensionTestsPath`, and the sample app as the workspace. Intelephense must be
 installed. It checks PHP language identity, SDK class definition, inherited method
 definition and PHP hover. The test does not claim universal PHP language coverage.
-
 ## Build an installable extension
 
 From the SDK checkout, run:

--- a/ios/Sources/PamNative/Protocol/PamProtocol.swift
+++ b/ios/Sources/PamNative/Protocol/PamProtocol.swift
@@ -345,6 +345,7 @@ public enum PamConstants {
     public static let checked = 51
     public static let loading = 52
     public static let selected = 66
+    public static let elevation = 56
     public static let drawerOpen = 85
     public static let drawerPosition = 86
     public static let modalPresentation = 58

--- a/ios/Sources/PamNative/Render/PamRenderComponents.swift
+++ b/ios/Sources/PamNative/Render/PamRenderComponents.swift
@@ -1,6 +1,32 @@
 import Foundation
 import UIKit
 
+enum PamMaterialElevation {
+    static func apply(
+        _ elevation: CGFloat,
+        to layer: CALayer,
+        bounds: CGRect,
+        cornerRadius: CGFloat
+    ) {
+        guard elevation > 0 else {
+            layer.shadowColor = nil
+            layer.shadowOpacity = 0
+            layer.shadowOffset = .zero
+            layer.shadowRadius = 0
+            layer.shadowPath = nil
+            return
+        }
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = Float(min(0.24, 0.10 + elevation * 0.008))
+        layer.shadowOffset = CGSize(width: 0, height: max(1, elevation * 0.45))
+        layer.shadowRadius = max(1, elevation * 0.72)
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: max(0, cornerRadius)
+        ).cgPath
+    }
+}
+
 final class PamPressButton: UIButton {
     static let minimumTouchTarget: CGFloat = 44
 
@@ -14,6 +40,11 @@ final class PamPressButton: UIButton {
     private var restingBackgroundColor: UIColor?
     private var restingTitleColor: UIColor?
     private var restingBorderColor: CGColor?
+    private var restingShadowColor: CGColor?
+    private var restingShadowOpacity: Float?
+    private var restingShadowOffset: CGSize?
+    private var restingShadowRadius: CGFloat?
+    private var restingShadowPath: CGPath?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -126,11 +157,21 @@ final class PamPressButton: UIButton {
             backgroundColor = restingBackgroundColor
             setTitleColor(restingTitleColor, for: .normal)
             layer.borderColor = restingBorderColor
+            layer.shadowColor = restingShadowColor
+            layer.shadowOpacity = restingShadowOpacity ?? 0
+            layer.shadowOffset = restingShadowOffset ?? .zero
+            layer.shadowRadius = restingShadowRadius ?? 0
+            layer.shadowPath = restingShadowPath
             restingAlpha = nil
             restingTransform = nil
             restingBackgroundColor = nil
             restingTitleColor = nil
             restingBorderColor = nil
+            restingShadowColor = nil
+            restingShadowOpacity = nil
+            restingShadowOffset = nil
+            restingShadowRadius = nil
+            restingShadowPath = nil
             return
         }
         if restingAlpha == nil { restingAlpha = alpha }
@@ -138,6 +179,11 @@ final class PamPressButton: UIButton {
         restingBackgroundColor = backgroundColor
         restingTitleColor = titleColor(for: .normal)
         restingBorderColor = layer.borderColor
+        restingShadowColor = layer.shadowColor
+        restingShadowOpacity = layer.shadowOpacity
+        restingShadowOffset = layer.shadowOffset
+        restingShadowRadius = layer.shadowRadius
+        restingShadowPath = layer.shadowPath
         if let opacity = styles[38] as? NSNumber { alpha = CGFloat(truncating: opacity) }
         let x = (styles[74] as? NSNumber).map(CGFloat.init(truncating:)) ?? 1
         let y = (styles[75] as? NSNumber).map(CGFloat.init(truncating:)) ?? 1
@@ -150,6 +196,14 @@ final class PamPressButton: UIButton {
         }
         if let color = styles[37] as? NSNumber {
             layer.borderColor = UIColor(argb: color.int64Value).cgColor
+        }
+        if let elevation = styles[56] as? NSNumber {
+            PamMaterialElevation.apply(
+                CGFloat(truncating: elevation),
+                to: layer,
+                bounds: bounds,
+                cornerRadius: layer.cornerRadius
+            )
         }
     }
 }

--- a/ios/Sources/PamNative/Render/PamRenderer.swift
+++ b/ios/Sources/PamNative/Render/PamRenderer.swift
@@ -1523,6 +1523,8 @@ public final class PamRenderer {
             view.layer.cornerRadius = CGFloat(value.decimalOrZero())
             applyBorder(view: view, nodeId: nodeId)
             applyBoxShadow(view: view, nodeId: nodeId)
+        case PamConstants.elevation:
+            applyBoxShadow(view: view, nodeId: nodeId)
         case PamConstants.shadowOffsetX,
              PamConstants.shadowOffsetY,
              PamConstants.shadowBlurRadius,
@@ -1908,6 +1910,8 @@ public final class PamRenderer {
             view.layer.cornerRadius = 0
             applyBorder(view: view, nodeId: nodeId)
             applyBoxShadow(view: view, nodeId: nodeId)
+        case PamConstants.elevation:
+            applyBoxShadow(view: view, nodeId: nodeId)
         case PamConstants.textAlign:
             applyTextAlignment(view: view, nodeId: nodeId)
         case PamConstants.shadowOffsetX,
@@ -2198,12 +2202,24 @@ public final class PamRenderer {
     }
 
     private func applyBoxShadow(view: UIView, nodeId: Int64) {
-        guard let state = nodes[nodeId],
-              let colorValue = state.properties[PamConstants.shadowColor]?.integerOrNil()
-        else {
+        guard let state = nodes[nodeId] else {
             view.layer.shadowColor = nil
             view.layer.shadowOpacity = 0
             view.layer.shadowPath = nil
+            return
+        }
+
+        guard let colorValue = state.properties[PamConstants.shadowColor]?.integerOrNil() else {
+            let elevation = max(
+                0,
+                CGFloat(state.properties[PamConstants.elevation]?.decimalOrNil() ?? 0),
+            )
+            PamMaterialElevation.apply(
+                elevation,
+                to: view.layer,
+                bounds: view.bounds,
+                cornerRadius: view.layer.cornerRadius,
+            )
             return
         }
 

--- a/ios/Tests/PamNativeTests/PamProtocolTests.swift
+++ b/ios/Tests/PamNativeTests/PamProtocolTests.swift
@@ -113,6 +113,7 @@ final class PamProtocolTests: XCTestCase {
         XCTAssertEqual(PamConstants.nativeTextColorResource, 453)
         XCTAssertEqual(PamConstants.nativeBorderColorResource, 454)
         XCTAssertEqual(PamConstants.nativeStateStyles, 455)
+        XCTAssertEqual(PamConstants.elevation, 56)
         XCTAssertEqual(
             [
                 NativeOperation.httpGet,

--- a/packages/native/src/Internal/DependencyTracker.php
+++ b/packages/native/src/Internal/DependencyTracker.php
@@ -17,6 +17,8 @@ final class DependencyTracker
     private static ?WeakMap $dependencies = null;
     /** @var WeakMap<Component, true>|null */
     private static ?WeakMap $dirty = null;
+    /** @var WeakMap<Component, Component>|null */
+    private static ?WeakMap $parents = null;
 
     private function __construct()
     {
@@ -25,6 +27,14 @@ final class DependencyTracker
     public static function begin(Component $component): void
     {
         self::clear($component);
+        $last = array_key_last(self::$stack);
+        $parent = $last === null ? null : self::$stack[$last];
+        $parents = self::$parents ??= new WeakMap();
+        if ($parent instanceof Component && $parent !== $component) {
+            $parents[$component] = $parent;
+        } else {
+            unset($parents[$component]);
+        }
         self::$stack[] = $component;
     }
 
@@ -68,7 +78,7 @@ final class DependencyTracker
                 continue;
             }
             foreach ($components as $component => $_) {
-                $dirty[$component] = true;
+                self::markComponentAndAncestorsDirty($component, $dirty);
             }
         }
     }
@@ -86,7 +96,19 @@ final class DependencyTracker
     public static function markDirty(Component $component): void
     {
         $dirty = self::$dirty ??= new WeakMap();
-        $dirty[$component] = true;
+        self::markComponentAndAncestorsDirty($component, $dirty);
+    }
+
+    public static function invalidateAll(): void
+    {
+        $dependencies = self::$dependencies;
+        if ($dependencies === null) {
+            return;
+        }
+        $dirty = self::$dirty ??= new WeakMap();
+        foreach ($dependencies as $component => $_) {
+            $dirty[$component] = true;
+        }
     }
 
     public static function forget(Component $component): void
@@ -94,6 +116,8 @@ final class DependencyTracker
         self::clear($component);
         $dirty = self::$dirty ??= new WeakMap();
         unset($dirty[$component]);
+        $parents = self::$parents ??= new WeakMap();
+        unset($parents[$component]);
     }
 
     public static function reset(): void
@@ -102,6 +126,29 @@ final class DependencyTracker
         self::$subscribers = null;
         self::$dependencies = null;
         self::$dirty = null;
+        self::$parents = null;
+    }
+
+    /** @param WeakMap<Component, true> $dirty */
+    private static function markComponentAndAncestorsDirty(
+        Component $component,
+        WeakMap $dirty,
+    ): void {
+        $parents = self::$parents;
+        $current = $component;
+        while (true) {
+            if (isset($dirty[$current])) {
+                return;
+            }
+            $dirty[$current] = true;
+            $parent = $parents !== null && isset($parents[$current])
+                ? $parents[$current]
+                : null;
+            if (!$parent instanceof Component || $parent === $current) {
+                return;
+            }
+            $current = $parent;
+        }
     }
 
     private static function clear(Component $component): void

--- a/packages/native/src/Internal/Runtime.php
+++ b/packages/native/src/Internal/Runtime.php
@@ -51,6 +51,7 @@ final class Runtime
     private static ?TreeEncoder $encoder = null;
     private static bool $rendering = false;
     private static bool $renderRequested = false;
+    private static bool $dispatchingEvent = false;
     private static WindowMetrics $windowMetrics;
 
     private function __construct()
@@ -166,6 +167,12 @@ final class Runtime
         if (self::$root === null) {
             return;
         }
+        if (self::$dispatchingEvent) {
+            // dispatchEvent() renders once after the callback. Coalesce state
+            // mutations raised inside that callback instead of traversing the
+            // tree immediately and then traversing it again.
+            return;
+        }
         if (self::$rendering) {
             self::$renderRequested = true;
 
@@ -221,6 +228,7 @@ final class Runtime
                     memoryClass: (float) ($values['memoryClass'] ?? 0.0),
                     performanceTier: (float) ($values['performanceTier'] ?? 1.0),
                 );
+                DependencyTracker::invalidateAll();
                 self::$dimensionsHandler?->__invoke(self::$windowMetrics);
                 self::render();
 
@@ -237,7 +245,12 @@ final class Runtime
             if ($callback === null) {
                 return;
             }
-            $callback($payload);
+            self::$dispatchingEvent = true;
+            try {
+                $callback($payload);
+            } finally {
+                self::$dispatchingEvent = false;
+            }
             self::render();
         } catch (Throwable $error) {
             self::reportError($error);
@@ -375,6 +388,7 @@ final class Runtime
         self::$encoder = null;
         self::$rendering = false;
         self::$renderRequested = false;
+        self::$dispatchingEvent = false;
         self::$windowMetrics = new WindowMetrics(0.0, 0.0, 1.0);
         ComponentLifecycle::shutdown();
         PamPhpRegistry::releaseInstances();

--- a/packages/native/src/Internal/TemplateRenderer.php
+++ b/packages/native/src/Internal/TemplateRenderer.php
@@ -2756,6 +2756,7 @@ final class TemplateRenderer
                     PropKey::BackgroundColor,
                     PropKey::TextColor,
                     PropKey::BorderColor,
+                    PropKey::Elevation,
                 ], true)) {
                     $nativeStates[$stateKind->value][$property->value] = $value;
                 }

--- a/packages/native/src/Navigation/DrawerNavigator.php
+++ b/packages/native/src/Navigation/DrawerNavigator.php
@@ -8,6 +8,7 @@ use BackedEnum;
 use Closure;
 use InvalidArgumentException;
 use Pam\Native\AccessibilityRole;
+use Pam\Native\App;
 use Pam\Native\Renderable;
 use Pam\Native\Restorable;
 use Pam\Native\Routing\RouteName;
@@ -66,12 +67,12 @@ final class DrawerNavigator implements Renderable, Restorable, NavigationStatePr
         private readonly float $swipeEdgeWidth = 32.0,
         private readonly float $swipeMinDistance = 56.0,
         private readonly float $permanentBreakpoint = 840.0,
-        private readonly int $backgroundColor = 0xFFFFFFFF,
-        private readonly int $activeColor = 0xFF0F172A,
-        private readonly int $inactiveColor = 0xFF64748B,
-        private readonly int $activeBackgroundColor = 0xFFE2E8F0,
-        private readonly int $overlayColor = 0x33000000,
-        private readonly int $dividerColor = 0xFFE2E8F0,
+        private int $backgroundColor = 0xFFFFFFFF,
+        private int $activeColor = 0xFF0F172A,
+        private int $inactiveColor = 0xFF64748B,
+        private int $activeBackgroundColor = 0xFFE2E8F0,
+        private int $overlayColor = 0x33000000,
+        private int $dividerColor = 0xFFE2E8F0,
         private readonly ?Closure $customContent = null,
     ) {
         $initialRoute = RouteName::value($initialRoute);
@@ -288,14 +289,47 @@ final class DrawerNavigator implements Renderable, Restorable, NavigationStatePr
 
     public function dimensions(WindowMetrics $metrics): void
     {
+        $wasPermanent = $this->resolvedType() === DrawerType::Permanent;
         $this->windowWidth = max(0.0, $metrics->width);
+        $isPermanent = $this->resolvedType() === DrawerType::Permanent;
+        if (!$wasPermanent && $isPermanent && $this->open) {
+            // A modal/front drawer becomes part of the page structure at the
+            // permanent breakpoint. Its transient open state must not survive
+            // that presentation change and cover the compact screen when the
+            // device rotates back.
+            $this->open = false;
+            State::set($this->stateKey(), $this->saveState());
+        }
+    }
+
+    public function appearance(
+        int $backgroundColor,
+        int $activeColor,
+        int $inactiveColor,
+        int $activeBackgroundColor,
+        int $overlayColor,
+        int $dividerColor,
+    ): void {
+        $this->backgroundColor = $backgroundColor;
+        $this->activeColor = $activeColor;
+        $this->inactiveColor = $inactiveColor;
+        $this->activeBackgroundColor = $activeBackgroundColor;
+        $this->overlayColor = $overlayColor;
+        $this->dividerColor = $dividerColor;
     }
 
     public function resolvedType(): DrawerType
     {
+        // A navigator can be nested under an application component instead
+        // of being passed directly to App::run(). In that case it does not
+        // own the dimensions callback, but Runtime still keeps authoritative
+        // window metrics and rerenders the tree after every size change.
+        $windowWidth = $this->windowWidth > 0.0
+            ? $this->windowWidth
+            : App::windowMetrics()->width;
         if (
             $this->permanentBreakpoint > 0.0
-            && $this->windowWidth >= $this->permanentBreakpoint
+            && $windowWidth >= $this->permanentBreakpoint
         ) {
             return DrawerType::Permanent;
         }
@@ -452,10 +486,14 @@ final class DrawerNavigator implements Renderable, Restorable, NavigationStatePr
             )
             ->permanentBreakpoint($this->permanentBreakpoint)
             ->onOpen(function (): void {
-                $this->openDrawer();
+                if ($this->resolvedType() !== DrawerType::Permanent) {
+                    $this->openDrawer();
+                }
             })
             ->onClose(function (): void {
-                $this->closeDrawer();
+                if ($this->resolvedType() !== DrawerType::Permanent) {
+                    $this->closeDrawer();
+                }
             });
     }
 

--- a/packages/native/tests/language2.php
+++ b/packages/native/tests/language2.php
@@ -111,6 +111,8 @@ $language2Styles = ScopedStyleCompiler::compile(<<<'CSS'
 
 .touchable:focus-visible {
     background: #3366FF;
+    border-color: #2244CC;
+    elevation: 3;
     transform: scale(1.04);
 }
 
@@ -350,6 +352,11 @@ $styledRoot = new CompiledTemplateNode(
 $styledRoot->children = $styledTemplate->children;
 $styledElement = TemplateRenderer::render($styledRoot, null, []);
 $styledChild = $styledElement->children()[0] ?? null;
+$nativeStateStyles = json_decode(
+    (string) ($styledElement->properties()[PropKey::NativeStateStyles->value] ?? ''),
+    true,
+    flags: JSON_THROW_ON_ERROR,
+);
 $assert(
     (float) ($styledElement->properties()[PropKey::PressOpacity->value] ?? 0) === 0.72
         && (float) ($styledElement->properties()[PropKey::PressScale->value] ?? 0) === 0.98
@@ -357,6 +364,8 @@ $assert(
             (string) ($styledElement->properties()[PropKey::NativeStateStyles->value] ?? ''),
             '"2"',
         )
+        && ($nativeStateStyles[2][PropKey::BorderColor->value] ?? null) === 0xFF2244CC
+        && (float) ($nativeStateStyles[2][PropKey::Elevation->value] ?? 0) === 3.0
         && $styledChild instanceof \Pam\Native\Element
         && (float) ($styledChild->properties()[PropKey::PaddingLeft->value] ?? 0) === 16.0
         && ($styledChild->properties()[PropKey::BackgroundColor->value] ?? null) === 0xFF4F46E5,

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -3072,6 +3072,52 @@ $assert(
 );
 TemplateRegistry::reset();
 
+$nestedStateChild = new class extends Component {
+    /** @return array{label: string} */
+    protected function initialState(): array
+    {
+        return ['label' => 'Nested A'];
+    }
+
+    public function changeLabel(string $label): void
+    {
+        $this->state->label = $label;
+    }
+
+    public function render(): \Pam\Native\Renderable
+    {
+        return Text::make((string) $this->state->label);
+    }
+};
+$nestedStateParent = new class($nestedStateChild) extends Component {
+    public function __construct(private readonly Component $child)
+    {
+    }
+
+    /** @return array{revision: int} */
+    protected function initialState(): array
+    {
+        return ['revision' => 0];
+    }
+
+    public function render(): \Pam\Native\Renderable
+    {
+        // Give the parent its own dependency so it is eligible for retained
+        // subtree reuse, matching a real stateful route component.
+        $this->state->revision;
+
+        return Column::make($this->child);
+    }
+};
+$nestedInitial = $nestedStateParent->toElement();
+$nestedStateChild->changeLabel('Nested B');
+$nestedUpdated = $nestedStateParent->toElement();
+$assert(
+    ($nestedInitial->children()[0]->properties()[PropKey::Text->value] ?? null) === 'Nested A'
+        && ($nestedUpdated->children()[0]->properties()[PropKey::Text->value] ?? null) === 'Nested B',
+    'Nested component state changes must invalidate every retained ancestor.',
+);
+
 $incremental = new TreeEncoder();
 $initial = $incremental->encode(Text::make('A')->key('value'));
 $unchanged = $incremental->encode(Text::make('A')->key('value'));
@@ -6411,6 +6457,62 @@ $assert(
         && $restoredGroupedDrawer->isGroupExpanded('Actions')
         && $restoredGroupedDrawer->isGroupExpanded('Forms'),
     'Grouped drawer state must restore selection and expanded sections.',
+);
+
+$responsiveMetricsReader = new class extends Component {
+    public int $renders = 0;
+
+    protected function initialState(): array
+    {
+        return ['revision' => 0];
+    }
+
+    public function render(): Renderable
+    {
+        $this->renders++;
+        $this->state->revision;
+        App::windowMetrics();
+
+        return Text::make('Nested responsive navigator metrics');
+    }
+};
+App::run($responsiveMetricsReader);
+Runtime::dispatchEvent(0, EventKind::Dimensions->value, Wire::map([
+    'width' => 1_000.0,
+    'height' => 600.0,
+    'density' => 2.0,
+]));
+$nestedResponsiveDrawer = Router::drawer('overview')
+    ->route('overview', 'Overview', Screen::make(Text::make('Overview')))
+    ->route('field', 'Text field', Screen::make(Text::make('Text field')))
+    ->responsive(840.0)
+    ->persistence('test-nested-responsive-drawer-presentation')
+    ->build();
+$assert(
+    $responsiveMetricsReader->renders === 2
+        && $nestedResponsiveDrawer->resolvedType()
+        === \Pam\Native\Navigation\DrawerType::Permanent,
+    'Window-metric readers and nested responsive drawers must update without being the App root.',
+);
+Runtime::shutdown();
+
+$responsiveDrawer = Router::drawer('overview')
+    ->route('overview', 'Overview', Screen::make(Text::make('Overview')))
+    ->route('field', 'Text field', Screen::make(Text::make('Text field')))
+    ->responsive(840.0)
+    ->persistence('test-responsive-drawer-presentation')
+    ->build();
+$responsiveDrawer->dimensions(new WindowMetrics(1_000.0, 600.0, 2.0));
+$permanentDrawerElement = $responsiveDrawer->toElement();
+$permanentOpen = $permanentDrawerElement->events()[EventKind::DrawerOpen->value] ?? null;
+$permanentOpen?->__invoke();
+$responsiveDrawer->dimensions(new WindowMetrics(412.0, 915.0, 2.0));
+$compactDrawerElement = $responsiveDrawer->toElement();
+$assert(
+    $responsiveDrawer->resolvedType() === \Pam\Native\Navigation\DrawerType::Front
+        && $responsiveDrawer->getState()['open'] === false
+        && $compactDrawerElement->properties()[PropKey::DrawerOpen->value] === false,
+    'Permanent drawer callbacks must not leak an open modal drawer into the compact layout after rotation.',
 );
 $assert(
     \Pam\Native\Protocol::SDK_VERSION === '1.0.21',


### PR DESCRIPTION
## Summary
- make viewport, insets, RTL physical positioning, intrinsic sizing and scroll geometry deterministic
- harden modal, drawer, keyboard, status bar and local selection interaction behavior
- expose runtime appearance updates to retained PHP components and add themeable drawer appearance
- add broad Android, Rust, PHP and UIKit regression coverage

## Validation
- PHP SDK suite passed
- Cargo workspace: 119 tests passed
- Android `testDebugUnitTest lintDebug assembleRelease` passed after resolving all seven lint findings
- PAM Native UI release built and visually validated on emulator-5556 in light and dark modes