### PR TITLE
release: prepare PAM Native 1.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.24 - 2026-09-07
+
+- Retry Android installs when a booting PackageInstaller leaves an inaccessible transient session.
+
 ## 1.0.23 - 2026-09-07
 
 - Add `PushNotifications::unregister()` to invalidate FCM tokens and unregister from APNs without a broad provider plugin.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.23"
+version = "1.0.24"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.23"
+version = "1.0.24"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.23"
+version = "1.0.24"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.23"
+version = "1.0.24"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.23';
+    public const string SDK_VERSION = '1.0.24';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6546,8 +6546,8 @@ $assert(
     'Permanent drawer callbacks must not leak an open modal drawer into the compact layout after rotation.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.23',
-    'The runtime SDK contract must match the stable 1.0.23 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.24',
+    'The runtime SDK contract must match the stable 1.0.24 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
Publishes the Android PackageInstaller recovery fix after v1.0.23 was correctly withheld by the clean starter gate.\n\nValidation: `cargo check --workspace`; `cargo fmt --check`; PHP SDK contract suite.