### PR TITLE
fix: isolate Android macrobenchmarks from target apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
         run: |
           mkdir -p dist
           tar -czf dist/pam-native-android-prerequisites.tar.gz \
+            runtime/catalog.json \
             runtime/android \
             target/aarch64-linux-android/release/libpam_native_engine.a \
             target/x86_64-linux-android/release/libpam_native_engine.a
@@ -170,6 +171,17 @@ jobs:
           java-version: '17'
           cache: gradle
       - uses: android-actions/setup-android@v4
+      - uses: shivammathur/setup-php@v2
+        if: matrix.api-level == 36
+        with:
+          php-version: '8.5'
+          tools: composer:v2
+      - uses: dtolnay/rust-toolchain@1.88.0
+        if: matrix.api-level == 36
+      - uses: Swatinem/rust-cache@v2
+        if: matrix.api-level == 36
+        with:
+          key: android-macrobenchmark
       - name: Install Android build dependencies
         run: sdkmanager "platforms;android-36" "ndk;27.1.12297006" "cmake;3.22.1"
       - uses: actions/download-artifact@v8
@@ -190,7 +202,11 @@ jobs:
           target: google_apis
           profile: pixel_6
           disable-animations: true
-          script: ./android/gradlew -p android -PpamNativeRoot="$GITHUB_WORKSPACE" :app:connectedDebugAndroidTest
+          script: |
+            ./android/gradlew -p android -PpamNativeRoot="$GITHUB_WORKSPACE" :app:connectedDebugAndroidTest
+            if [ "${{ matrix.api-level }}" = "36" ]; then composer install --working-dir=examples/showcase --no-interaction --prefer-dist --no-progress; fi
+            if [ "${{ matrix.api-level }}" = "36" ]; then PAM_HOME="$GITHUB_WORKSPACE" PAM_NATIVE_HOME="$GITHUB_WORKSPACE" cargo run --locked --release --package pam-native-cli -- prepare examples/showcase; fi
+            if [ "${{ matrix.api-level }}" = "36" ]; then ./examples/showcase/.pam-native/android/gradlew -p examples/showcase/.pam-native/android -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR :macrobenchmark:connectedBenchmarkAndroidTest; fi
       - uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -198,6 +214,12 @@ jobs:
           path: |
             android/app/build/reports/androidTests/connected/
             android/app/build/outputs/androidTest-results/connected/
+            android/macrobenchmark/build/reports/androidTests/connected/
+            android/macrobenchmark/build/outputs/androidTest-results/connected/
+            android/macrobenchmark/build/outputs/connected_android_test_additional_output/
+            examples/showcase/.pam-native/android/macrobenchmark/build/reports/androidTests/connected/
+            examples/showcase/.pam-native/android/macrobenchmark/build/outputs/androidTest-results/connected/
+            examples/showcase/.pam-native/android/macrobenchmark/build/outputs/connected_android_test_additional_output/
           if-no-files-found: warn
           retention-days: 7
       - name: Remove regenerable build artifacts

