### PR TITLE
feat: unregister native push tokens

### DIFF
--- a/android/app/src/main/java/dev/pam/nativeapp/modules/NotificationsModule.kt
+++ b/android/app/src/main/java/dev/pam/nativeapp/modules/NotificationsModule.kt
@@ -29,6 +29,7 @@ internal class NotificationsModule(private val activity: PamActivity) : NativeMo
                 "schedule" -> schedule(payload, completion)
                 "cancel" -> cancel(payload, completion)
                 "registerPush" -> registerPush(completion)
+                "unregisterPush" -> unregisterPush(completion)
                 "nextPushEvent" -> PamPushNotifications.next(completion)
                 else -> error("Unknown notifications method $method")
             }
@@ -81,6 +82,41 @@ internal class NotificationsModule(private val activity: PamActivity) : NativeMo
                 completion.complete(
                     ModuleResultStatus.FAILURE,
                     (error.message ?: "Push registration failed").toByteArray(),
+                )
+            }
+        }
+        main.post(::poll)
+    }
+
+    private fun unregisterPush(completion: ModuleCompletion) {
+        val firebase = runCatching {
+            Class.forName("com.google.firebase.messaging.FirebaseMessaging")
+        }.getOrElse {
+            error(
+                "Push unregistration requires the host app to provide Firebase Messaging " +
+                    "or a generated notifications module",
+            )
+        }
+        val instance = firebase.getMethod("getInstance").invoke(null)
+        val task = firebase.getMethod("deleteToken").invoke(instance)
+        val started = System.currentTimeMillis()
+        fun poll() {
+            runCatching {
+                val complete = task.javaClass.getMethod("isComplete").invoke(task) as Boolean
+                if (!complete) {
+                    require(System.currentTimeMillis() - started < 15_000) {
+                        "Push token unregistration timed out"
+                    }
+                    main.postDelayed(::poll, 50)
+                    return
+                }
+                val successful = task.javaClass.getMethod("isSuccessful").invoke(task) as Boolean
+                require(successful) { "Firebase rejected push token unregistration" }
+                completion.complete(ModuleResultStatus.SUCCESS, ByteArray(0))
+            }.onFailure { error ->
+                completion.complete(
+                    ModuleResultStatus.FAILURE,
+                    (error.message ?: "Push unregistration failed").toByteArray(),
                 )
             }
         }

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -217,6 +217,12 @@ $pushSubscription = PushNotifications::listenAndRoute(
 
 // During component cleanup:
 PushNotifications::unsubscribe($pushSubscription);
+
+// After removing this installation token from your server:
+PushNotifications::unregister(
+    fn () => $this->markNotificationsDisabled(),
+    fn (string $message) => $this->recordPushUnregistrationFailure($message),
+);
 ```
 
 Android FCM is enabled by adding `.pam/google-services.json`; APNs delegate

--- a/docs/native-capabilities.md
+++ b/docs/native-capabilities.md
@@ -287,6 +287,16 @@ PushNotifications::register(
 
 Omitting the callback preserves the legacy exception behavior.
 
+After the server removes the installation token, disable provider delivery and
+invalidate the native token with the same failure contract:
+
+```php
+PushNotifications::unregister(
+    fn () => $this->markNotificationsDisabled(),
+    fn (string $message) => $this->recordPushUnregistrationFailure($message),
+);
+```
+
 ```swift
 func application(
     _ application: UIApplication,

--- a/docs/production-capabilities.md
+++ b/docs/production-capabilities.md
@@ -98,11 +98,18 @@ $registration = PushNotifications::register(
     $recordProviderFailure,
 );
 $subscription = PushNotifications::listenAndRoute($navigator, $onMessage);
+
+// After the application server forgets this installation:
+PushNotifications::unregister($onRemoved, $recordProviderFailure);
 ```
 
 The second `register()` callback receives provider/configuration failures and
 keeps them in application control. It is optional; omitting it preserves the
 legacy exception behavior.
+
+`unregister()` invalidates the FCM token on Android and unregisters the
+application from APNs on iOS. Remove the installation token from the
+application server first so a provider failure can be retried safely.
 
 Android projects only need their Firebase client file at
 `.pam/google-services.json` (preferred) or root `google-services.json`. PAM

--- a/ios/Sources/PamNative/Modules/NotificationsModule.swift
+++ b/ios/Sources/PamNative/Modules/NotificationsModule.swift
@@ -93,6 +93,12 @@ final class NotificationsModule: NativeModule, ClosableNativeModule {
                 completion(.success, Data())
             case "registerPush":
                 PushTokenRegistry.shared.register(completion: completion)
+            case "unregisterPush":
+                DispatchQueue.main.async {
+                    UIApplication.shared.unregisterForRemoteNotifications()
+                    PushTokenRegistry.shared.unregister()
+                    completion(.success, Data())
+                }
             case "nextPushEvent":
                 PushTokenRegistry.shared.nextEvent(completion: completion)
             default:
@@ -140,6 +146,15 @@ private final class PushTokenRegistry {
         waiters.removeAll()
         lock.unlock()
         callbacks.forEach { $0(.success, payload(value)) }
+    }
+
+    func unregister() {
+        lock.lock()
+        token = nil
+        let callbacks = waiters
+        waiters.removeAll()
+        lock.unlock()
+        callbacks.forEach { $0(.failure, Data("Push registration was cancelled".utf8)) }
     }
 
     func reject(_ message: String) {

--- a/packages/native/src/System/PushNotifications.php
+++ b/packages/native/src/System/PushNotifications.php
@@ -58,6 +58,34 @@ final class PushNotifications
         );
     }
 
+    /**
+     * Stops remote notifications for this installation and invalidates its native token.
+     *
+     * @param Closure(): void $callback
+     * @param Closure(string): void|null $failure
+     */
+    public static function unregister(
+        Closure $callback,
+        ?Closure $failure = null,
+    ): int {
+        return NativeModules::call(
+            'notifications',
+            'unregisterPush',
+            [],
+            static function ($result) use ($callback, $failure): void {
+                if ($result->status === ModuleResultStatus::Failure) {
+                    if ($failure !== null) {
+                        $failure($result->payload);
+
+                        return;
+                    }
+                    throw new RuntimeException($result->payload);
+                }
+                $callback();
+            },
+        );
+    }
+
     /** @param Closure(PushMessage): void $callback */
     public static function listen(Closure $callback): int
     {

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -3349,6 +3349,37 @@ $assert(
     'Push registration failures must reach the optional failure callback.',
 );
 
+$pushUnregistered = false;
+$pushUnregisterRequest = PushNotifications::unregister(
+    static function () use (&$pushUnregistered): void { $pushUnregistered = true; },
+    static function (string $message): void { throw new RuntimeException($message); },
+);
+$pushUnregisterCall = TestDiagnostics::$moduleCall;
+$assert(
+    $pushUnregisterCall !== null
+        && $pushUnregisterCall['requestId'] === $pushUnregisterRequest
+        && $pushUnregisterCall['module'] === 'notifications'
+        && $pushUnregisterCall['method'] === 'unregisterPush',
+    'Push unregistration must emit its typed native module call.',
+);
+Runtime::dispatchModuleResult($pushUnregisterRequest, ModuleResultStatus::Success->value, '');
+$assert($pushUnregistered, 'Push unregistration must invoke its success callback.');
+
+$pushUnregisterFailure = null;
+$failedPushUnregisterRequest = PushNotifications::unregister(
+    static function (): void { throw new RuntimeException('Failed push unregistration must not invoke success.'); },
+    static function (string $message) use (&$pushUnregisterFailure): void { $pushUnregisterFailure = $message; },
+);
+Runtime::dispatchModuleResult(
+    $failedPushUnregisterRequest,
+    ModuleResultStatus::Failure->value,
+    'Firebase rejected push token unregistration.',
+);
+$assert(
+    $pushUnregisterFailure === 'Firebase rejected push token unregistration.',
+    'Push unregistration failures must reach the optional failure callback.',
+);
+
 $recording = null;
 $audioRequest = AudioRecorder::stop(
     static function (AudioRecording $value) use (&$recording): void {


### PR DESCRIPTION
Applications could acquire native push tokens through core PAM Native, but could not invalidate them without installing a broad provider plugin. This adds `PushNotifications::unregister()` with typed success/failure callbacks, FCM token deletion on Android, and APNs unregistration on iOS.

This lets notification-only applications avoid bundling Firebase Analytics, Remote Config and Crashlytics solely to delete an FCM token.

Validation: `php packages/native/tests/run.php`; Android `./gradlew testDebugUnitTest`; Kotlin debug compilation; `cargo fmt --all -- --check`; `git diff --check`.
