### PR TITLE
fix: install Android Rust target in release starter gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,6 +408,8 @@ jobs:
           php-version: '8.5'
           coverage: none
       - uses: dtolnay/rust-toolchain@1.88.0
+        with:
+          targets: x86_64-linux-android
       - name: Assemble the candidate PAM entrypoint and public runtime payload
         run: |
           curl --proto '=https' --proto-redir '=https' --tlsv1.2 \

--- a/scripts/test-release-workflows.php
+++ b/scripts/test-release-workflows.php
@@ -102,6 +102,7 @@ requireFragments($release, 'release.yml', [
     "          test -f \"\${pam_home}/runtime/catalog.json\"\n",
     "          printf 'PAM_HOME=%s\\n' \"\${pam_home}\" >>\"\${GITHUB_ENV}\"\n",
     "          PAM_HOME: \${{ env.PAM_HOME }}\n",
+    "          targets: x86_64-linux-android\n",
     "          script: pam-cli/scripts/community-experience-gate.sh all\n",
     "      - community-first-run\n",
     "              --mtime=\"@\${source_date_epoch}\" \\\n",


### PR DESCRIPTION
The `v1.0.22` release completed 50 certification jobs, then the clean community starter gate failed because its candidate CLI cross-compiles for `x86_64-linux-android` without installing that Rust target.

Install the target in the release job before assembling and running every starter, and pin the requirement in the workflow contract test.

Evidence: release run `34082698377`, job `101623121863`, failed with `Rust target x86_64-linux-android is missing`. Validation: `php scripts/test-release-workflows.php`; `git diff --check`.
