### PR TITLE
release: PAM Native 1.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.25 - 2026-09-07
+
+- Isolate Android macrobenchmarks from the target process so the Kotlin instrumentation runtime loads reliably.
+- Exercise the complete PAM Native showcase benchmark on Android API 36 in CI and preserve its reports and metrics.
+
 ## 1.0.24 - 2026-09-07
 
 - Retry Android installs when a booting PackageInstaller leaves an inaccessible transient session.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "pam-native-cli"
-version = "1.0.24"
+version = "1.0.25"
 dependencies = [
  "serde",
  "serde_json",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-engine"
-version = "1.0.24"
+version = "1.0.25"
 dependencies = [
  "pam-native-protocol",
  "ttf-parser",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "pam-native-protocol"
-version = "1.0.24"
+version = "1.0.25"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 exclude = ["pam-cli"]
 
 [workspace.package]
-version = "1.0.24"
+version = "1.0.25"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/packages/native/src/Protocol.php
+++ b/packages/native/src/Protocol.php
@@ -6,7 +6,7 @@ namespace Pam\Native;
 
 final class Protocol
 {
-    public const string SDK_VERSION = '1.0.24';
+    public const string SDK_VERSION = '1.0.25';
     public const int ABI_VERSION = 1;
     public const int MINIMUM_VERSION = 1;
     public const int VERSION = 1;

--- a/packages/native/tests/run.php
+++ b/packages/native/tests/run.php
@@ -6546,8 +6546,8 @@ $assert(
     'Permanent drawer callbacks must not leak an open modal drawer into the compact layout after rotation.',
 );
 $assert(
-    \Pam\Native\Protocol::SDK_VERSION === '1.0.24',
-    'The runtime SDK contract must match the stable 1.0.24 package release.',
+    \Pam\Native\Protocol::SDK_VERSION === '1.0.25',
+    'The runtime SDK contract must match the stable 1.0.25 package release.',
 );
 $protocolReport = \Pam\Native\Protocol::negotiate(new \Pam\Native\ProtocolHandshake(
     abiVersion: 1,


### PR DESCRIPTION
PAM Native 1.0.25 makes Android macrobenchmarks execute in their own instrumentation process and certifies the generated showcase on API 36. The showcase benchmark now enters its real initial gallery route, exercises property patches and the virtualized 10K list, and produces a strict baseline profile instead of silently skipping unavailable targets.

Validation:
- Full PR #130 CI passed across Rust/PHP, Android API 26/36, Swift/UIKit, and accessibility evidence.
- Generated showcase macrobenchmark artifact: 4 tests, 0 failures/errors; 10 cold starts, 5 property-patch runs, 5 virtualized-list runs; baseline/startup profiles emitted.
- `cargo check --locked`
- `cargo fmt --all -- --check`
- `php packages/native/tests/run.php`