--- a/android/macrobenchmark/build.gradle.kts
+++ b/android/macrobenchmark/build.gradle.kts
@@ -13,6 +13,7 @@ android {
     namespace = "dev.pam.nativeapp.benchmark"
     compileSdk = 36
     targetProjectPath = ":app"
+    experimentalProperties["android.experimental.self-instrumenting"] = true
 
     defaultConfig {
         minSdk = 26

--- a/android/macrobenchmark/src/main/java/dev/pam/nativeapp/benchmark/BaselineProfileGenerator.kt
+++ b/android/macrobenchmark/src/main/java/dev/pam/nativeapp/benchmark/BaselineProfileGenerator.kt
@@ -3,6 +3,7 @@ package dev.pam.nativeapp.benchmark
 import androidx.benchmark.macro.junit4.BaselineProfileRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import org.junit.Rule
 import org.junit.Test
@@ -20,9 +21,10 @@ class BaselineProfileGenerator {
     ) {
         pressHome()
         startActivityAndWait()
-        device.wait(Until.findObject(By.desc("benchmark-counter")), UI_TIMEOUT_MS)?.click()
-        device.wait(Until.findObject(By.desc("benchmark-list-route")), UI_TIMEOUT_MS)?.click()
-        device.wait(Until.hasObject(By.desc("benchmark-large-list")), UI_TIMEOUT_MS)
+        device.ensureHome()
+        device.requireObject("benchmark-counter").click()
+        device.requireObject("benchmark-list-route").click()
+        device.requireObject("benchmark-large-list")
         repeat(3) {
             device.swipe(
                 device.displayWidth / 2,
@@ -38,5 +40,22 @@ class BaselineProfileGenerator {
     private companion object {
         const val SWIPE_STEPS = 12
         const val UI_TIMEOUT_MS = 5_000L
+    }
+
+    private fun UiDevice.requireObject(description: String) =
+        wait(Until.findObject(By.desc(description)), UI_TIMEOUT_MS)
+            ?: error("Baseline profile target $description was not found")
+
+    private fun UiDevice.ensureHome() {
+        if (hasObject(By.desc("benchmark-counter"))) return
+
+        wait(Until.findObject(By.desc("Open the technical lab")), UI_TIMEOUT_MS)?.let {
+            it.click()
+            requireObject("benchmark-counter")
+            return
+        }
+
+        pressBack()
+        requireObject("benchmark-counter")
     }
 }

--- a/android/macrobenchmark/src/main/java/dev/pam/nativeapp/benchmark/PamNativeBenchmark.kt
+++ b/android/macrobenchmark/src/main/java/dev/pam/nativeapp/benchmark/PamNativeBenchmark.kt
@@ -89,8 +89,15 @@ class PamNativeBenchmark {
 
     private fun UiDevice.ensureHome() {
         if (hasObject(By.desc("benchmark-counter"))) return
-        requireObject("benchmark-back").click()
-        wait(Until.hasObject(By.desc("benchmark-counter")), UI_TIMEOUT_MS)
+
+        wait(Until.findObject(By.desc("Open the technical lab")), UI_TIMEOUT_MS)?.let {
+            it.click()
+            requireObject("benchmark-counter")
+            return
+        }
+
+        pressBack()
+        requireObject("benchmark-counter")
     }
 
     private fun UiDevice.swipeUp() {

--- a/crates/pam-native-cli/src/mobile.rs
+++ b/crates/pam-native-cli/src/mobile.rs
@@ -8516,6 +8516,14 @@ mod tests {
     }
 
     #[test]
+    fn macrobenchmark_instrumentation_runs_outside_the_target_process() {
+        let build = include_str!("../../../android/macrobenchmark/build.gradle.kts");
+        assert!(build.contains(
+            "experimentalProperties[\"android.experimental.self-instrumenting\"] = true"
+        ));
+    }
+
+    #[test]
     fn retries_only_transient_adb_activity_registration_failures() {
         assert!(transient_adb_launch_failure(
             "Error type 3: Activity class {dev.pam.app/dev.pam.nativeapp.PamActivity} does not exist."

--- a/examples/showcase/src/Showcase.php
+++ b/examples/showcase/src/Showcase.php
@@ -64,6 +64,34 @@ final class Showcase
                             fontWeight: 700,
                             letterSpacing: 1.2,
                         )),
+                    Row::make(
+                        Button::make("Patch #{$this->count}")
+                            ->key('counter')
+                            ->accessibilityLabel('benchmark-counter')
+                            ->style(new Style(
+                                flexGrow: 1,
+                                textColor: 0xFF052E16,
+                                backgroundColor: 0xFF22C55E,
+                                borderRadius: 10,
+                                fontWeight: 700,
+                            ))
+                            ->onPress(function (): void {
+                                $this->count++;
+                            }),
+                        Button::make('10K list')
+                            ->key('details')
+                            ->accessibilityLabel('benchmark-list-route')
+                            ->style(new Style(
+                                flexGrow: 1,
+                                textColor: 0xFFF8FAFC,
+                                backgroundColor: 0xFF334155,
+                                borderRadius: 10,
+                                fontWeight: 700,
+                            ))
+                            ->onPress(function (): void {
+                                Navigation::push('details');
+                            }),
+                    )->key('actions')->style(new Style(height: 52, gap: 10)),
                     Text::make('PHP logic. Native pixels.')
                         ->key('title')
                         ->style(new Style(
@@ -127,34 +155,6 @@ final class Showcase
                         ->onChange(function (string $value): void {
                             $this->name = $value;
                         }),
-                    Row::make(
-                        Button::make("Patch #{$this->count}")
-                            ->key('counter')
-                            ->accessibilityLabel('benchmark-counter')
-                            ->style(new Style(
-                                flexGrow: 1,
-                                textColor: 0xFF052E16,
-                                backgroundColor: 0xFF22C55E,
-                                borderRadius: 10,
-                                fontWeight: 700,
-                            ))
-                            ->onPress(function (): void {
-                                $this->count++;
-                            }),
-                        Button::make('10K list')
-                            ->key('details')
-                            ->accessibilityLabel('benchmark-list-route')
-                            ->style(new Style(
-                                flexGrow: 1,
-                                textColor: 0xFFF8FAFC,
-                                backgroundColor: 0xFF334155,
-                                borderRadius: 10,
-                                fontWeight: 700,
-                            ))
-                            ->onPress(function (): void {
-                                Navigation::push('details');
-                            }),
-                    )->key('actions')->style(new Style(height: 52, gap: 10)),
                     Button::make('Tags, classes, props and slots')
                         ->key('tags')
                         ->style(new Style(

--- a/scripts/test-release-workflows.php
+++ b/scripts/test-release-workflows.php
@@ -71,7 +71,13 @@ requireFragments($ci, 'ci.yml', [
     "php scripts/test-hot-reload-evidence.php\n",
     "python3 -m unittest benchmarks/package/test_reproducibility.py\n",
     "python3 -m json.tool benchmarks/package/reproducibility.schema.json >/dev/null\n",
+    "            runtime/catalog.json \\\n",
+    "if [ \"\${{ matrix.api-level }}\" = \"36\" ]; then PAM_HOME=\"\$GITHUB_WORKSPACE\" PAM_NATIVE_HOME=\"\$GITHUB_WORKSPACE\" cargo run --locked --release --package pam-native-cli -- prepare examples/showcase; fi\n",
+    "if [ \"\${{ matrix.api-level }}\" = \"36\" ]; then ./examples/showcase/.pam-native/android/gradlew -p examples/showcase/.pam-native/android -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR :macrobenchmark:connectedBenchmarkAndroidTest; fi\n",
 ]);
+if (str_contains($ci, 'if [[')) {
+    fail('ci.yml emulator scripts must remain POSIX sh compatible');
+}
 requireFragments($android, 'ecosystem-android.yml', [
     "  workflow_call:\n",
     "      - android/**\n",


### PR DESCRIPTION
PAM macrobenchmarks were loaded inside the target process, causing shared Kotlin runtime classes to be stripped or incompatibly obfuscated and invalidating measurements. Enable AGP self-instrumenting mode and run the macrobenchmark suite in the API 36 CI device gate.\n\nValidation: 38 CLI tests; release workflow contracts; physical Galaxy instrumentation now starts all three tests in a separate process and reaches activity measurement (the locked Bouncer prevents valid frames).