### PR TITLE
fix(ci): keep delayed PR jobs on immutable head SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.checkout_ref || github.ref }}
+          ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@1.88.0
         with:
           components: clippy,rustfmt
@@ -97,7 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.checkout_ref || github.ref }}
+          ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -164,7 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.checkout_ref || github.ref }}
+          ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -233,7 +233,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.checkout_ref || github.ref }}
+          ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - name: Test PamNative on an iOS Simulator
         working-directory: ios
         run: |
@@ -280,7 +280,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.checkout_ref || github.ref }}
+          ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - uses: actions/download-artifact@v8
         with:
           name: pam-native-android-api-26-tests


### PR DESCRIPTION
Prevents downstream accessibility jobs from checking out the ephemeral refs/pull/*/merge ref after a PR is merged. All CI jobs now resolve an explicit workflow-call ref, then the immutable PR head SHA, then github.sha.